### PR TITLE
Show current git branch in the status bar

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -774,6 +774,10 @@ pub struct AppState {
     pub term_height: u16,
     pub memory_rss_kb: u64,
     memory_last_checked: Instant,
+    /// Currently checked-out git branch in `workspace`, if any. Refreshed
+    /// on a 2 s cadence so external `git checkout`s are picked up live.
+    pub git_branch: Option<String>,
+    git_branch_last_checked: Instant,
 }
 
 impl AppState {
@@ -815,6 +819,7 @@ impl AppState {
         }
 
         let lsp_config = crate::lsp::config::WorkspaceLspConfig::load(&workspace);
+        let git_branch = crate::git::current_branch(&workspace);
         let mut state = Self {
             editor,
             clipboard: ClipboardManager::new(),
@@ -861,6 +866,8 @@ impl AppState {
             term_height: 24,
             memory_rss_kb: 0,
             memory_last_checked: Instant::now(),
+            git_branch,
+            git_branch_last_checked: Instant::now(),
         };
         // Apply config to initial buffer.
         if state.config.word_wrap {
@@ -2803,6 +2810,17 @@ impl AppState {
         }
     }
 
+    /// Refresh the cached git branch (throttled to every 2 seconds).
+    ///
+    /// Picks up branch changes made outside the editor (e.g. `git checkout`
+    /// from another terminal).
+    pub fn refresh_git_branch(&mut self) {
+        if self.git_branch_last_checked.elapsed() >= Duration::from_secs(2) {
+            self.git_branch = crate::git::current_branch(&self.workspace);
+            self.git_branch_last_checked = Instant::now();
+        }
+    }
+
     /// Reload the active buffer from disk (used after external modification).
     fn reload_active_file(&mut self) {
         let path = match self.editor.active().path.clone() {
@@ -3897,6 +3915,7 @@ impl App {
             state.poll_file_watcher();
             state.poll_auto_save();
             state.refresh_memory();
+            state.refresh_git_branch();
 
             // Drain pending LSP server updates (non-blocking).
             state.poll_lsp_updates();

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -143,6 +143,25 @@ pub fn fetch_head_content(path: &Path) -> Option<String> {
     }
 }
 
+/// Return the name of the currently checked-out branch in `workspace`.
+///
+/// Returns `None` if `workspace` is not inside a git repo, git is unavailable,
+/// or HEAD is detached.
+pub fn current_branch(workspace: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(workspace)
+        .args(["branch", "--show-current"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+    let name = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    if name.is_empty() { None } else { Some(name) }
+}
+
 /// Compute a `GitGutter` for the file at `path` against its HEAD version.
 ///
 /// Returns `None` if the file is not tracked or git is unavailable.

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -10,7 +10,7 @@ use crate::theme::ThemeColors;
 /// Render the status bar at the bottom of the screen.
 ///
 /// Normal layout:
-///   [ filename [+]  lang ]  ...spacer...  [ line:col  UTF-8 ][ F1 Help ]
+///   [ filename [+]  lang ]  ...spacer...  [ ⎇ branch  line:col  UTF-8 ][ F1 Help ]
 ///
 /// Modal layout:
 ///   [ JumpToLine / OpenFile / SaveAs prompt ]
@@ -112,9 +112,16 @@ pub fn render(state: &AppState, theme: &ThemeColors, area: Rect, buf: &mut TermB
         String::new()
     };
 
-    // Right side: word-wrap flag + LSP/TS mode + diagnostics + language + position + memory + encoding
+    let branch_str = state
+        .git_branch
+        .as_deref()
+        .map(|b| format!(" ⎇ {}", b))
+        .unwrap_or_default();
+
+    // Right side: branch + word-wrap flag + LSP/TS mode + diagnostics + language + position + memory + encoding
     let right = format!(
-        "{}{}{}{}  {}{}{}",
+        "{}{}{}{}{}  {}{}{}",
+        branch_str,
         wrap_flag,
         lsp_flag,
         diag_str,


### PR DESCRIPTION
Surfaces the active branch so users can confirm which branch they're
editing without dropping to a shell. Polled every 2 s in the render
loop (mirroring the existing memory-refresh pattern) so external
checkouts are reflected within ~2 s.