### PR TITLE
Add code formatting: live indent rules and external formatter

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -758,6 +758,10 @@ pub struct AppState {
     file_watcher: Option<FileWatcher>,
     /// Per-workspace LSP configuration (loaded from `<workspace>/.txt/lsp.toml`).
     pub lsp_config: crate::lsp::config::WorkspaceLspConfig,
+    /// Per-workspace formatting overrides (loaded from
+    /// `<workspace>/.txt/formatters.toml`). `None` when the file is missing
+    /// or unparseable; the global config still applies.
+    pub project_fmt: Option<crate::formatting::FormattingConfig>,
     /// Active LSP server connection (None when LSP is disabled or unavailable).
     pub lsp: Option<crate::lsp::LspRegistry>,
     /// Pending trust-on-first-use approval for the LSP binary, if any.
@@ -815,6 +819,7 @@ impl AppState {
         }
 
         let lsp_config = crate::lsp::config::WorkspaceLspConfig::load(&workspace);
+        let project_fmt = crate::formatting::project::load(&workspace);
         let mut state = Self {
             editor,
             clipboard: ClipboardManager::new(),
@@ -852,6 +857,7 @@ impl AppState {
             auto_save_timer: None,
             file_watcher: None,
             lsp_config,
+            project_fmt,
             lsp: None,
             pending_lsp_approval: None,
             status_error: None,
@@ -1047,23 +1053,55 @@ impl AppState {
 
             // ── Text insertion ────────────────────────────────────────
             EditorAction::InsertChar(c) => {
+                let (indent, rules) = self.indent_for_active();
                 if self.editor.active().buffer.cursors.is_multi() {
                     self.editor.active_mut().buffer.multi_insert_char(c);
                 } else {
-                    self.editor.active_mut().buffer.insert_char(c);
+                    self.editor
+                        .active_mut()
+                        .buffer
+                        .insert_char_with_indent(c, &indent, rules);
                 }
             }
             EditorAction::InsertNewline => {
-                self.editor.active_mut().buffer.insert_newline();
+                let (indent, rules) = self.indent_for_active();
+                self.editor
+                    .active_mut()
+                    .buffer
+                    .insert_newline(&indent, rules);
             }
             EditorAction::InsertTab => {
-                let tab_size = self.config.tab_size;
-                if self.editor.active().buffer.cursors.is_multi() {
-                    let spaces = " ".repeat(tab_size.max(1));
-                    self.editor.active_mut().buffer.multi_insert_str(&spaces);
+                let (indent, _) = self.indent_for_active();
+                // Multi-line selection → indent every touched line.
+                let buf = &self.editor.active().buffer;
+                let primary = buf.cursors.primary();
+                let multi_line_selection = primary.has_selection() && {
+                    let r = primary.selection_bytes();
+                    let rope = buf.rope();
+                    rope.char_to_line(rope.byte_to_char(r.start))
+                        != rope.char_to_line(rope.byte_to_char(r.end))
+                };
+                if multi_line_selection {
+                    self.editor.active_mut().buffer.indent_lines(&indent);
+                } else if self.editor.active().buffer.cursors.is_multi() {
+                    self.editor
+                        .active_mut()
+                        .buffer
+                        .multi_insert_str(&indent.one_level());
                 } else {
-                    self.editor.active_mut().buffer.insert_tab(tab_size);
+                    self.editor.active_mut().buffer.insert_tab(&indent);
                 }
+            }
+            EditorAction::IndentSelection => {
+                let (indent, _) = self.indent_for_active();
+                self.editor.active_mut().buffer.indent_lines(&indent);
+            }
+            EditorAction::DedentSelection => {
+                let (indent, _) = self.indent_for_active();
+                self.editor.active_mut().buffer.dedent_lines(&indent);
+            }
+            EditorAction::FormatBuffer => {
+                self.format_buffer();
             }
 
             // ── Deletion ──────────────────────────────────────────────
@@ -1571,6 +1609,7 @@ impl AppState {
             }
             EditorAction::ReloadConfig => {
                 self.config = Config::load();
+                self.project_fmt = crate::formatting::project::load(&self.workspace);
                 self.input.reload_keybindings();
                 for tab in &mut self.editor.tabs {
                     tab.viewport.word_wrap = self.config.word_wrap;
@@ -2668,6 +2707,80 @@ impl AppState {
                 self.command_palette = None;
             }
             _ => {}
+        }
+    }
+
+    // ── Code formatting ───────────────────────────────────────────────────────
+
+    /// Resolve the live indent rules for the active buffer's language,
+    /// merging project + global config and falling back to the legacy
+    /// `tab_size` and built-in defaults.
+    fn indent_for_active(
+        &self,
+    ) -> (
+        crate::formatting::IndentConfig,
+        crate::formatting::IndentRules,
+    ) {
+        let lang = self.editor.active().syntax.language;
+        let resolver = crate::formatting::FormattingResolver {
+            global: &self.config.formatting,
+            project: self.project_fmt.as_ref(),
+            legacy_tab_size: self.config.tab_size,
+        };
+        (
+            resolver.indent(lang),
+            crate::formatting::IndentRules::for_lang(lang),
+        )
+    }
+
+    /// Run the configured external formatter for the active buffer's
+    /// language and replace the buffer atomically. On any error, the buffer
+    /// is left untouched and `status_error` is set.
+    fn format_buffer(&mut self) {
+        let lang = self.editor.active().syntax.language;
+        let path = self.editor.active().path.clone();
+        let resolver = crate::formatting::FormattingResolver {
+            global: &self.config.formatting,
+            project: self.project_fmt.as_ref(),
+            legacy_tab_size: self.config.tab_size,
+        };
+        let fc = match resolver.formatter(lang) {
+            Some(f) => f,
+            None => {
+                let name = lang.name();
+                let display = if name.is_empty() { "this file" } else { name };
+                self.status_error = Some(format!("No formatter configured for {display}"));
+                return;
+            }
+        };
+
+        let input = self.editor.active().buffer.to_string();
+        let (saved_line, saved_col) = {
+            let c = self.editor.active().buffer.cursors.primary();
+            (c.line, c.col)
+        };
+
+        match crate::formatting::run_formatter(&fc, &input, path.as_deref()) {
+            Ok(out) if out == input => {
+                // No-op format — leave the buffer alone, no undo entry.
+            }
+            Ok(out) => {
+                let buf = &mut self.editor.active_mut().buffer;
+                buf.begin_batch();
+                let len = buf.rope().len_bytes();
+                buf.delete_range(0, len);
+                buf.move_cursor_to(0, false);
+                buf.insert_str(&out);
+                buf.commit_batch();
+                // Restore cursor by clamped (line, col).
+                let new_cursor =
+                    crate::buffer::cursor::Cursor::from_line_col(buf.rope(), saved_line, saved_col);
+                buf.move_cursor_to(new_cursor.byte_offset, false);
+                self.editor.active_mut().reparse();
+            }
+            Err(e) => {
+                self.status_error = Some(format!("Formatter failed: {e}"));
+            }
         }
     }
 

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -9,6 +9,7 @@ use crate::buffer::{
     edit as rope_edit,
     history::{EditCommand, UndoStack},
 };
+use crate::formatting::{IndentConfig, IndentRules, IndentStyle};
 
 /// High-level text buffer.
 ///
@@ -262,25 +263,202 @@ impl Buffer {
         self.modified = true;
     }
 
-    /// Insert a newline at the primary cursor, applying auto-indent.
-    pub fn insert_newline(&mut self) {
+    /// Insert a newline at the primary cursor, applying language-aware
+    /// auto-indent.
+    ///
+    /// Copies the leading whitespace from the current line and adds one extra
+    /// indent level when the character before the cursor matches one of the
+    /// language's `increase_after` triggers (e.g. `{ ( [` for C-family,
+    /// `:` for Python).
+    pub fn insert_newline(&mut self, indent: &IndentConfig, rules: IndentRules) {
         let cursor = self.cursors.primary();
         let line = cursor.line;
-        let indent = self.leading_indent(line);
+        let leading = self.leading_indent(line);
         let prev_char = self.char_before_cursor(cursor.byte_offset);
-        let extra = if matches!(prev_char, Some('{') | Some('(') | Some('[') | Some(':')) {
-            self.indent_unit()
+        let bump = matches!(prev_char, Some(c) if rules.increase_after.contains(&c));
+        let extra = if bump {
+            indent.one_level()
         } else {
             String::new()
         };
-        let new_text = format!("\n{}{}", indent, extra);
+        let new_text = format!("\n{leading}{extra}");
         self.insert_str(&new_text);
     }
 
-    /// Insert `tab_size` spaces at the primary cursor.
-    pub fn insert_tab(&mut self, tab_size: usize) {
-        let spaces = " ".repeat(tab_size.max(1));
-        self.insert_str(&spaces);
+    /// Insert one indent level at the primary cursor.
+    ///
+    /// With spaces: smart-tab from the current display column to the next
+    /// multiple of `width` (so Tab on column 3 with width 4 inserts one
+    /// space). With tabs: inserts a single `\t`.
+    pub fn insert_tab(&mut self, indent: &IndentConfig) {
+        match indent.style {
+            IndentStyle::Tabs => {
+                self.insert_str("\t");
+            }
+            IndentStyle::Spaces => {
+                let width = indent.width.max(1);
+                let display_col = self.cursors.primary().preferred_col;
+                let count = width - (display_col % width);
+                self.insert_str(&" ".repeat(count));
+            }
+        }
+    }
+
+    /// Indent every line touched by the primary cursor's selection (or the
+    /// current line if there's no selection) by one indent level.
+    /// Recorded as a single undo entry. The cursor and selection move with
+    /// their lines.
+    pub fn indent_lines(&mut self, indent: &IndentConfig) {
+        let unit = indent.one_level();
+        let unit_bytes = unit.len();
+        let (first_line, last_line) = self.touched_line_range();
+
+        let primary = self.cursors.primary();
+        let original_offset = primary.byte_offset;
+        let original_sel = primary.selection;
+        let mut tracked: Vec<usize> = vec![original_offset];
+        if let Some(s) = original_sel {
+            tracked.push(s.anchor);
+            tracked.push(s.active);
+        }
+
+        self.history.begin_batch();
+        // Insert at each line's start, descending so earlier line offsets stay
+        // valid for the next iteration.
+        for line in (first_line..=last_line).rev() {
+            let start = self.line_start_byte(line);
+            rope_edit::insert(&mut self.rope, start, &unit);
+            self.history.record(EditCommand::Insert {
+                at: start,
+                text: unit.clone(),
+            });
+            for off in tracked.iter_mut() {
+                if *off >= start {
+                    *off += unit_bytes;
+                }
+            }
+        }
+        self.history.commit_batch();
+
+        let new_offset = tracked[0];
+        *self.cursors.primary_mut() = Cursor::from_byte_offset(&self.rope, new_offset);
+        if original_sel.is_some() {
+            let new_sel = crate::buffer::cursor::Selection::new(tracked[1], tracked[2]);
+            self.cursors.primary_mut().selection = Some(new_sel);
+        }
+        self.modified = true;
+    }
+
+    /// Dedent every line touched by the primary cursor's selection (or the
+    /// current line) by one indent level. Lines without enough leading
+    /// whitespace are left unchanged. Recorded as a single undo entry.
+    pub fn dedent_lines(&mut self, indent: &IndentConfig) {
+        let (first_line, last_line) = self.touched_line_range();
+
+        // Strip-per-line, computed up front in original-rope coordinates.
+        let mut strips: Vec<(usize, String)> = Vec::new();
+        for line in first_line..=last_line {
+            let line_str = self.line_str(line);
+            let strip = leading_dedent_match(&line_str, indent);
+            if !strip.is_empty() {
+                let start = self.line_start_byte(line);
+                strips.push((start, strip));
+            }
+        }
+
+        if strips.is_empty() {
+            return;
+        }
+
+        let primary = self.cursors.primary();
+        let original_offset = primary.byte_offset;
+        let original_sel = primary.selection;
+        let mut tracked: Vec<usize> = vec![original_offset];
+        if let Some(s) = original_sel {
+            tracked.push(s.anchor);
+            tracked.push(s.active);
+        }
+
+        self.history.begin_batch();
+        // Apply highest-offset deletions first so earlier offsets stay valid.
+        for (start, strip) in strips.iter().rev() {
+            let end = start + strip.len();
+            let deleted = rope_edit::delete(&mut self.rope, *start, end);
+            self.history.record(EditCommand::Delete {
+                start: *start,
+                end,
+                deleted,
+            });
+            let strip_len = strip.len();
+            for off in tracked.iter_mut() {
+                if *off >= end {
+                    *off -= strip_len;
+                } else if *off > *start {
+                    // Was inside the stripped whitespace — clamp to start.
+                    *off = *start;
+                }
+            }
+        }
+        self.history.commit_batch();
+
+        let new_offset = tracked[0];
+        *self.cursors.primary_mut() = Cursor::from_byte_offset(&self.rope, new_offset);
+        if original_sel.is_some() {
+            let new_sel = crate::buffer::cursor::Selection::new(tracked[1], tracked[2]);
+            self.cursors.primary_mut().selection = Some(new_sel);
+        }
+        self.modified = true;
+    }
+
+    /// Insert a single character with optional auto-dedent on closing
+    /// brackets. When `c` is in `rules.decrease_on` and the line up to the
+    /// cursor is whitespace-only, dedent the line by one level before
+    /// inserting `c`. The whole operation is a single undo entry.
+    pub fn insert_char_with_indent(&mut self, c: char, indent: &IndentConfig, rules: IndentRules) {
+        if !rules.decrease_on.contains(&c) {
+            self.insert_char(c);
+            return;
+        }
+        // Auto-dedent only fires for single-cursor edits where the line up
+        // to the cursor is purely whitespace.
+        if self.cursors.is_multi() {
+            self.insert_char(c);
+            return;
+        }
+        let cursor = self.cursors.primary();
+        if cursor.has_selection() {
+            self.insert_char(c);
+            return;
+        }
+        let line = cursor.line;
+        let line_start = self.line_start_byte(line);
+        let prefix_bytes = cursor.byte_offset - line_start;
+        let line_str = self.line_str(line);
+        let prefix = &line_str[..prefix_bytes.min(line_str.len())];
+        if prefix.is_empty() || !prefix.chars().all(|ch| ch == ' ' || ch == '\t') {
+            self.insert_char(c);
+            return;
+        }
+        let strip = leading_dedent_match(prefix, indent);
+        if strip.is_empty() {
+            self.insert_char(c);
+            return;
+        }
+        self.history.begin_batch();
+        let strip_end = line_start + strip.len();
+        let deleted = rope_edit::delete(&mut self.rope, line_start, strip_end);
+        self.history.record(EditCommand::Delete {
+            start: line_start,
+            end: strip_end,
+            deleted,
+        });
+        let new_offset = cursor.byte_offset - strip.len();
+        *self.cursors.primary_mut() = Cursor::from_byte_offset(&self.rope, new_offset);
+        let mut s = String::with_capacity(c.len_utf8());
+        s.push(c);
+        // insert_str handles cursor advance + history recording.
+        self.insert_str(&s);
+        self.history.commit_batch();
     }
 
     /// Duplicate the current line (or selection).
@@ -902,9 +1080,28 @@ impl Buffer {
         ws
     }
 
-    fn indent_unit(&self) -> String {
-        // 4 spaces by default; Phase 8 will read from config.
-        "    ".to_string()
+    /// Range of lines `(first, last)` inclusive that the primary cursor
+    /// (and its selection, if any) touches. Used by indent / dedent.
+    fn touched_line_range(&self) -> (usize, usize) {
+        let cursor = self.cursors.primary();
+        if !cursor.has_selection() {
+            return (cursor.line, cursor.line);
+        }
+        let range = cursor.selection_bytes();
+        let start_line = self.rope.char_to_line(self.rope.byte_to_char(range.start));
+        // If the selection ends exactly at a line start (i.e. the user
+        // selected up to but not into the next line), don't include that
+        // next line — Tab on a 3-line selection that ends at the start of
+        // line 4 should indent lines 1-3.
+        let end_char = self.rope.byte_to_char(range.end);
+        let end_line_raw = self.rope.char_to_line(end_char);
+        let end_line_start_char = self.rope.line_to_char(end_line_raw);
+        let end_line = if range.end > range.start && end_char == end_line_start_char {
+            end_line_raw.saturating_sub(1)
+        } else {
+            end_line_raw
+        };
+        (start_line, end_line.max(start_line))
     }
 
     fn char_before_cursor(&self, byte_offset: usize) -> Option<char> {
@@ -945,6 +1142,27 @@ impl Buffer {
     }
 }
 
+/// Returns the leading whitespace prefix of `line_str` to strip when
+/// dedenting once. Matches one `\t` if the line starts with a tab, otherwise
+/// up to `indent.width` leading spaces. Returns the empty string when there
+/// is no leading whitespace to strip.
+fn leading_dedent_match(line_str: &str, indent: &IndentConfig) -> String {
+    let mut chars = line_str.chars();
+    match chars.next() {
+        Some('\t') => "\t".to_string(),
+        Some(' ') => {
+            let width = indent.width.max(1);
+            let count = line_str
+                .chars()
+                .take(width)
+                .take_while(|c| *c == ' ')
+                .count();
+            " ".repeat(count)
+        }
+        _ => String::new(),
+    }
+}
+
 impl std::fmt::Display for Buffer {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.rope)
@@ -960,6 +1178,22 @@ impl Default for Buffer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::syntax::language::Lang;
+
+    fn spaces(width: usize) -> IndentConfig {
+        IndentConfig {
+            style: IndentStyle::Spaces,
+            width,
+        }
+    }
+
+    fn rust_rules() -> IndentRules {
+        IndentRules::for_lang(Lang::Rust)
+    }
+
+    fn python_rules() -> IndentRules {
+        IndentRules::for_lang(Lang::Python)
+    }
 
     #[test]
     fn insert_and_read() {
@@ -1097,7 +1331,7 @@ mod tests {
     fn newline_with_auto_indent() {
         let mut buf = Buffer::from_str("    hello");
         buf.move_cursor_to(9, false); // end of line
-        buf.insert_newline();
+        buf.insert_newline(&spaces(4), rust_rules());
         // New line should have the same 4-space indent
         assert!(buf.to_string().starts_with("    hello\n    "));
     }
@@ -1106,10 +1340,28 @@ mod tests {
     fn newline_after_brace_increases_indent() {
         let mut buf = Buffer::from_str("fn foo() {");
         buf.move_cursor_to(10, false);
-        buf.insert_newline();
+        buf.insert_newline(&spaces(4), rust_rules());
         let content = buf.to_string();
         // Should add one extra indent level after '{'
         assert!(content.contains("fn foo() {\n    "));
+    }
+
+    #[test]
+    fn newline_python_colon_increases_indent() {
+        let mut buf = Buffer::from_str("def f():");
+        buf.move_cursor_to(8, false);
+        buf.insert_newline(&spaces(4), python_rules());
+        assert_eq!(buf.to_string(), "def f():\n    ");
+    }
+
+    #[test]
+    fn newline_python_brace_does_not_increase_indent() {
+        // In Python, `{ ( [` are dict / list / call literals — not blocks.
+        let mut buf = Buffer::from_str("xs = {");
+        buf.move_cursor_to(6, false);
+        buf.insert_newline(&spaces(4), python_rules());
+        // No extra indent: just the leading whitespace from the previous line (none).
+        assert_eq!(buf.to_string(), "xs = {\n");
     }
 
     #[test]
@@ -1166,25 +1418,98 @@ mod tests {
     }
 
     #[test]
-    fn insert_tab_default_size() {
+    fn insert_tab_spaces_default_at_column_zero() {
         let mut buf = Buffer::new();
-        buf.insert_tab(4);
+        buf.insert_tab(&spaces(4));
         assert_eq!(buf.to_string(), "    ");
         assert_eq!(buf.cursors.primary().byte_offset, 4);
     }
 
     #[test]
-    fn insert_tab_custom_size() {
-        let mut buf = Buffer::new();
-        buf.insert_tab(2);
-        assert_eq!(buf.to_string(), "  ");
+    fn insert_tab_spaces_smart_advances_to_column_boundary() {
+        // At column 1, Tab with width=4 should fill 3 spaces (to column 4).
+        let mut buf = Buffer::from_str("x");
+        buf.move_cursor_to(1, false);
+        buf.insert_tab(&spaces(4));
+        assert_eq!(buf.to_string(), "x   ");
     }
 
     #[test]
-    fn insert_tab_size_one() {
+    fn insert_tab_tabs_inserts_tab_char() {
         let mut buf = Buffer::new();
-        buf.insert_tab(1);
-        assert_eq!(buf.to_string(), " ");
+        buf.insert_tab(&IndentConfig {
+            style: IndentStyle::Tabs,
+            width: 4,
+        });
+        assert_eq!(buf.to_string(), "\t");
+    }
+
+    #[test]
+    fn indent_lines_three_line_selection() {
+        let mut buf = Buffer::from_str("a\nb\nc\n");
+        buf.move_cursor_to(0, false);
+        buf.move_cursor_to(6, true); // select all 3 lines + trailing newline
+        buf.indent_lines(&spaces(4));
+        assert_eq!(buf.to_string(), "    a\n    b\n    c\n");
+        // One undo restores the original.
+        buf.undo();
+        assert_eq!(buf.to_string(), "a\nb\nc\n");
+    }
+
+    #[test]
+    fn indent_lines_no_selection_only_current_line() {
+        let mut buf = Buffer::from_str("a\nb\nc\n");
+        buf.move_cursor_to(2, false); // line 1, col 0 (the 'b')
+        buf.indent_lines(&spaces(4));
+        assert_eq!(buf.to_string(), "a\n    b\nc\n");
+    }
+
+    #[test]
+    fn dedent_lines_handles_tabs_and_spaces() {
+        let mut buf = Buffer::from_str("\tline1\n    line2\n  line3\n");
+        buf.move_cursor_to(0, false);
+        buf.move_cursor_to(buf.rope().len_bytes(), true);
+        buf.dedent_lines(&spaces(4));
+        assert_eq!(buf.to_string(), "line1\nline2\nline3\n");
+    }
+
+    #[test]
+    fn dedent_lines_no_op_on_unindented_lines() {
+        let mut buf = Buffer::from_str("a\nb\nc\n");
+        let before = buf.to_string();
+        buf.move_cursor_to(0, false);
+        buf.move_cursor_to(buf.rope().len_bytes(), true);
+        buf.dedent_lines(&spaces(4));
+        assert_eq!(buf.to_string(), before);
+    }
+
+    #[test]
+    fn insert_close_brace_dedents_when_only_whitespace_before() {
+        // "fn x() {\n    " — typing '}' on the indented line dedents and inserts.
+        let mut buf = Buffer::from_str("fn x() {\n    ");
+        buf.move_cursor_to(13, false); // after the 4 spaces
+        buf.insert_char_with_indent('}', &spaces(4), rust_rules());
+        assert_eq!(buf.to_string(), "fn x() {\n}");
+        // Single undo restores both.
+        buf.undo();
+        assert_eq!(buf.to_string(), "fn x() {\n    ");
+    }
+
+    #[test]
+    fn insert_close_brace_no_dedent_with_content_on_line() {
+        let mut buf = Buffer::from_str("foo");
+        buf.move_cursor_to(3, false);
+        buf.insert_char_with_indent('}', &spaces(4), rust_rules());
+        assert_eq!(buf.to_string(), "foo}");
+    }
+
+    #[test]
+    fn insert_close_brace_python_dedent_works() {
+        // Python's IndentRules also include `}` `)` `]` for literal collections.
+        let mut buf = Buffer::from_str("xs = [\n    ");
+        buf.move_cursor_to(11, false);
+        buf.insert_char_with_indent(']', &spaces(4), python_rules());
+        assert_eq!(buf.to_string(), "xs = [\n]");
     }
 
     // ── Multi-cursor tests ────────────────────────────────────────────────

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,6 +2,8 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
+use crate::formatting::FormattingConfig;
+
 const MAX_RECENT: usize = 50;
 
 /// Predefined colour themes. Serialises as snake_case strings in TOML.
@@ -79,6 +81,10 @@ pub struct Config {
     /// each time an onboarding overlay is shown.
     #[serde(default)]
     pub last_seen_version: Option<String>,
+    /// Live indent rules and external formatter commands. See
+    /// `crate::formatting::FormattingConfig` for the schema.
+    #[serde(default)]
+    pub formatting: FormattingConfig,
 }
 
 fn default_tab_size() -> usize {
@@ -96,6 +102,7 @@ impl Default for Config {
             theme: Theme::Default,
             keymap_preset: KeymapPreset::Default,
             last_seen_version: None,
+            formatting: FormattingConfig::default(),
         }
     }
 }
@@ -272,6 +279,44 @@ mod tests {
             show_whitespace: true,
             keymap_preset: KeymapPreset::IntellijIdea,
             last_seen_version: Some("0.3.0".to_string()),
+            formatting: FormattingConfig::default(),
+        };
+        let serialized = toml::to_string(&original).unwrap();
+        let deserialized: Config = toml::from_str(&serialized).unwrap();
+        assert_eq!(original, deserialized);
+    }
+
+    #[test]
+    fn formatting_section_round_trips() {
+        use crate::formatting::{FormatterConfig, IndentSection, IndentStyle, PerLangIndent};
+        let mut languages = std::collections::BTreeMap::new();
+        languages.insert(
+            "javascript".into(),
+            PerLangIndent {
+                style: None,
+                width: Some(2),
+            },
+        );
+        let mut formatters = std::collections::BTreeMap::new();
+        formatters.insert(
+            "rust".into(),
+            FormatterConfig {
+                command: "rustfmt".into(),
+                args: vec![],
+                stdin: true,
+            },
+        );
+        let formatting = FormattingConfig {
+            indent: IndentSection {
+                style: Some(IndentStyle::Spaces),
+                width: Some(4),
+                languages,
+            },
+            formatters,
+        };
+        let original = Config {
+            formatting,
+            ..Config::default()
         };
         let serialized = toml::to_string(&original).unwrap();
         let deserialized: Config = toml::from_str(&serialized).unwrap();

--- a/src/formatting/mod.rs
+++ b/src/formatting/mod.rs
@@ -1,0 +1,629 @@
+//! Code formatting: indent config, per-language defaults, and external
+//! formatter invocation.
+//!
+//! Two concerns live here:
+//!
+//! * **Live indent rules** (`IndentConfig`, `default_indent`) — drive the
+//!   Tab key, Shift+Tab, auto-indent on Enter, and auto-dedent on `}`/`)`/`]`.
+//! * **Whole-buffer formatting** (`FormatterConfig`, `default_formatter`,
+//!   `run_formatter`) — shells out to an external tool such as `rustfmt`,
+//!   `black`, or `prettier`, replacing the buffer atomically.
+//!
+//! Resolution precedence is project > global > built-in default. The
+//! [`FormattingResolver`] type encapsulates the merge.
+
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::thread;
+
+use serde::{Deserialize, Serialize};
+
+use crate::syntax::language::Lang;
+
+pub mod project;
+
+// ── Indent style and config ───────────────────────────────────────────────
+
+/// Tabs versus spaces.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum IndentStyle {
+    #[default]
+    Spaces,
+    Tabs,
+}
+
+/// Resolved indentation rule for a single language.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IndentConfig {
+    pub style: IndentStyle,
+    pub width: usize,
+}
+
+impl IndentConfig {
+    /// Materialise the string for one indent level.
+    pub fn one_level(&self) -> String {
+        match self.style {
+            IndentStyle::Tabs => "\t".to_string(),
+            IndentStyle::Spaces => " ".repeat(self.width.max(1)),
+        }
+    }
+}
+
+// ── Per-language overrides (config schema) ────────────────────────────────
+
+/// Per-language indent override; both fields are optional so you can override
+/// just the style or just the width.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PerLangIndent {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub style: Option<IndentStyle>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub width: Option<usize>,
+}
+
+/// `[indent]` section: global defaults plus per-language overrides under
+/// `[indent.languages.<lang>]`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IndentSection {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub style: Option<IndentStyle>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub width: Option<usize>,
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub languages: std::collections::BTreeMap<String, PerLangIndent>,
+}
+
+// ── Formatter config ──────────────────────────────────────────────────────
+
+/// External formatter invocation: command, args (with `{path}` substitution),
+/// and whether to pipe the buffer text on stdin.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FormatterConfig {
+    pub command: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default = "default_stdin")]
+    pub stdin: bool,
+}
+
+fn default_stdin() -> bool {
+    true
+}
+
+/// Top-level formatting config — embedded as `Config::formatting`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FormattingConfig {
+    #[serde(default)]
+    pub indent: IndentSection,
+    #[serde(default)]
+    pub formatters: std::collections::BTreeMap<String, FormatterConfig>,
+}
+
+// ── Language indent behaviour ─────────────────────────────────────────────
+
+/// Static rules driving auto-indent on Enter and auto-dedent on close
+/// brackets. Independent of the global indent style — that controls *what*
+/// the indent looks like, this controls *when* to add or remove one.
+#[derive(Debug, Clone, Copy)]
+pub struct IndentRules {
+    /// Trailing chars on the previous line that bump the new line's indent.
+    pub increase_after: &'static [char],
+    /// Chars that, when typed on an otherwise-whitespace line, dedent that
+    /// line by one level before being inserted.
+    pub decrease_on: &'static [char],
+}
+
+impl IndentRules {
+    /// Indent rules for `lang`. Defaults to the C-family braces rule for
+    /// languages without a special case.
+    pub fn for_lang(lang: Lang) -> Self {
+        match lang {
+            Lang::Python => Self {
+                increase_after: &[':'],
+                // Python uses literal collections too, so `}` `)` `]` still
+                // align — but they don't bump indent on Enter.
+                decrease_on: &[')', ']', '}'],
+            },
+            Lang::Yaml | Lang::Toml | Lang::Properties | Lang::Markdown => Self {
+                increase_after: &[],
+                decrease_on: &[],
+            },
+            _ => Self {
+                increase_after: &['{', '(', '['],
+                decrease_on: &[')', ']', '}'],
+            },
+        }
+    }
+}
+
+// ── Built-in defaults ─────────────────────────────────────────────────────
+
+/// Built-in indent defaults per language. Used when neither the global config
+/// nor the project config specifies a value.
+pub fn default_indent(lang: Lang) -> IndentConfig {
+    match lang {
+        Lang::JavaScript
+        | Lang::TypeScript
+        | Lang::Tsx
+        | Lang::Json
+        | Lang::Yaml
+        | Lang::Css
+        | Lang::Html => IndentConfig {
+            style: IndentStyle::Spaces,
+            width: 2,
+        },
+        _ => IndentConfig {
+            style: IndentStyle::Spaces,
+            width: 4,
+        },
+    }
+}
+
+/// Built-in default external formatter per language.
+///
+/// Returns `None` for languages where no formatter is bundled. Adding new
+/// languages: append a match arm here and remove the `TODO` comment below.
+pub fn default_formatter(lang: Lang) -> Option<FormatterConfig> {
+    match lang {
+        Lang::Rust => Some(FormatterConfig {
+            command: "rustfmt".into(),
+            args: vec![],
+            stdin: true,
+        }),
+        Lang::Python => Some(FormatterConfig {
+            command: "black".into(),
+            args: vec!["-".into(), "--quiet".into()],
+            stdin: true,
+        }),
+        Lang::JavaScript | Lang::TypeScript | Lang::Tsx => Some(FormatterConfig {
+            command: "prettier".into(),
+            args: vec!["--stdin-filepath".into(), "{path}".into()],
+            stdin: true,
+        }),
+        // TODO: add default formatter for Json (e.g. prettier --parser json)
+        // TODO: add default formatter for Go (gofmt)
+        // TODO: add default formatter for Java
+        // TODO: add default formatter for CSharp (dotnet format)
+        // TODO: add default formatter for Kotlin (ktlint)
+        // TODO: add default formatter for Groovy
+        // TODO: add default formatter for Yaml / Toml / Properties
+        // TODO: add default formatter for Html / Css (prettier)
+        // TODO: add default formatter for Markdown / Sh (shfmt)
+        _ => None,
+    }
+}
+
+// ── Resolver ──────────────────────────────────────────────────────────────
+
+/// Merges project-level overrides over the global config to produce a
+/// concrete [`IndentConfig`] or [`FormatterConfig`] for a given language.
+pub struct FormattingResolver<'a> {
+    pub global: &'a FormattingConfig,
+    pub project: Option<&'a FormattingConfig>,
+    /// Legacy `Config::tab_size`, used as the global indent width when no
+    /// `[indent].width` is set.
+    pub legacy_tab_size: usize,
+}
+
+impl FormattingResolver<'_> {
+    /// Resolved indent config for `lang`. Falls back through:
+    /// project per-lang → project global → global per-lang → global global
+    /// → legacy `tab_size` (width only) → built-in default.
+    pub fn indent(&self, lang: Lang) -> IndentConfig {
+        let key = lang.config_key();
+        let mut style: Option<IndentStyle> = None;
+        let mut width: Option<usize> = None;
+
+        if let Some(proj) = self.project {
+            if let Some(p) = proj.indent.languages.get(key) {
+                style = style.or(p.style);
+                width = width.or(p.width);
+            }
+            style = style.or(proj.indent.style);
+            width = width.or(proj.indent.width);
+        }
+
+        if let Some(p) = self.global.indent.languages.get(key) {
+            style = style.or(p.style);
+            width = width.or(p.width);
+        }
+        style = style.or(self.global.indent.style);
+        width = width.or(self.global.indent.width);
+
+        // Fall back to legacy `tab_size` for width when nothing else specified
+        // a width — this preserves behaviour for users who only have the old
+        // `tab_size` setting and no `[indent]` section.
+        let default = default_indent(lang);
+        IndentConfig {
+            style: style.unwrap_or(default.style),
+            width: width.unwrap_or(if self.legacy_tab_size > 0 {
+                self.legacy_tab_size
+            } else {
+                default.width
+            }),
+        }
+    }
+
+    /// Resolved formatter for `lang`, or `None` if no formatter is configured
+    /// (and no built-in default exists). Project formatters override global,
+    /// and global overrides built-in defaults.
+    pub fn formatter(&self, lang: Lang) -> Option<FormatterConfig> {
+        let key = lang.config_key();
+        if !key.is_empty() {
+            if let Some(proj) = self.project
+                && let Some(fc) = proj.formatters.get(key)
+            {
+                return Some(fc.clone());
+            }
+            if let Some(fc) = self.global.formatters.get(key) {
+                return Some(fc.clone());
+            }
+        }
+        default_formatter(lang)
+    }
+}
+
+// ── External formatter invocation ─────────────────────────────────────────
+
+/// Errors from running an external formatter.
+#[derive(Debug)]
+pub enum FormatError {
+    /// `Command::spawn` failed (binary missing, permission denied, etc.).
+    Spawn(String),
+    /// Formatter exited non-zero. `stderr` is captured for display.
+    NonZero { stderr: String },
+    /// I/O error reading from / writing to the child process.
+    Io(String),
+}
+
+impl std::fmt::Display for FormatError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Spawn(s) => write!(f, "{s}"),
+            Self::NonZero { stderr } => {
+                let first = stderr.lines().next().unwrap_or("(no output)");
+                write!(f, "{first}")
+            }
+            Self::Io(s) => write!(f, "{s}"),
+        }
+    }
+}
+
+/// Substitute `{path}` placeholders in `args` with the buffer's path.
+/// Missing path → empty string.
+fn substitute_path(args: &[String], path: Option<&Path>) -> Vec<String> {
+    let p = path.map(|p| p.display().to_string()).unwrap_or_default();
+    args.iter().map(|a| a.replace("{path}", &p)).collect()
+}
+
+/// Run the configured formatter on `input`, returning the formatted text.
+///
+/// When `fc.stdin` is true, the buffer is written to the child's stdin from a
+/// dedicated writer thread (so large buffers don't deadlock against a small
+/// pipe buffer). Stdout is captured in the main thread via `wait_with_output`.
+///
+/// On non-zero exit, the captured stderr is returned in [`FormatError::NonZero`].
+pub fn run_formatter(
+    fc: &FormatterConfig,
+    input: &str,
+    path: Option<&Path>,
+) -> Result<String, FormatError> {
+    let args = substitute_path(&fc.args, path);
+    let mut cmd = Command::new(&fc.command);
+    cmd.args(&args);
+    if fc.stdin {
+        cmd.stdin(Stdio::piped());
+    } else {
+        cmd.stdin(Stdio::null());
+    }
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| FormatError::Spawn(format!("{}: {e}", fc.command)))?;
+
+    let writer_handle = if fc.stdin {
+        child.stdin.take().map(|mut stdin| {
+            let input = input.to_string();
+            thread::spawn(move || {
+                let _ = stdin.write_all(input.as_bytes());
+                // stdin dropped here, signalling EOF to the child.
+            })
+        })
+    } else {
+        None
+    };
+
+    let out = child
+        .wait_with_output()
+        .map_err(|e| FormatError::Io(e.to_string()))?;
+    if let Some(h) = writer_handle {
+        let _ = h.join();
+    }
+
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+        return Err(FormatError::NonZero { stderr });
+    }
+    String::from_utf8(out.stdout).map_err(|e| FormatError::Io(e.to_string()))
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn default_indent_javascript_is_two() {
+        assert_eq!(default_indent(Lang::JavaScript).width, 2);
+        assert_eq!(default_indent(Lang::TypeScript).width, 2);
+        assert_eq!(default_indent(Lang::Tsx).width, 2);
+    }
+
+    #[test]
+    fn default_indent_rust_is_four_spaces() {
+        let i = default_indent(Lang::Rust);
+        assert_eq!(i.width, 4);
+        assert_eq!(i.style, IndentStyle::Spaces);
+    }
+
+    #[test]
+    fn one_level_tabs_inserts_tab() {
+        let i = IndentConfig {
+            style: IndentStyle::Tabs,
+            width: 4,
+        };
+        assert_eq!(i.one_level(), "\t");
+    }
+
+    #[test]
+    fn one_level_spaces_repeats_width() {
+        let i = IndentConfig {
+            style: IndentStyle::Spaces,
+            width: 3,
+        };
+        assert_eq!(i.one_level(), "   ");
+    }
+
+    #[test]
+    fn default_formatter_unknown_returns_none() {
+        assert!(default_formatter(Lang::Unknown).is_none());
+        assert!(default_formatter(Lang::Yaml).is_none());
+    }
+
+    #[test]
+    fn default_formatter_rust_is_rustfmt() {
+        let f = default_formatter(Lang::Rust).unwrap();
+        assert_eq!(f.command, "rustfmt");
+        assert!(f.stdin);
+    }
+
+    #[test]
+    fn default_formatter_javascript_uses_prettier_with_path_placeholder() {
+        let f = default_formatter(Lang::JavaScript).unwrap();
+        assert_eq!(f.command, "prettier");
+        assert!(f.args.iter().any(|a| a == "{path}"));
+    }
+
+    #[test]
+    fn substitute_path_replaces_placeholder() {
+        let args = vec!["--stdin-filepath".into(), "{path}".into()];
+        let path = PathBuf::from("/tmp/foo.js");
+        let out = substitute_path(&args, Some(&path));
+        assert_eq!(out, vec!["--stdin-filepath", "/tmp/foo.js"]);
+    }
+
+    #[test]
+    fn substitute_path_empty_when_missing() {
+        let args = vec!["{path}".into()];
+        let out = substitute_path(&args, None);
+        assert_eq!(out, vec![""]);
+    }
+
+    fn empty_global() -> FormattingConfig {
+        FormattingConfig::default()
+    }
+
+    #[test]
+    fn resolver_returns_built_in_default_when_unconfigured() {
+        // legacy_tab_size = 0 means the legacy field is absent — fall back to
+        // the per-language built-in defaults.
+        let g = empty_global();
+        let r = FormattingResolver {
+            global: &g,
+            project: None,
+            legacy_tab_size: 0,
+        };
+        assert_eq!(r.indent(Lang::Rust).width, 4);
+        assert_eq!(r.indent(Lang::JavaScript).width, 2);
+    }
+
+    #[test]
+    fn resolver_legacy_tab_size_acts_as_global_width() {
+        // A user with only `tab_size = 4` (no `[indent]` section) gets that
+        // value for every language, including JS whose built-in default
+        // would otherwise be 2.
+        let g = empty_global();
+        let r = FormattingResolver {
+            global: &g,
+            project: None,
+            legacy_tab_size: 4,
+        };
+        assert_eq!(r.indent(Lang::Rust).width, 4);
+        assert_eq!(r.indent(Lang::JavaScript).width, 4);
+    }
+
+    #[test]
+    fn resolver_uses_legacy_tab_size_for_width_when_no_indent_section() {
+        let g = empty_global();
+        // User only set tab_size = 8 in the legacy field.
+        let r = FormattingResolver {
+            global: &g,
+            project: None,
+            legacy_tab_size: 8,
+        };
+        // Built-in default for Rust is 4, but legacy tab_size overrides.
+        assert_eq!(r.indent(Lang::Rust).width, 8);
+        // Same for JS (would be 2 by default).
+        assert_eq!(r.indent(Lang::JavaScript).width, 8);
+    }
+
+    #[test]
+    fn resolver_per_language_overrides_global() {
+        let mut g = empty_global();
+        g.indent.width = Some(8);
+        g.indent.style = Some(IndentStyle::Tabs);
+        g.indent.languages.insert(
+            "rust".into(),
+            PerLangIndent {
+                style: Some(IndentStyle::Spaces),
+                width: Some(4),
+            },
+        );
+        let r = FormattingResolver {
+            global: &g,
+            project: None,
+            legacy_tab_size: 4,
+        };
+        let i = r.indent(Lang::Rust);
+        assert_eq!(i.style, IndentStyle::Spaces);
+        assert_eq!(i.width, 4);
+
+        let py = r.indent(Lang::Python);
+        assert_eq!(py.style, IndentStyle::Tabs);
+        assert_eq!(py.width, 8);
+    }
+
+    #[test]
+    fn resolver_project_overrides_global() {
+        let mut g = empty_global();
+        g.indent.languages.insert(
+            "rust".into(),
+            PerLangIndent {
+                style: Some(IndentStyle::Spaces),
+                width: Some(4),
+            },
+        );
+        let mut p = empty_global();
+        p.indent.languages.insert(
+            "rust".into(),
+            PerLangIndent {
+                style: Some(IndentStyle::Tabs),
+                width: Some(2),
+            },
+        );
+        let r = FormattingResolver {
+            global: &g,
+            project: Some(&p),
+            legacy_tab_size: 4,
+        };
+        let i = r.indent(Lang::Rust);
+        assert_eq!(i.style, IndentStyle::Tabs);
+        assert_eq!(i.width, 2);
+    }
+
+    #[test]
+    fn resolver_formatter_project_overrides_global() {
+        let mut g = empty_global();
+        g.formatters.insert(
+            "rust".into(),
+            FormatterConfig {
+                command: "rustfmt".into(),
+                args: vec![],
+                stdin: true,
+            },
+        );
+        let mut p = empty_global();
+        p.formatters.insert(
+            "rust".into(),
+            FormatterConfig {
+                command: "rustfmt-nightly".into(),
+                args: vec!["--edition".into(), "2024".into()],
+                stdin: true,
+            },
+        );
+        let r = FormattingResolver {
+            global: &g,
+            project: Some(&p),
+            legacy_tab_size: 4,
+        };
+        let f = r.formatter(Lang::Rust).unwrap();
+        assert_eq!(f.command, "rustfmt-nightly");
+    }
+
+    #[test]
+    fn resolver_formatter_falls_back_to_built_in() {
+        let g = empty_global();
+        let r = FormattingResolver {
+            global: &g,
+            project: None,
+            legacy_tab_size: 4,
+        };
+        assert!(r.formatter(Lang::Rust).is_some());
+        assert!(r.formatter(Lang::Unknown).is_none());
+    }
+
+    // ── run_formatter end-to-end (uses tiny shell helpers) ────────────────
+
+    #[test]
+    fn run_formatter_passes_stdin_through_cat() {
+        // `cat` echoes stdin → stdout; perfect stub formatter.
+        let fc = FormatterConfig {
+            command: "cat".into(),
+            args: vec![],
+            stdin: true,
+        };
+        let out = run_formatter(&fc, "hello\nworld\n", None).unwrap();
+        assert_eq!(out, "hello\nworld\n");
+    }
+
+    #[test]
+    fn run_formatter_substitutes_path_placeholder() {
+        // `sh -c 'echo "$1"' --` echoes the second argument.
+        let fc = FormatterConfig {
+            command: "sh".into(),
+            args: vec![
+                "-c".into(),
+                "echo \"$1\"".into(),
+                "--".into(),
+                "{path}".into(),
+            ],
+            stdin: false,
+        };
+        let path = PathBuf::from("/tmp/foo.js");
+        let out = run_formatter(&fc, "", Some(&path)).unwrap();
+        assert_eq!(out.trim_end(), "/tmp/foo.js");
+    }
+
+    #[test]
+    fn run_formatter_nonzero_exit_returns_error_with_stderr() {
+        let fc = FormatterConfig {
+            command: "sh".into(),
+            args: vec!["-c".into(), "echo 'bad input' >&2; exit 7".into()],
+            stdin: false,
+        };
+        match run_formatter(&fc, "", None) {
+            Err(FormatError::NonZero { stderr }) => {
+                assert!(stderr.contains("bad input"));
+            }
+            other => panic!("expected NonZero error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn run_formatter_missing_binary_returns_spawn_error() {
+        let fc = FormatterConfig {
+            command: "this-binary-does-not-exist-xyzzy".into(),
+            args: vec![],
+            stdin: false,
+        };
+        match run_formatter(&fc, "", None) {
+            Err(FormatError::Spawn(_)) => {}
+            other => panic!("expected Spawn error, got {other:?}"),
+        }
+    }
+}

--- a/src/formatting/project.rs
+++ b/src/formatting/project.rs
@@ -1,0 +1,75 @@
+//! Per-workspace formatting overrides loaded from
+//! `<workspace>/.txt/formatters.toml`.
+//!
+//! Same TOML schema as the global `[formatting]` section in
+//! `~/.config/txt/config.toml`: `[indent]` with optional `style` / `width`
+//! and `[indent.languages.<lang>]` overrides, plus `[formatters.<lang>]`
+//! entries. Project values override global on a field-by-field basis (see
+//! [`super::FormattingResolver`]).
+
+use std::path::Path;
+
+use super::FormattingConfig;
+
+/// Load `<workspace>/.txt/formatters.toml`.
+///
+/// Returns `None` when the file is missing or cannot be parsed (mirrors
+/// `WorkspaceLspConfig::load_from_path` graceful-degradation pattern).
+pub fn load(workspace: &Path) -> Option<FormattingConfig> {
+    let path = workspace.join(".txt").join("formatters.toml");
+    let text = std::fs::read_to_string(&path).ok()?;
+    toml::from_str::<FormattingConfig>(&text).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::formatting::{IndentStyle, PerLangIndent};
+
+    #[test]
+    fn missing_file_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(load(dir.path()).is_none());
+    }
+
+    #[test]
+    fn invalid_toml_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let txt_dir = dir.path().join(".txt");
+        std::fs::create_dir_all(&txt_dir).unwrap();
+        std::fs::write(txt_dir.join("formatters.toml"), ": not valid {{").unwrap();
+        assert!(load(dir.path()).is_none());
+    }
+
+    #[test]
+    fn loads_indent_and_formatters() {
+        let dir = tempfile::tempdir().unwrap();
+        let txt_dir = dir.path().join(".txt");
+        std::fs::create_dir_all(&txt_dir).unwrap();
+        let toml_str = r#"
+[indent]
+style = "spaces"
+width = 4
+
+[indent.languages.javascript]
+width = 2
+
+[formatters.rust]
+command = "rustfmt"
+args = []
+stdin = true
+"#;
+        std::fs::write(txt_dir.join("formatters.toml"), toml_str).unwrap();
+        let cfg = load(dir.path()).expect("should parse");
+        assert_eq!(cfg.indent.style, Some(IndentStyle::Spaces));
+        assert_eq!(cfg.indent.width, Some(4));
+        assert_eq!(
+            cfg.indent.languages.get("javascript"),
+            Some(&PerLangIndent {
+                style: None,
+                width: Some(2),
+            })
+        );
+        assert_eq!(cfg.formatters.get("rust").unwrap().command, "rustfmt");
+    }
+}

--- a/src/input/action.rs
+++ b/src/input/action.rs
@@ -8,6 +8,17 @@ pub enum EditorAction {
     InsertChar(char),
     InsertNewline,
     InsertTab,
+    /// Indent every line touched by the selection (or the current line) by
+    /// one indent level. Bound to Tab when there is a multi-line selection,
+    /// and exposed for keymap remapping under the name `indent_selection`.
+    IndentSelection,
+    /// Dedent every line touched by the selection (or the current line) by
+    /// one indent level. Bound to Shift+Tab.
+    DedentSelection,
+    /// Run the configured external formatter for the active buffer's
+    /// language and replace the buffer contents in a single undo entry.
+    /// Default keybinding: Ctrl+Shift+I.
+    FormatBuffer,
 
     // ── Deletion ──────────────────────────────────────────────────────
     DeleteBackward,
@@ -271,6 +282,9 @@ pub fn action_to_name(action: &EditorAction) -> Option<&'static str> {
         EditorAction::DuplicateLine => "duplicate_line",
         EditorAction::MoveLineUp => "move_line_up",
         EditorAction::MoveLineDown => "move_line_down",
+        EditorAction::IndentSelection => "indent_selection",
+        EditorAction::DedentSelection => "dedent_selection",
+        EditorAction::FormatBuffer => "format_buffer",
         // Search / replace
         EditorAction::OpenSearch => "open_search",
         EditorAction::OpenReplace => "open_replace",
@@ -380,6 +394,9 @@ pub fn action_from_name(name: &str) -> Option<EditorAction> {
         "duplicate_line" => EditorAction::DuplicateLine,
         "move_line_up" => EditorAction::MoveLineUp,
         "move_line_down" => EditorAction::MoveLineDown,
+        "indent_selection" => EditorAction::IndentSelection,
+        "dedent_selection" => EditorAction::DedentSelection,
+        "format_buffer" => EditorAction::FormatBuffer,
         // Search / replace
         "open_search" => EditorAction::OpenSearch,
         "open_replace" => EditorAction::OpenReplace,

--- a/src/input/keybinding.rs
+++ b/src/input/keybinding.rs
@@ -471,6 +471,7 @@ impl KeyBindings {
         bind("ctrl+shift+c", EditorAction::CopyFileReference);
         bind("ctrl+shift+b", EditorAction::ToggleSidebar);
         bind("ctrl+shift+n", EditorAction::SidebarNewFolder);
+        bind("ctrl+shift+i", EditorAction::FormatBuffer);
 
         KeyBindings { map, reverse }
     }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -70,7 +70,8 @@ impl InputHandler {
         match event.code {
             KeyCode::Enter if !ctrl && !alt => return EditorAction::InsertNewline,
             KeyCode::Tab if !ctrl && !alt && !shift => return EditorAction::InsertTab,
-            KeyCode::BackTab => return EditorAction::Unhandled,
+            // Shift+Tab dedents the selection or current line.
+            KeyCode::BackTab => return EditorAction::DedentSelection,
             _ => {}
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod clipboard;
 mod config;
 mod editor;
 mod error;
+mod formatting;
 mod git;
 mod input;
 mod lsp;

--- a/src/syntax/language.rs
+++ b/src/syntax/language.rs
@@ -118,6 +118,32 @@ impl Lang {
         }
     }
 
+    /// Stable lowercase identifier used as a key in TOML config tables
+    /// (e.g. `[indent.rust]`, `[formatters.python]`). `Unknown` returns `""`.
+    pub fn config_key(self) -> &'static str {
+        match self {
+            Self::Rust => "rust",
+            Self::Python => "python",
+            Self::JavaScript => "javascript",
+            Self::Json => "json",
+            Self::Markdown => "markdown",
+            Self::Sh => "sh",
+            Self::TypeScript => "typescript",
+            Self::Tsx => "tsx",
+            Self::CSharp => "csharp",
+            Self::Java => "java",
+            Self::Go => "go",
+            Self::Kotlin => "kotlin",
+            Self::Groovy => "groovy",
+            Self::Yaml => "yaml",
+            Self::Properties => "properties",
+            Self::Toml => "toml",
+            Self::Html => "html",
+            Self::Css => "css",
+            Self::Unknown => "",
+        }
+    }
+
     /// The string to prepend (and remove) when toggling line comments.
     /// Returns `None` for languages that don't support line comments.
     pub fn comment_prefix(self) -> Option<&'static str> {

--- a/src/ui/help_overlay.rs
+++ b/src/ui/help_overlay.rs
@@ -135,6 +135,14 @@ const TEMPLATE: &[HelpEntry] = &[
         actions: &["toggle_line_comment"],
         desc: "Toggle line comment",
     },
+    HelpEntry::Static {
+        key: "Tab / Shift+Tab",
+        desc: "Indent / dedent selection",
+    },
+    HelpEntry::Binding {
+        actions: &["format_buffer"],
+        desc: "Format buffer (external tool)",
+    },
     // ── Clipboard ────────────────────────────────────────────────────
     HelpEntry::Section("Clipboard"),
     HelpEntry::Binding {


### PR DESCRIPTION
Two parts:

1. **Live indent rules** — per-language IndentConfig (style + width)
   resolved via project > global > legacy `tab_size` > built-in default.
   Tab/Shift+Tab indent or dedent the selection, smart-tab from the
   current display column when typing, auto-indent on Enter respects
   `{ ( [` (and `:` for Python), and typing `} ) ]` on a whitespace-only
   line auto-dedents that line.

2. **Whole-buffer format** — Ctrl+Shift+I runs the configured external
   formatter (rustfmt / black / prettier for the launch languages) and
   replaces the buffer atomically as a single undo entry. The cursor is
   restored by clamped (line, col); failures leave the buffer untouched
   and surface stderr in the status bar.

Config:
  [indent]                       # global defaults
  style = "spaces"
  width = 4
  [indent.languages.javascript]  # per-language overrides
  width = 2
  [formatters.rust]
  command = "rustfmt"
  args = []
  stdin = true

Project overrides live in `<workspace>/.txt/formatters.toml` and use the
same schema. Existing `tab_size` keeps working as the global width fallback
when no `[indent]` section is present. Other languages return None from
`default_formatter` with TODO comments where new defaults can be added.