### PR TITLE
Add bounded undo, capped search, and bracket/center navigation

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -858,6 +858,21 @@ impl AppState {
                     }
                 }
             }
+            EditorAction::GoToMatchingBracket => {
+                let buf = &mut self.editor.active_mut().buffer;
+                let cursor_byte = buf.cursors.primary().byte_offset;
+                if let Some((open_b, close_b)) =
+                    crate::buffer::edit::find_matching_bracket(buf.rope(), cursor_byte)
+                {
+                    // Jump to the opposite bracket from the one currently under cursor.
+                    let target = if cursor_byte == open_b {
+                        close_b
+                    } else {
+                        open_b
+                    };
+                    buf.move_cursor_to(target, false);
+                }
+            }
 
             // ── Text insertion ────────────────────────────────────────
             EditorAction::InsertChar(c) => {
@@ -1123,6 +1138,12 @@ impl AppState {
                             (vp.scroll_row + text_h / 2).min(total_lines.saturating_sub(1));
                     }
                 }
+            }
+            EditorAction::ScrollCursorCenter => {
+                let cursor_line = self.editor.active().buffer.cursors.primary().line;
+                let half = text_h / 2;
+                let vp = &mut self.editor.active_mut().viewport;
+                vp.scroll_row = cursor_line.saturating_sub(half);
             }
 
             // ── Edit ops ──────────────────────────────────────────────
@@ -1579,6 +1600,8 @@ impl AppState {
             | EditorAction::MoveCursorFileEnd
             | EditorAction::MoveCursorPage(_)
             | EditorAction::Scroll(_)
+            | EditorAction::ScrollCursorCenter
+            | EditorAction::GoToMatchingBracket
             | EditorAction::MouseClick { .. }
             | EditorAction::MouseDrag { .. } => return false,
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -126,7 +126,7 @@ impl FuzzyPickerState {
             })
             .collect();
 
-        scored.sort_by(|a, b| b.0.cmp(&a.0));
+        scored.sort_by_key(|b| std::cmp::Reverse(b.0));
         scored.truncate(200);
         self.filtered = scored;
     }
@@ -2257,13 +2257,11 @@ impl AppState {
                 }
                 _ => {} // Any other key cancels.
             },
-            Some(ConfirmDelete::DirConfirmed(path)) => {
-                if action == EditorAction::InsertNewline {
-                    let _ = std::fs::remove_dir_all(&path);
-                    self.refresh_sidebar();
-                }
+            Some(ConfirmDelete::DirConfirmed(path)) if action == EditorAction::InsertNewline => {
+                let _ = std::fs::remove_dir_all(&path);
+                self.refresh_sidebar();
             }
-            None => {}
+            Some(ConfirmDelete::DirConfirmed(_)) | None => {}
         }
     }
 
@@ -3159,7 +3157,7 @@ impl AppState {
             }
 
             // Apply in reverse byte order.
-            text_edits.sort_by(|a, b| b.0.cmp(&a.0));
+            text_edits.sort_by_key(|b| std::cmp::Reverse(b.0));
             let tab = &mut self.editor.tabs[tab_idx];
             for (start, end, new_text) in &text_edits {
                 let rope = tab.buffer.rope();

--- a/src/buffer/edit.rs
+++ b/src/buffer/edit.rs
@@ -88,6 +88,64 @@ pub fn prev_word_boundary(rope: &Rope, byte_offset: usize) -> usize {
     idx
 }
 
+/// Find the matching bracket for the bracket character at `cursor_byte`.
+///
+/// Returns `Some((open_byte, close_byte))` if a pair is found, else `None`.
+/// Scans at most 100 000 chars in each direction so we never block on a huge
+/// file with mismatched brackets.
+pub fn find_matching_bracket(rope: &Rope, cursor_byte: usize) -> Option<(usize, usize)> {
+    if cursor_byte >= rope.len_bytes() {
+        return None;
+    }
+    let char_idx = rope.byte_to_char(cursor_byte);
+    let ch = rope.char(char_idx);
+
+    const MAX_SCAN: usize = 100_000;
+    let total_chars = rope.len_chars();
+
+    let (open_ch, close_ch, forward) = match ch {
+        '{' => ('{', '}', true),
+        '(' => ('(', ')', true),
+        '[' => ('[', ']', true),
+        '}' => ('{', '}', false),
+        ')' => ('(', ')', false),
+        ']' => ('[', ']', false),
+        _ => return None,
+    };
+
+    if forward {
+        let mut depth = 0i32;
+        let limit = (char_idx + MAX_SCAN).min(total_chars);
+        for i in char_idx..limit {
+            let c = rope.char(i);
+            if c == open_ch {
+                depth += 1;
+            } else if c == close_ch {
+                depth -= 1;
+                if depth == 0 {
+                    return Some((cursor_byte, rope.char_to_byte(i)));
+                }
+            }
+        }
+    } else {
+        let mut depth = 0i32;
+        let start = char_idx.saturating_sub(MAX_SCAN);
+        for i in (start..=char_idx).rev() {
+            let c = rope.char(i);
+            if c == close_ch {
+                depth += 1;
+            } else if c == open_ch {
+                depth -= 1;
+                if depth == 0 {
+                    return Some((rope.char_to_byte(i), cursor_byte));
+                }
+            }
+        }
+    }
+
+    None
+}
+
 /// Find the byte offset of the start of the next word from `byte_offset`.
 pub fn next_word_boundary(rope: &Rope, byte_offset: usize) -> usize {
     let len = rope.len_bytes();

--- a/src/buffer/history.rs
+++ b/src/buffer/history.rs
@@ -58,6 +58,11 @@ enum UndoEntry {
     Batch(Vec<EditCommand>),
 }
 
+/// Default cap on the number of entries kept on the undo stack. The oldest
+/// entries are dropped when this limit is exceeded so editing a long-lived
+/// buffer can't grow undo memory without bound.
+const DEFAULT_MAX_ENTRIES: usize = 1000;
+
 /// Undo/redo stack.
 pub struct UndoStack {
     /// Past commands, oldest first. Undo pops from the back.
@@ -66,6 +71,9 @@ pub struct UndoStack {
     redo_stack: Vec<UndoEntry>,
     /// Accumulator for the current batch (Some while a BatchGuard is alive).
     current_batch: Option<Vec<EditCommand>>,
+    /// Maximum number of entries on the undo stack. Oldest are dropped when
+    /// exceeded.
+    max_entries: usize,
 }
 
 impl UndoStack {
@@ -74,6 +82,16 @@ impl UndoStack {
             undo_stack: Vec::new(),
             redo_stack: Vec::new(),
             current_batch: None,
+            max_entries: DEFAULT_MAX_ENTRIES,
+        }
+    }
+
+    /// Drop entries from the front of the undo stack until it fits within
+    /// `max_entries`. Called after every push.
+    fn trim_to_capacity(&mut self) {
+        if self.undo_stack.len() > self.max_entries {
+            let drop = self.undo_stack.len() - self.max_entries;
+            self.undo_stack.drain(..drop);
         }
     }
 
@@ -85,6 +103,7 @@ impl UndoStack {
             batch.push(cmd);
         } else {
             self.undo_stack.push(UndoEntry::Single(cmd));
+            self.trim_to_capacity();
         }
     }
 
@@ -103,6 +122,7 @@ impl UndoStack {
             && !batch.is_empty()
         {
             self.undo_stack.push(UndoEntry::Batch(batch));
+            self.trim_to_capacity();
         }
     }
 
@@ -289,5 +309,30 @@ mod tests {
         stack.pop_undo();
         assert_eq!(stack.undo_depth(), 1);
         assert_eq!(stack.redo_depth(), 2);
+    }
+
+    #[test]
+    fn undo_stack_is_bounded() {
+        let mut stack = UndoStack::new();
+        stack.max_entries = 3;
+        for i in 0..10 {
+            stack.record(insert(i, "x"));
+        }
+        // Only the 3 newest entries survive.
+        assert_eq!(stack.undo_depth(), 3);
+    }
+
+    #[test]
+    fn batch_commit_respects_cap() {
+        let mut stack = UndoStack::new();
+        stack.max_entries = 2;
+        stack.record(insert(0, "a"));
+        stack.record(insert(1, "b"));
+        stack.begin_batch();
+        stack.record(insert(2, "c"));
+        stack.record(insert(3, "d"));
+        stack.commit_batch();
+        // Two singles + one batch = 3 → trimmed to 2.
+        assert_eq!(stack.undo_depth(), 2);
     }
 }

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -624,7 +624,7 @@ impl Buffer {
             .collect();
 
         // Process descending so higher-offset inserts don't shift lower positions.
-        ops.sort_by(|a, b| b.ins_pt.cmp(&a.ins_pt));
+        ops.sort_by_key(|b| std::cmp::Reverse(b.ins_pt));
 
         // new_positions[cursor_idx] = byte offset after the edit.
         let mut new_positions = vec![0usize; n];
@@ -730,7 +730,7 @@ impl Buffer {
         }
 
         // Descending so higher-offset deletes don't affect lower positions.
-        ops.sort_by(|a, b| b.del_start.cmp(&a.del_start));
+        ops.sort_by_key(|b| std::cmp::Reverse(b.del_start));
 
         // Start with current positions (unchanged for cursors with no op).
         let mut new_positions: Vec<usize> = self
@@ -826,7 +826,7 @@ impl Buffer {
             return;
         }
 
-        ops.sort_by(|a, b| b.del_start.cmp(&a.del_start));
+        ops.sort_by_key(|b| std::cmp::Reverse(b.del_start));
 
         let mut new_positions: Vec<usize> = self
             .cursors

--- a/src/input/action.rs
+++ b/src/input/action.rs
@@ -39,12 +39,18 @@ pub enum EditorAction {
 
     // ── Scrolling (without moving the cursor) ─────────────────────────
     Scroll(ScrollDir),
+    /// Re-center the viewport so the primary cursor is on the middle row.
+    /// Does not move the cursor.
+    ScrollCursorCenter,
 
     // ── AST-aware selection (tree-sitter) ────────────────────────────
     /// Ctrl+W: expand selection to the next enclosing AST node.
     AstExpandSelection,
     /// Ctrl+Shift+W: contract selection back to the previous one.
     AstContractSelection,
+    /// Jump the primary cursor to the matching bracket (`{}`, `()`, `[]`).
+    /// No-op when the cursor is not on a bracket character.
+    GoToMatchingBracket,
 
     // ── Clipboard ────────────────────────────────────────────────────
     Copy,
@@ -237,9 +243,11 @@ pub fn action_to_name(action: &EditorAction) -> Option<&'static str> {
         // Scrolling
         EditorAction::Scroll(ScrollDir::Up) => "scroll_up",
         EditorAction::Scroll(ScrollDir::Down) => "scroll_down",
+        EditorAction::ScrollCursorCenter => "scroll_cursor_center",
         // AST selection
         EditorAction::AstExpandSelection => "ast_expand_selection",
         EditorAction::AstContractSelection => "ast_contract_selection",
+        EditorAction::GoToMatchingBracket => "go_to_matching_bracket",
         // Clipboard
         EditorAction::Copy => "copy",
         EditorAction::Cut => "cut",
@@ -344,9 +352,11 @@ pub fn action_from_name(name: &str) -> Option<EditorAction> {
         // Scrolling
         "scroll_up" => EditorAction::Scroll(ScrollDir::Up),
         "scroll_down" => EditorAction::Scroll(ScrollDir::Down),
+        "scroll_cursor_center" => EditorAction::ScrollCursorCenter,
         // AST selection
         "ast_expand_selection" => EditorAction::AstExpandSelection,
         "ast_contract_selection" => EditorAction::AstContractSelection,
+        "go_to_matching_bracket" => EditorAction::GoToMatchingBracket,
         // Clipboard
         "copy" => EditorAction::Copy,
         "cut" => EditorAction::Cut,

--- a/src/input/keybinding.rs
+++ b/src/input/keybinding.rs
@@ -320,6 +320,8 @@ impl KeyBindings {
         bind("alt+r", EditorAction::SearchToggleRegex);
         bind("alt+c", EditorAction::SearchToggleCaseSensitive);
         bind("alt+z", EditorAction::ToggleWordWrap);
+        bind("alt+m", EditorAction::GoToMatchingBracket);
+        bind("alt+l", EditorAction::ScrollCursorCenter);
 
         // ── Ctrl+Space / Ctrl+. ────────────────────────────────────
         bind("ctrl+space", EditorAction::TriggerCompletion);

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -2,6 +2,11 @@ use regex::Regex;
 
 use crate::buffer::cursor::ByteRange;
 
+/// Cap on the number of matches stored at once. Protects the editor against
+/// pathological queries (e.g. `e` in a megabyte file) that would otherwise
+/// allocate millions of byte-ranges and stall the UI.
+const MAX_MATCHES: usize = 10_000;
+
 /// State for the find / replace bar.
 ///
 /// Matches are recomputed synchronously on every query change. For Phase 6 this is
@@ -12,7 +17,11 @@ pub struct SearchState {
     pub is_regex: bool,
     pub case_sensitive: bool,
     /// All match byte-ranges in the current buffer text, in document order.
+    /// Capped at `MAX_MATCHES`; if the cap was hit, `match_count_capped` is true.
     pub matches: Vec<ByteRange>,
+    /// True if `recompute_matches` stopped collecting at `MAX_MATCHES`. The UI
+    /// can display this as "10000+ matches".
+    pub match_count_capped: bool,
     /// 0-based index into `matches` for the highlighted "current" match.
     pub current_match: usize,
     /// True when the replace input row is visible (Ctrl+H).
@@ -29,6 +38,7 @@ impl SearchState {
             is_regex: false,
             case_sensitive: false,
             matches: Vec::new(),
+            match_count_capped: false,
             current_match: 0,
             show_replace,
             focus_replace: false,
@@ -38,8 +48,12 @@ impl SearchState {
     // ── Match computation ────────────────────────────────────────────────────
 
     /// Recompute all match byte-ranges against `text`.
+    ///
+    /// Stops collecting at `MAX_MATCHES` and sets `match_count_capped` so the
+    /// status bar can indicate truncation.
     pub fn recompute_matches(&mut self, text: &str) {
         self.matches.clear();
+        self.match_count_capped = false;
         if self.query.is_empty() {
             return;
         }
@@ -47,6 +61,10 @@ impl SearchState {
         let pattern = build_pattern(&self.query, self.is_regex, self.case_sensitive);
         if let Ok(re) = Regex::new(&pattern) {
             for m in re.find_iter(text) {
+                if self.matches.len() >= MAX_MATCHES {
+                    self.match_count_capped = true;
+                    break;
+                }
                 self.matches.push(ByteRange::new(m.start(), m.end()));
             }
         }
@@ -211,5 +229,25 @@ mod tests {
         assert_eq!(s1.bar_height(), 1);
         let s2 = SearchState::new(true);
         assert_eq!(s2.bar_height(), 2);
+    }
+
+    #[test]
+    fn match_count_is_capped() {
+        let mut s = SearchState::new(false);
+        s.query = "a".to_string();
+        // Build text with way more than MAX_MATCHES occurrences.
+        let text = "a".repeat(MAX_MATCHES + 100);
+        s.recompute_matches(&text);
+        assert_eq!(s.matches.len(), MAX_MATCHES);
+        assert!(s.match_count_capped);
+    }
+
+    #[test]
+    fn match_count_not_capped_when_under_limit() {
+        let mut s = SearchState::new(false);
+        s.query = "x".to_string();
+        s.recompute_matches("xx xx");
+        assert_eq!(s.matches.len(), 4);
+        assert!(!s.match_count_capped);
     }
 }

--- a/src/ui/editor_view.rs
+++ b/src/ui/editor_view.rs
@@ -6,6 +6,7 @@ use ratatui::{
 use unicode_width::UnicodeWidthStr;
 
 use crate::buffer::cursor::ByteRange;
+use crate::buffer::edit::find_matching_bracket;
 use crate::editor::tab::BufferHandle;
 use crate::git::{GitGutter, GutterMark};
 use crate::lsp::types::DiagSeverity;
@@ -492,63 +493,6 @@ fn line_str_graphemes(s: &str) -> impl Iterator<Item = &str> {
 
 fn line_str_byte_len(s: &str) -> usize {
     s.len()
-}
-
-/// Find the matching bracket for the character at `cursor_byte`.
-///
-/// Returns `Some((open_byte, close_byte))` if a pair is found, else `None`.
-/// Scans at most 100 000 chars in each direction.
-fn find_matching_bracket(rope: &ropey::Rope, cursor_byte: usize) -> Option<(usize, usize)> {
-    if cursor_byte >= rope.len_bytes() {
-        return None;
-    }
-    let char_idx = rope.byte_to_char(cursor_byte);
-    let ch = rope.char(char_idx);
-
-    const MAX_SCAN: usize = 100_000;
-    let total_chars = rope.len_chars();
-
-    let (open_ch, close_ch, forward) = match ch {
-        '{' => ('{', '}', true),
-        '(' => ('(', ')', true),
-        '[' => ('[', ']', true),
-        '}' => ('{', '}', false),
-        ')' => ('(', ')', false),
-        ']' => ('[', ']', false),
-        _ => return None,
-    };
-
-    if forward {
-        let mut depth = 0i32;
-        let limit = (char_idx + MAX_SCAN).min(total_chars);
-        for i in char_idx..limit {
-            let c = rope.char(i);
-            if c == open_ch {
-                depth += 1;
-            } else if c == close_ch {
-                depth -= 1;
-                if depth == 0 {
-                    return Some((cursor_byte, rope.char_to_byte(i)));
-                }
-            }
-        }
-    } else {
-        let mut depth = 0i32;
-        let start = char_idx.saturating_sub(MAX_SCAN);
-        for i in (start..=char_idx).rev() {
-            let c = rope.char(i);
-            if c == close_ch {
-                depth += 1;
-            } else if c == open_ch {
-                depth -= 1;
-                if depth == 0 {
-                    return Some((rope.char_to_byte(i), cursor_byte));
-                }
-            }
-        }
-    }
-
-    None
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/src/ui/help_overlay.rs
+++ b/src/ui/help_overlay.rs
@@ -65,6 +65,14 @@ const TEMPLATE: &[HelpEntry] = &[
         actions: &["move_cursor_page_up", "move_cursor_page_down"],
         desc: "Page up / down",
     },
+    HelpEntry::Binding {
+        actions: &["go_to_matching_bracket"],
+        desc: "Jump to matching bracket",
+    },
+    HelpEntry::Binding {
+        actions: &["scroll_cursor_center"],
+        desc: "Scroll cursor to center",
+    },
     // ── Selection ────────────────────────────────────────────────────
     HelpEntry::Section("Selection"),
     HelpEntry::Binding {

--- a/src/ui/search_bar.rs
+++ b/src/ui/search_bar.rs
@@ -87,6 +87,8 @@ pub fn render(search: &SearchState, area: Rect, buf: &mut TermBuffer) {
         } else {
             " No matches".to_string()
         }
+    } else if search.match_count_capped {
+        format!(" {}/{}+", search.current_match + 1, search.matches.len())
     } else {
         format!(" {}/{}", search.current_match + 1, search.matches.len())
     };


### PR DESCRIPTION
- Cap UndoStack at 1000 entries so long sessions can't grow undo memory
  without bound. Trim oldest single entries and committed batches.
- Cap search match collection at 10_000 ranges and surface truncation
  in the search bar count display ("1/10000+"). Protects against
  pathological queries (e.g. "e" in a megabyte file) that would
  otherwise stall the UI and hold millions of byte-ranges.
- Add GoToMatchingBracket (Alt+M) — jump the primary cursor between
  paired { } ( ) [ ] using the existing 100k-char bounded scan.
  Hoist find_matching_bracket from src/ui/editor_view.rs into
  src/buffer/edit.rs so both the visual highlight and the navigation
  action share one implementation.
- Add ScrollCursorCenter (Alt+L) — re-center the viewport on the
  primary cursor without moving the cursor. Useful after a long jump
  or search hit.
- Document both new shortcuts in the F1 help overlay.