### PR TITLE
Add git operations dialog (Ctrl+Shift+G)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -22,6 +22,7 @@ use crate::{
     ui,
     ui::command_palette::CommandPaletteState,
     ui::editor_view::gutter_width,
+    ui::git_dialog::GitDialogState,
     watcher::FileWatcher,
 };
 
@@ -57,6 +58,12 @@ pub enum InputMode {
     NewFolderName(PathBuf, String),
     /// F2: "Rename: {input}" (LSP rename symbol)
     Rename(String),
+    /// Git dialog → "Commit message: {input}". On submit, runs `git commit -m`.
+    GitCommitMessage(String),
+    /// Git dialog → "New branch: {input}". On submit, runs `git checkout -b`.
+    GitNewBranch(String),
+    /// Git dialog → "Stash message: {input}" (optional). On submit, runs `git stash push`.
+    GitStashMessage(String),
 }
 
 impl InputMode {
@@ -746,6 +753,7 @@ pub struct AppState {
     pub hover: Option<HoverState>,
     pub references_list: Option<ReferencesListState>,
     pub git_gutter: Option<GitGutter>,
+    pub git_dialog: Option<GitDialogState>,
     pub config: Config,
     pub input: InputHandler,
     pub workspace: PathBuf,
@@ -843,6 +851,7 @@ impl AppState {
             hover: None,
             references_list: None,
             git_gutter: None,
+            git_dialog: None,
             config,
             input: InputHandler::new(),
             workspace,
@@ -941,8 +950,17 @@ impl AppState {
 
         // Modal input (status-bar prompts) — must come before sidebar so that
         // rename / new-folder prompts receive Enter/typing even while sidebar is focused.
+        // Also takes precedence over the git dialog so InputMode::Git* prompts
+        // (commit message, new branch, stash message) own input while the
+        // dialog stays open behind them.
         if !self.input_mode.is_normal() {
             self.handle_modal_input(action);
+            return;
+        }
+
+        // Git operations dialog — captures all input.
+        if self.git_dialog.is_some() {
+            self.handle_git_dialog(action);
             return;
         }
 
@@ -1488,6 +1506,9 @@ impl AppState {
                     self.lsp_picker = Some(LspPickerState::new(&self.lsp_config));
                 }
             }
+            EditorAction::OpenGitDialog => {
+                self.open_git_dialog();
+            }
             EditorAction::TriggerCompletion => {
                 self.trigger_completion();
             }
@@ -1662,7 +1683,10 @@ impl AppState {
                     | InputMode::SaveAsPath(s)
                     | InputMode::RenamePath(_, s)
                     | InputMode::NewFolderName(_, s)
-                    | InputMode::Rename(s) => {
+                    | InputMode::Rename(s)
+                    | InputMode::GitCommitMessage(s)
+                    | InputMode::GitNewBranch(s)
+                    | InputMode::GitStashMessage(s) => {
                         s.push(c);
                     }
                     _ => {}
@@ -1676,7 +1700,10 @@ impl AppState {
                     | InputMode::SaveAsPath(s)
                     | InputMode::RenamePath(_, s)
                     | InputMode::NewFolderName(_, s)
-                    | InputMode::Rename(s) => {
+                    | InputMode::Rename(s)
+                    | InputMode::GitCommitMessage(s)
+                    | InputMode::GitNewBranch(s)
+                    | InputMode::GitStashMessage(s) => {
                         s.pop();
                     }
                     InputMode::Normal => {}
@@ -1770,6 +1797,15 @@ impl AppState {
                         if !input.is_empty() {
                             self.send_rename(&input);
                         }
+                    }
+                    InputMode::GitCommitMessage(input) => {
+                        self.git_finish_commit(&input);
+                    }
+                    InputMode::GitNewBranch(input) => {
+                        self.git_finish_new_branch(&input);
+                    }
+                    InputMode::GitStashMessage(input) => {
+                        self.git_finish_stash_push(&input);
                     }
                     InputMode::Normal => {}
                 }
@@ -2360,6 +2396,427 @@ impl AppState {
 
         // Start new server if enabled — routed through the trust gate.
         self.request_lsp_start();
+    }
+
+    // ── Git operations dialog ────────────────────────────────────────────────
+
+    fn open_git_dialog(&mut self) {
+        if !crate::git::ops::is_repo(&self.workspace) {
+            self.status_error = Some("Not a git repository".into());
+            return;
+        }
+        self.git_dialog = Some(GitDialogState::new());
+    }
+
+    /// Drive the git dialog. Captures all input until `Esc` from the menu
+    /// closes the overlay. Routes nav keys to `GitScreen::move_*`, and
+    /// handles per-screen actions inline.
+    fn handle_git_dialog(&mut self, action: EditorAction) {
+        use crate::ui::git_dialog::{ConfirmOp, GitScreen, MenuItem};
+
+        // Quit always closes the dialog without doing anything.
+        if matches!(action, EditorAction::Quit | EditorAction::ForceQuit) {
+            self.git_dialog = None;
+            return;
+        }
+
+        // Esc / CloseSearch: step back; if no history, close the dialog.
+        if matches!(action, EditorAction::CloseSearch) {
+            let close = match self.git_dialog.as_mut() {
+                Some(d) => !d.pop(),
+                None => true,
+            };
+            if close {
+                self.git_dialog = None;
+            }
+            return;
+        }
+
+        // Navigation keys are uniform across most screens.
+        match action {
+            EditorAction::MoveCursor(Direction::Up) => {
+                if let Some(d) = self.git_dialog.as_mut() {
+                    d.screen.move_up();
+                    d.screen.scroll_by(-1);
+                }
+                return;
+            }
+            EditorAction::MoveCursor(Direction::Down) => {
+                if let Some(d) = self.git_dialog.as_mut() {
+                    d.screen.move_down();
+                    d.screen.scroll_by(1);
+                }
+                return;
+            }
+            EditorAction::MoveCursorPage(Direction::Up) | EditorAction::Scroll(ScrollDir::Up) => {
+                if let Some(d) = self.git_dialog.as_mut() {
+                    d.screen.scroll_by(-5);
+                }
+                return;
+            }
+            EditorAction::MoveCursorPage(Direction::Down)
+            | EditorAction::Scroll(ScrollDir::Down) => {
+                if let Some(d) = self.git_dialog.as_mut() {
+                    d.screen.scroll_by(5);
+                }
+                return;
+            }
+            _ => {}
+        }
+
+        // Per-screen handling. We snapshot the current screen kind so we can
+        // borrow self mutably below for I/O without holding a borrow on
+        // `self.git_dialog`.
+        let screen_kind = match self.git_dialog.as_ref() {
+            Some(d) => d.screen.clone(),
+            None => return,
+        };
+
+        match (screen_kind, action) {
+            // ── Menu ──
+            (GitScreen::Menu { selected }, EditorAction::InsertNewline) => {
+                let item = MenuItem::ALL[selected];
+                self.git_open_menu_item(item);
+            }
+
+            // ── Stage ──
+            (
+                GitScreen::Stage { entries, .. },
+                EditorAction::InsertChar(' ') | EditorAction::InsertChar('x'),
+            ) => {
+                if let Some(GitDialogState {
+                    screen:
+                        GitScreen::Stage {
+                            checked, selected, ..
+                        },
+                    ..
+                }) = self.git_dialog.as_mut()
+                    && let Some(slot) = checked.get_mut(*selected)
+                    && !entries.is_empty()
+                {
+                    *slot = !*slot;
+                }
+            }
+            (
+                GitScreen::Stage {
+                    entries, checked, ..
+                },
+                EditorAction::InsertNewline,
+            ) => {
+                self.git_apply_stage(&entries, &checked);
+            }
+
+            // ── Branches ──
+            (GitScreen::Branches { entries, selected }, EditorAction::InsertNewline) => {
+                if let Some(branch) = entries.get(selected) {
+                    if branch.current {
+                        if let Some(d) = self.git_dialog.as_mut() {
+                            d.set_error("Already on this branch");
+                        }
+                    } else {
+                        let name = branch.name.clone();
+                        match crate::git::ops::checkout(&self.workspace, &name) {
+                            Ok(out) => {
+                                self.git_after_branch_change();
+                                self.set_git_output("Checkout", out);
+                            }
+                            Err(e) => self.set_git_error(e),
+                        }
+                    }
+                }
+            }
+            (GitScreen::Branches { .. }, EditorAction::InsertChar('n')) => {
+                self.input_mode = InputMode::GitNewBranch(String::new());
+            }
+            (GitScreen::Branches { entries, selected }, EditorAction::InsertChar('d')) => {
+                if let Some(branch) = entries.get(selected) {
+                    if branch.current {
+                        if let Some(d) = self.git_dialog.as_mut() {
+                            d.set_error("Cannot delete the current branch");
+                        }
+                    } else if let Some(d) = self.git_dialog.as_mut() {
+                        let op = ConfirmOp::DeleteBranch(branch.name.clone());
+                        d.push(GitScreen::Confirm { op });
+                    }
+                }
+            }
+
+            // ── Stashes ──
+            (GitScreen::Stashes { entries, selected }, EditorAction::InsertNewline) => {
+                if let Some(s) = entries.get(selected) {
+                    let idx = s.index;
+                    match crate::git::ops::stash_apply(&self.workspace, idx) {
+                        Ok(out) => self.set_git_output("Stash apply", out),
+                        Err(e) => self.set_git_error(e),
+                    }
+                }
+            }
+            (GitScreen::Stashes { entries, selected }, EditorAction::InsertChar('p')) => {
+                if let Some(s) = entries.get(selected) {
+                    let idx = s.index;
+                    match crate::git::ops::stash_pop(&self.workspace, idx) {
+                        Ok(out) => {
+                            self.git_after_branch_change();
+                            self.set_git_output("Stash pop", out);
+                        }
+                        Err(e) => self.set_git_error(e),
+                    }
+                }
+            }
+            (GitScreen::Stashes { entries, selected }, EditorAction::InsertChar('d')) => {
+                if let Some(s) = entries.get(selected)
+                    && let Some(d) = self.git_dialog.as_mut()
+                {
+                    let op = ConfirmOp::DropStash(s.index);
+                    d.push(GitScreen::Confirm { op });
+                }
+            }
+            (GitScreen::Stashes { .. }, EditorAction::InsertChar('n')) => {
+                self.input_mode = InputMode::GitStashMessage(String::new());
+            }
+
+            // ── Confirm (y/n) ──
+            (GitScreen::Confirm { op }, EditorAction::InsertChar('y' | 'Y')) => {
+                self.git_run_confirm(op);
+            }
+            (GitScreen::Confirm { .. }, EditorAction::InsertChar('n' | 'N')) => {
+                if let Some(d) = self.git_dialog.as_mut() {
+                    d.pop();
+                }
+            }
+
+            _ => {}
+        }
+    }
+
+    fn git_open_menu_item(&mut self, item: crate::ui::git_dialog::MenuItem) {
+        use crate::ui::git_dialog::{GitScreen, MenuItem};
+
+        match item {
+            MenuItem::Status => match crate::git::ops::status_summary(&self.workspace) {
+                Ok(out) => {
+                    if let Some(d) = self.git_dialog.as_mut() {
+                        d.push(GitScreen::Status {
+                            output: out,
+                            scroll: 0,
+                        });
+                    }
+                }
+                Err(e) => self.set_git_error(e),
+            },
+            MenuItem::Stage => match crate::git::ops::status(&self.workspace) {
+                Ok(entries) => {
+                    if let Some(d) = self.git_dialog.as_mut() {
+                        let checked = vec![false; entries.len()];
+                        d.push(GitScreen::Stage {
+                            entries,
+                            checked,
+                            selected: 0,
+                        });
+                    }
+                }
+                Err(e) => self.set_git_error(e),
+            },
+            MenuItem::Commit => {
+                self.input_mode = InputMode::GitCommitMessage(String::new());
+            }
+            MenuItem::Push => match crate::git::ops::push(&self.workspace) {
+                Ok(out) => self.set_git_output("Push", out),
+                Err(e) => self.set_git_error(e),
+            },
+            MenuItem::Pull => match crate::git::ops::pull(&self.workspace) {
+                Ok(out) => {
+                    self.git_after_branch_change();
+                    self.set_git_output("Pull", out);
+                }
+                Err(e) => self.set_git_error(e),
+            },
+            MenuItem::Branches => match crate::git::ops::branches(&self.workspace) {
+                Ok(entries) => {
+                    if let Some(d) = self.git_dialog.as_mut() {
+                        let selected = entries.iter().position(|b| b.current).unwrap_or(0);
+                        d.push(GitScreen::Branches { entries, selected });
+                    }
+                }
+                Err(e) => self.set_git_error(e),
+            },
+            MenuItem::Stashes => match crate::git::ops::stashes(&self.workspace) {
+                Ok(entries) => {
+                    if let Some(d) = self.git_dialog.as_mut() {
+                        d.push(GitScreen::Stashes {
+                            entries,
+                            selected: 0,
+                        });
+                    }
+                }
+                Err(e) => self.set_git_error(e),
+            },
+        }
+    }
+
+    /// Apply staging based on the user's checked/unchecked selections.
+    /// Files that are currently staged become `git reset` targets; files that
+    /// are unstaged or untracked become `git add` targets.
+    fn git_apply_stage(&mut self, entries: &[crate::git::ops::StatusEntry], checked: &[bool]) {
+        let mut to_add: Vec<&std::path::Path> = Vec::new();
+        let mut to_reset: Vec<&std::path::Path> = Vec::new();
+        for (entry, &is_checked) in entries.iter().zip(checked.iter()) {
+            if !is_checked {
+                continue;
+            }
+            if entry.is_staged() {
+                to_reset.push(&entry.path);
+            } else {
+                to_add.push(&entry.path);
+            }
+        }
+
+        if to_add.is_empty() && to_reset.is_empty() {
+            if let Some(d) = self.git_dialog.as_mut() {
+                d.set_error("Nothing selected");
+            }
+            return;
+        }
+
+        if let Err(e) = crate::git::ops::add(&self.workspace, &to_add) {
+            self.set_git_error(e);
+            return;
+        }
+        if let Err(e) = crate::git::ops::reset(&self.workspace, &to_reset) {
+            self.set_git_error(e);
+            return;
+        }
+
+        // Refresh the stage screen with new statuses.
+        match crate::git::ops::status(&self.workspace) {
+            Ok(entries) => {
+                if let Some(d) = self.git_dialog.as_mut() {
+                    let checked = vec![false; entries.len()];
+                    d.replace(crate::ui::git_dialog::GitScreen::Stage {
+                        entries,
+                        checked,
+                        selected: 0,
+                    });
+                }
+            }
+            Err(e) => self.set_git_error(e),
+        }
+        self.refresh_git_gutter();
+    }
+
+    fn git_finish_commit(&mut self, message: &str) {
+        let trimmed = message.trim();
+        if trimmed.is_empty() {
+            if let Some(d) = self.git_dialog.as_mut() {
+                d.set_error("Empty commit message — cancelled");
+            }
+            return;
+        }
+        match crate::git::ops::commit(&self.workspace, trimmed) {
+            Ok(out) => {
+                self.set_git_output("Commit", out);
+                self.refresh_git_gutter();
+            }
+            Err(e) => self.set_git_error(e),
+        }
+    }
+
+    fn git_finish_new_branch(&mut self, name: &str) {
+        let trimmed = name.trim();
+        if trimmed.is_empty() {
+            if let Some(d) = self.git_dialog.as_mut() {
+                d.set_error("Empty branch name — cancelled");
+            }
+            return;
+        }
+        match crate::git::ops::create_branch(&self.workspace, trimmed) {
+            Ok(out) => {
+                self.git_after_branch_change();
+                self.set_git_output("Create branch", out);
+            }
+            Err(e) => self.set_git_error(e),
+        }
+    }
+
+    fn git_finish_stash_push(&mut self, message: &str) {
+        let trimmed = message.trim();
+        let msg = if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed)
+        };
+        match crate::git::ops::stash_push(&self.workspace, msg) {
+            Ok(out) => {
+                self.git_after_branch_change();
+                self.set_git_output("Stash push", out);
+            }
+            Err(e) => self.set_git_error(e),
+        }
+    }
+
+    fn git_run_confirm(&mut self, op: crate::ui::git_dialog::ConfirmOp) {
+        use crate::ui::git_dialog::ConfirmOp;
+        // Pop the confirm screen first so the result lands on the prior screen.
+        if let Some(d) = self.git_dialog.as_mut() {
+            d.pop();
+        }
+        match op {
+            ConfirmOp::DropStash(idx) => match crate::git::ops::stash_drop(&self.workspace, idx) {
+                Ok(out) => {
+                    // Refresh the stash list under us.
+                    if let Ok(entries) = crate::git::ops::stashes(&self.workspace)
+                        && let Some(d) = self.git_dialog.as_mut()
+                    {
+                        d.replace(crate::ui::git_dialog::GitScreen::Stashes {
+                            entries,
+                            selected: 0,
+                        });
+                    }
+                    self.set_git_output("Stash drop", out);
+                }
+                Err(e) => self.set_git_error(e),
+            },
+            ConfirmOp::DeleteBranch(name) => {
+                match crate::git::ops::delete_branch(&self.workspace, &name) {
+                    Ok(out) => {
+                        if let Ok(entries) = crate::git::ops::branches(&self.workspace)
+                            && let Some(d) = self.git_dialog.as_mut()
+                        {
+                            let selected = entries.iter().position(|b| b.current).unwrap_or(0);
+                            d.replace(crate::ui::git_dialog::GitScreen::Branches {
+                                entries,
+                                selected,
+                            });
+                        }
+                        self.set_git_output("Delete branch", out);
+                    }
+                    Err(e) => self.set_git_error(e),
+                }
+            }
+        }
+    }
+
+    fn set_git_output(&mut self, title: &str, body: String) {
+        if let Some(d) = self.git_dialog.as_mut() {
+            d.push(crate::ui::git_dialog::GitScreen::Output {
+                title: title.into(),
+                body,
+                scroll: 0,
+            });
+        }
+    }
+
+    fn set_git_error(&mut self, err: String) {
+        if let Some(d) = self.git_dialog.as_mut() {
+            d.set_error(err);
+        }
+    }
+
+    /// Called after operations that may change which file is on disk under
+    /// the active buffer (checkout, pull, stash pop, new branch). Refreshes
+    /// the gutter; the existing file watcher will pick up content changes.
+    fn git_after_branch_change(&mut self) {
+        self.refresh_git_gutter();
     }
 
     // ── Sidebar input handling ────────────────────────────────────────────────

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,5 +1,7 @@
 use std::{collections::HashMap, path::Path, process::Command};
 
+pub mod ops;
+
 /// Status of a single line in the git gutter.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GutterMark {

--- a/src/git/ops.rs
+++ b/src/git/ops.rs
@@ -1,0 +1,359 @@
+//! Subprocess wrappers for the common git operations exposed by the
+//! [`crate::ui::git_dialog`] overlay.
+//!
+//! All commands shell out to `git` via [`std::process::Command`], matching the
+//! pattern used by [`crate::git::fetch_head_content`] in `mod.rs`. Each public
+//! function returns `Result<T, String>`: `Ok` carries successfully parsed
+//! output, `Err` carries a human-readable error suitable for showing in the
+//! dialog's error banner.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+// ── Status entries ───────────────────────────────────────────────────────────
+
+/// One entry from `git status --porcelain=v1`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatusEntry {
+    /// Status of the file in the index (staged area). Space if unchanged.
+    pub index: char,
+    /// Status of the file in the working tree (unstaged). Space if unchanged.
+    pub worktree: char,
+    /// File path relative to the repository root.
+    pub path: PathBuf,
+}
+
+impl StatusEntry {
+    pub fn is_staged(&self) -> bool {
+        self.index != ' ' && self.index != '?'
+    }
+
+    #[allow(dead_code)]
+    pub fn is_unstaged(&self) -> bool {
+        self.worktree != ' '
+    }
+
+    #[allow(dead_code)]
+    pub fn is_untracked(&self) -> bool {
+        self.index == '?' && self.worktree == '?'
+    }
+}
+
+/// One entry from `git branch --list`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BranchEntry {
+    pub name: String,
+    pub current: bool,
+}
+
+/// One entry from `git stash list`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StashEntry {
+    /// 0-based index, matches `stash@{N}`.
+    pub index: usize,
+    /// Display message (the part after `stash@{N}: `).
+    pub message: String,
+}
+
+// ── Pure parsers (testable, no I/O) ──────────────────────────────────────────
+
+pub fn parse_porcelain(out: &str) -> Vec<StatusEntry> {
+    let mut entries = Vec::new();
+    for line in out.lines() {
+        // Format: "XY <path>" — exactly two status chars, then a space.
+        let mut chars = line.chars();
+        let x = match chars.next() {
+            Some(c) => c,
+            None => continue,
+        };
+        let y = match chars.next() {
+            Some(c) => c,
+            None => continue,
+        };
+        // The third char must be a space.
+        if chars.next() != Some(' ') {
+            continue;
+        }
+        let rest: String = chars.collect();
+        // Renames are reported as "old -> new"; show the new name only.
+        let path_str = rest.split(" -> ").last().unwrap_or(&rest);
+        entries.push(StatusEntry {
+            index: x,
+            worktree: y,
+            path: PathBuf::from(path_str),
+        });
+    }
+    entries
+}
+
+pub fn parse_branches(out: &str) -> Vec<BranchEntry> {
+    let mut entries = Vec::new();
+    for line in out.lines() {
+        // git branch --list uses "* current\n  other\n  + worktree\n".
+        let line = line.trim_end();
+        if line.is_empty() {
+            continue;
+        }
+        let (marker, name) = line.split_at(2.min(line.len()));
+        let current = marker.starts_with('*');
+        let name = name.trim();
+        if name.is_empty() {
+            continue;
+        }
+        // Skip detached-HEAD lines like "(HEAD detached at 1234abc)".
+        if name.starts_with('(') {
+            continue;
+        }
+        entries.push(BranchEntry {
+            name: name.to_string(),
+            current,
+        });
+    }
+    entries
+}
+
+pub fn parse_stash_list(out: &str) -> Vec<StashEntry> {
+    let mut entries = Vec::new();
+    for (idx, line) in out.lines().enumerate() {
+        // Format: "stash@{0}: WIP on main: 1234abc message"
+        let message = match line.split_once(": ") {
+            Some((_prefix, rest)) => rest.to_string(),
+            None => line.to_string(),
+        };
+        entries.push(StashEntry {
+            index: idx,
+            message,
+        });
+    }
+    entries
+}
+
+// ── Subprocess helpers ───────────────────────────────────────────────────────
+
+fn run(workspace: &Path, args: &[&str]) -> Result<String, String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(workspace)
+        .output()
+        .map_err(|e| format!("failed to run git: {e}"))?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stderr = stderr.trim();
+        if stderr.is_empty() {
+            Err(format!("git exited with status {}", output.status))
+        } else {
+            Err(stderr.to_string())
+        }
+    }
+}
+
+/// Returns `true` if `workspace` is inside a git working tree.
+pub fn is_repo(workspace: &Path) -> bool {
+    Command::new("git")
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .current_dir(workspace)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+// ── Status / staging ─────────────────────────────────────────────────────────
+
+pub fn status(workspace: &Path) -> Result<Vec<StatusEntry>, String> {
+    let out = run(workspace, &["status", "--porcelain=v1"])?;
+    Ok(parse_porcelain(&out))
+}
+
+pub fn status_summary(workspace: &Path) -> Result<String, String> {
+    run(workspace, &["status"])
+}
+
+pub fn add(workspace: &Path, paths: &[&Path]) -> Result<(), String> {
+    if paths.is_empty() {
+        return Ok(());
+    }
+    let mut args: Vec<&str> = vec!["add", "--"];
+    let path_strs: Vec<String> = paths.iter().map(|p| p.to_string_lossy().into()).collect();
+    for p in &path_strs {
+        args.push(p);
+    }
+    run(workspace, &args).map(|_| ())
+}
+
+pub fn reset(workspace: &Path, paths: &[&Path]) -> Result<(), String> {
+    if paths.is_empty() {
+        return Ok(());
+    }
+    let mut args: Vec<&str> = vec!["reset", "HEAD", "--"];
+    let path_strs: Vec<String> = paths.iter().map(|p| p.to_string_lossy().into()).collect();
+    for p in &path_strs {
+        args.push(p);
+    }
+    run(workspace, &args).map(|_| ())
+}
+
+// ── Commit / push / pull ─────────────────────────────────────────────────────
+
+pub fn commit(workspace: &Path, message: &str) -> Result<String, String> {
+    run(workspace, &["commit", "-m", message])
+}
+
+pub fn push(workspace: &Path) -> Result<String, String> {
+    run(workspace, &["push"])
+}
+
+pub fn pull(workspace: &Path) -> Result<String, String> {
+    run(workspace, &["pull"])
+}
+
+// ── Branches ─────────────────────────────────────────────────────────────────
+
+pub fn branches(workspace: &Path) -> Result<Vec<BranchEntry>, String> {
+    let out = run(workspace, &["branch", "--list"])?;
+    Ok(parse_branches(&out))
+}
+
+pub fn checkout(workspace: &Path, branch: &str) -> Result<String, String> {
+    run(workspace, &["checkout", branch])
+}
+
+pub fn create_branch(workspace: &Path, name: &str) -> Result<String, String> {
+    run(workspace, &["checkout", "-b", name])
+}
+
+pub fn delete_branch(workspace: &Path, name: &str) -> Result<String, String> {
+    run(workspace, &["branch", "-d", name])
+}
+
+// ── Stashes ──────────────────────────────────────────────────────────────────
+
+pub fn stashes(workspace: &Path) -> Result<Vec<StashEntry>, String> {
+    let out = run(workspace, &["stash", "list"])?;
+    Ok(parse_stash_list(&out))
+}
+
+pub fn stash_push(workspace: &Path, message: Option<&str>) -> Result<String, String> {
+    match message {
+        Some(m) if !m.is_empty() => run(workspace, &["stash", "push", "-m", m]),
+        _ => run(workspace, &["stash", "push"]),
+    }
+}
+
+pub fn stash_apply(workspace: &Path, idx: usize) -> Result<String, String> {
+    let r = format!("stash@{{{}}}", idx);
+    run(workspace, &["stash", "apply", &r])
+}
+
+pub fn stash_pop(workspace: &Path, idx: usize) -> Result<String, String> {
+    let r = format!("stash@{{{}}}", idx);
+    run(workspace, &["stash", "pop", &r])
+}
+
+pub fn stash_drop(workspace: &Path, idx: usize) -> Result<String, String> {
+    let r = format!("stash@{{{}}}", idx);
+    run(workspace, &["stash", "drop", &r])
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_porcelain_modified_and_added() {
+        let out = " M src/main.rs\nA  src/lib.rs\n?? foo.txt\n";
+        let entries = parse_porcelain(out);
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].index, ' ');
+        assert_eq!(entries[0].worktree, 'M');
+        assert_eq!(entries[0].path, PathBuf::from("src/main.rs"));
+        assert_eq!(entries[1].index, 'A');
+        assert_eq!(entries[1].worktree, ' ');
+        assert!(entries[2].is_untracked());
+    }
+
+    #[test]
+    fn parse_porcelain_rename_keeps_new_name() {
+        let out = "R  old.txt -> new.txt\n";
+        let entries = parse_porcelain(out);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].path, PathBuf::from("new.txt"));
+    }
+
+    #[test]
+    fn parse_porcelain_skips_blank_and_short_lines() {
+        let out = "\n M\nXY foo\n";
+        let entries = parse_porcelain(out);
+        // " M\n" has only 2 chars (no path), should be skipped.
+        // "XY foo" is valid.
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].path, PathBuf::from("foo"));
+    }
+
+    #[test]
+    fn parse_branches_marks_current() {
+        let out = "  feature/a\n* main\n  feature/b\n";
+        let entries = parse_branches(out);
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].name, "feature/a");
+        assert!(!entries[0].current);
+        assert_eq!(entries[1].name, "main");
+        assert!(entries[1].current);
+        assert!(!entries[2].current);
+    }
+
+    #[test]
+    fn parse_branches_skips_detached_head() {
+        let out = "* (HEAD detached at 1234abc)\n  main\n";
+        let entries = parse_branches(out);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "main");
+    }
+
+    #[test]
+    fn parse_stash_list_indexes_by_position() {
+        let out =
+            "stash@{0}: WIP on main: 1234 work in progress\nstash@{1}: On feature: 5678 thing\n";
+        let entries = parse_stash_list(out);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].index, 0);
+        assert!(entries[0].message.contains("work in progress"));
+        assert_eq!(entries[1].index, 1);
+    }
+
+    #[test]
+    fn parse_stash_list_empty() {
+        assert!(parse_stash_list("").is_empty());
+    }
+
+    #[test]
+    fn status_entry_categories() {
+        let staged = StatusEntry {
+            index: 'M',
+            worktree: ' ',
+            path: PathBuf::from("a"),
+        };
+        assert!(staged.is_staged());
+        assert!(!staged.is_unstaged());
+
+        let unstaged = StatusEntry {
+            index: ' ',
+            worktree: 'M',
+            path: PathBuf::from("b"),
+        };
+        assert!(!unstaged.is_staged());
+        assert!(unstaged.is_unstaged());
+
+        let untracked = StatusEntry {
+            index: '?',
+            worktree: '?',
+            path: PathBuf::from("c"),
+        };
+        assert!(untracked.is_untracked());
+        assert!(!untracked.is_staged());
+    }
+}

--- a/src/input/action.rs
+++ b/src/input/action.rs
@@ -173,6 +173,8 @@ pub enum EditorAction {
     OpenBufferSwitcher,
     /// Open the LSP server configuration overlay (Ctrl+L).
     OpenLspConfig,
+    /// Open the git operations dialog (Ctrl+Shift+G).
+    OpenGitDialog,
 
     // ── LSP features ─────────────────────────────────────────────────
     /// Trigger code completion (Ctrl+Space).
@@ -307,6 +309,7 @@ pub fn action_to_name(action: &EditorAction) -> Option<&'static str> {
         EditorAction::OpenCommandPalette => "open_command_palette",
         EditorAction::OpenBufferSwitcher => "open_buffer_switcher",
         EditorAction::OpenLspConfig => "open_lsp_config",
+        EditorAction::OpenGitDialog => "open_git_dialog",
         // LSP features
         EditorAction::TriggerCompletion => "trigger_completion",
         EditorAction::ShowHover => "show_hover",
@@ -416,6 +419,7 @@ pub fn action_from_name(name: &str) -> Option<EditorAction> {
         "open_command_palette" => EditorAction::OpenCommandPalette,
         "open_buffer_switcher" => EditorAction::OpenBufferSwitcher,
         "open_lsp_config" => EditorAction::OpenLspConfig,
+        "open_git_dialog" => EditorAction::OpenGitDialog,
         // LSP features
         "trigger_completion" => EditorAction::TriggerCompletion,
         "show_hover" => EditorAction::ShowHover,

--- a/src/input/keybinding.rs
+++ b/src/input/keybinding.rs
@@ -471,6 +471,7 @@ impl KeyBindings {
         bind("ctrl+shift+c", EditorAction::CopyFileReference);
         bind("ctrl+shift+b", EditorAction::ToggleSidebar);
         bind("ctrl+shift+n", EditorAction::SidebarNewFolder);
+        bind("ctrl+shift+g", EditorAction::OpenGitDialog);
 
         KeyBindings { map, reverse }
     }

--- a/src/ui/command_palette.rs
+++ b/src/ui/command_palette.rs
@@ -187,6 +187,11 @@ pub static COMMANDS: &[CommandEntry] = &[
         action: || EditorAction::LspStop,
     },
     CommandEntry {
+        name: "Git: Operations…",
+        key_hint: "Ctrl+Shift+G",
+        action: || EditorAction::OpenGitDialog,
+    },
+    CommandEntry {
         name: "Quit",
         key_hint: "Ctrl+Q",
         action: || EditorAction::Quit,

--- a/src/ui/git_dialog.rs
+++ b/src/ui/git_dialog.rs
@@ -1,0 +1,705 @@
+//! Git operations dialog. A single overlay with a [`GitScreen`] state machine
+//! exposing the common workflow: view status, stage files, commit, push/pull,
+//! switch/create branches, and manage stashes.
+//!
+//! Modeled on [`crate::ui::command_palette`]: an `Option<GitDialogState>`
+//! lives on `AppState`, the renderer is a centered float, and input is
+//! routed through `AppState::handle_git_dialog`.
+
+use ratatui::{
+    buffer::Buffer as TermBuffer,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+};
+
+use crate::git::ops::{BranchEntry, StashEntry, StatusEntry};
+use crate::theme::ThemeColors;
+
+// ── Menu items ───────────────────────────────────────────────────────────────
+
+/// Top-level operations shown on the menu screen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MenuItem {
+    Status,
+    Stage,
+    Commit,
+    Push,
+    Pull,
+    Branches,
+    Stashes,
+}
+
+impl MenuItem {
+    pub const ALL: &'static [MenuItem] = &[
+        MenuItem::Status,
+        MenuItem::Stage,
+        MenuItem::Commit,
+        MenuItem::Push,
+        MenuItem::Pull,
+        MenuItem::Branches,
+        MenuItem::Stashes,
+    ];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            MenuItem::Status => "Status",
+            MenuItem::Stage => "Stage / Unstage files",
+            MenuItem::Commit => "Commit…",
+            MenuItem::Push => "Push",
+            MenuItem::Pull => "Pull",
+            MenuItem::Branches => "Branches…",
+            MenuItem::Stashes => "Stashes…",
+        }
+    }
+
+    pub fn hint(self) -> &'static str {
+        match self {
+            MenuItem::Status => "show working tree status",
+            MenuItem::Stage => "Space toggles, Enter applies",
+            MenuItem::Commit => "type a message, Enter to confirm",
+            MenuItem::Push => "git push",
+            MenuItem::Pull => "git pull",
+            MenuItem::Branches => "switch / create / delete",
+            MenuItem::Stashes => "apply / pop / drop / push",
+        }
+    }
+}
+
+// ── Confirm operations ───────────────────────────────────────────────────────
+
+/// Operations that need a y/n confirmation before running.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConfirmOp {
+    DropStash(usize),
+    DeleteBranch(String),
+}
+
+impl ConfirmOp {
+    pub fn prompt(&self) -> String {
+        match self {
+            ConfirmOp::DropStash(i) => format!("Drop stash@{{{}}}? (y/n)", i),
+            ConfirmOp::DeleteBranch(name) => format!("Delete branch '{}'? (y/n)", name),
+        }
+    }
+}
+
+// ── Screens ──────────────────────────────────────────────────────────────────
+
+/// One screen of the dialog. Each screen owns the data it displays so the
+/// renderer never needs to hit the disk.
+#[derive(Debug, Clone)]
+pub enum GitScreen {
+    Menu {
+        selected: usize,
+    },
+    Status {
+        output: String,
+        scroll: usize,
+    },
+    Stage {
+        entries: Vec<StatusEntry>,
+        checked: Vec<bool>,
+        selected: usize,
+    },
+    Branches {
+        entries: Vec<BranchEntry>,
+        selected: usize,
+    },
+    Stashes {
+        entries: Vec<StashEntry>,
+        selected: usize,
+    },
+    Confirm {
+        op: ConfirmOp,
+    },
+    /// Read-only output display after running an operation. `Esc` returns to
+    /// the previous screen.
+    Output {
+        /// Operation name shown as a body header (e.g. "Push", "Commit").
+        title: String,
+        body: String,
+        scroll: usize,
+    },
+}
+
+// ── State ────────────────────────────────────────────────────────────────────
+
+/// Mutable state for the git operations overlay.
+#[derive(Debug, Clone)]
+pub struct GitDialogState {
+    pub screen: GitScreen,
+    /// Stack of previous screens, for `Esc`-to-back navigation.
+    pub history: Vec<GitScreen>,
+    /// Latest error message, rendered as a banner above the body. Cleared on
+    /// successful operations and on screen transitions that aren't error
+    /// recoveries.
+    pub last_error: Option<String>,
+}
+
+impl GitDialogState {
+    pub fn new() -> Self {
+        Self {
+            screen: GitScreen::Menu { selected: 0 },
+            history: Vec::new(),
+            last_error: None,
+        }
+    }
+
+    /// Navigate to a new screen, pushing the current screen onto the history.
+    pub fn push(&mut self, next: GitScreen) {
+        let current = std::mem::replace(&mut self.screen, next);
+        self.history.push(current);
+        self.last_error = None;
+    }
+
+    /// Return to the previous screen if any. Returns `false` when the dialog
+    /// should be closed (already at the menu with no history).
+    pub fn pop(&mut self) -> bool {
+        if let Some(prev) = self.history.pop() {
+            self.screen = prev;
+            self.last_error = None;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Replace the active screen without touching history. Used when a
+    /// completed operation lands on a fresh result screen.
+    pub fn replace(&mut self, next: GitScreen) {
+        self.screen = next;
+    }
+
+    pub fn set_error(&mut self, err: impl Into<String>) {
+        self.last_error = Some(err.into());
+    }
+
+    #[allow(dead_code)]
+    pub fn clear_error(&mut self) {
+        self.last_error = None;
+    }
+}
+
+impl Default for GitDialogState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Helpers used by the dispatch handler ─────────────────────────────────────
+
+impl GitScreen {
+    /// Number of selectable rows in the body.
+    pub fn list_len(&self) -> usize {
+        match self {
+            GitScreen::Menu { .. } => MenuItem::ALL.len(),
+            GitScreen::Stage { entries, .. } => entries.len(),
+            GitScreen::Branches { entries, .. } => entries.len(),
+            GitScreen::Stashes { entries, .. } => entries.len(),
+            _ => 0,
+        }
+    }
+
+    /// Move the highlighted row up if applicable.
+    pub fn move_up(&mut self) {
+        let sel = self.selected_mut();
+        if let Some(s) = sel
+            && *s > 0
+        {
+            *s -= 1;
+        }
+    }
+
+    /// Move the highlighted row down if applicable.
+    pub fn move_down(&mut self) {
+        let len = self.list_len();
+        if let Some(s) = self.selected_mut()
+            && *s + 1 < len
+        {
+            *s += 1;
+        }
+    }
+
+    /// Scroll the read-only screens by `delta` rows (positive = down).
+    pub fn scroll_by(&mut self, delta: isize) {
+        match self {
+            GitScreen::Status { scroll, .. } | GitScreen::Output { scroll, .. } => {
+                if delta < 0 {
+                    *scroll = scroll.saturating_sub((-delta) as usize);
+                } else {
+                    *scroll = scroll.saturating_add(delta as usize);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn selected_mut(&mut self) -> Option<&mut usize> {
+        match self {
+            GitScreen::Menu { selected }
+            | GitScreen::Stage { selected, .. }
+            | GitScreen::Branches { selected, .. }
+            | GitScreen::Stashes { selected, .. } => Some(selected),
+            _ => None,
+        }
+    }
+
+    /// Title shown at the top of the overlay.
+    pub fn title(&self) -> &'static str {
+        match self {
+            GitScreen::Menu { .. } => " Git ",
+            GitScreen::Status { .. } => " Git · Status ",
+            GitScreen::Stage { .. } => " Git · Stage / Unstage ",
+            GitScreen::Branches { .. } => " Git · Branches ",
+            GitScreen::Stashes { .. } => " Git · Stashes ",
+            GitScreen::Confirm { .. } => " Git · Confirm ",
+            GitScreen::Output { .. } => " Git · Output ",
+        }
+    }
+
+    /// Footer hints — short, comma-separated.
+    pub fn hint(&self) -> &'static str {
+        match self {
+            GitScreen::Menu { .. } => "↑↓ navigate  ·  Enter select  ·  Esc close",
+            GitScreen::Stage { .. } => "Space toggle  ·  Enter stage/unstage  ·  Esc back",
+            GitScreen::Branches { .. } => "Enter switch  ·  n new  ·  d delete  ·  Esc back",
+            GitScreen::Stashes { .. } => "Enter apply  ·  p pop  ·  d drop  ·  n push  ·  Esc back",
+            GitScreen::Status { .. } | GitScreen::Output { .. } => "↑↓ scroll  ·  Esc back",
+            GitScreen::Confirm { .. } => "y confirm  ·  n cancel",
+        }
+    }
+}
+
+// ── Rendering ────────────────────────────────────────────────────────────────
+
+const OVERLAY_W: u16 = 70;
+const OVERLAY_H: u16 = 22;
+
+pub fn render(state: &GitDialogState, theme: &ThemeColors, area: Rect, buf: &mut TermBuffer) {
+    if area.width < 30 || area.height < 8 {
+        return;
+    }
+
+    let ow = OVERLAY_W.min(area.width);
+    let oh = OVERLAY_H.min(area.height);
+    let ox = area.x + area.width.saturating_sub(ow) / 2;
+    let oy = area.y + area.height.saturating_sub(oh) / 2;
+    let overlay = Rect::new(ox, oy, ow, oh);
+
+    let bg = theme.picker_bg;
+    let border_style = Style::default().bg(bg).fg(Color::Rgb(80, 100, 160));
+    let title_style = Style::default()
+        .bg(bg)
+        .fg(Color::Rgb(200, 200, 255))
+        .add_modifier(Modifier::BOLD);
+    let body_style = Style::default().bg(bg).fg(Color::Rgb(200, 200, 220));
+    let selected_style = Style::default()
+        .bg(theme.picker_sel_bg)
+        .fg(Color::White)
+        .add_modifier(Modifier::BOLD);
+    let hint_style = Style::default().bg(bg).fg(Color::Rgb(120, 140, 170));
+    let error_style = Style::default()
+        .bg(Color::Rgb(140, 30, 30))
+        .fg(Color::White)
+        .add_modifier(Modifier::BOLD);
+
+    // Background fill.
+    for y in overlay.y..overlay.y + overlay.height {
+        for x in overlay.x..overlay.x + overlay.width {
+            buf.set_string(x, y, " ", Style::default().bg(bg));
+        }
+    }
+
+    draw_border(buf, overlay, border_style);
+
+    // Title.
+    let title = state.screen.title();
+    let tx = overlay.x + overlay.width.saturating_sub(title.len() as u16) / 2;
+    buf.set_string(tx, overlay.y, title, title_style);
+
+    let inner_w = overlay.width.saturating_sub(2) as usize;
+    let mut row = overlay.y + 1;
+    let body_bottom = overlay.y + overlay.height - 2; // leave 1 for hint
+
+    // Optional error banner.
+    if let Some(err) = &state.last_error
+        && row < body_bottom
+    {
+        let line = clip(&format!(" ! {} ", err), inner_w);
+        for x in overlay.x + 1..overlay.x + overlay.width - 1 {
+            buf.set_string(x, row, " ", error_style);
+        }
+        buf.set_string(overlay.x + 1, row, &line, error_style);
+        row += 1;
+    }
+
+    // Body.
+    let mut ctx = BodyCtx {
+        buf,
+        overlay,
+        start_y: row,
+        end_y: body_bottom,
+        normal: body_style,
+        sel: selected_style,
+    };
+    match &state.screen {
+        GitScreen::Menu { selected } => ctx.render_menu(*selected),
+        GitScreen::Status { output, scroll } => ctx.render_text(output, *scroll),
+        GitScreen::Output {
+            title,
+            body,
+            scroll,
+        } => {
+            let header_y = ctx.start_y;
+            if header_y < ctx.end_y {
+                let header = format!(" {} ", title);
+                let line = clip(&header, (ctx.overlay.width - 2) as usize);
+                let title_local = Style::default()
+                    .bg(theme.picker_bg)
+                    .fg(Color::Rgb(140, 200, 140))
+                    .add_modifier(Modifier::BOLD);
+                ctx.buf
+                    .set_string(ctx.overlay.x + 1, header_y, &line, title_local);
+            }
+            ctx.start_y = (header_y + 1).min(ctx.end_y);
+            ctx.render_text(body, *scroll);
+        }
+        GitScreen::Stage {
+            entries,
+            checked,
+            selected,
+        } => ctx.render_stage(entries, checked, *selected),
+        GitScreen::Branches { entries, selected } => ctx.render_branches(entries, *selected),
+        GitScreen::Stashes { entries, selected } => ctx.render_stashes(entries, *selected),
+        GitScreen::Confirm { op } => ctx.render_confirm(&op.prompt()),
+    }
+
+    // Footer hint.
+    let hint = state.screen.hint();
+    let hint_y = overlay.y + overlay.height - 1;
+    let hx = overlay.x + overlay.width.saturating_sub(hint.len() as u16) / 2;
+    let line = clip(hint, inner_w);
+    buf.set_string(hx.max(overlay.x + 1), hint_y, &line, hint_style);
+}
+
+/// Layout + style context used by the body sub-renderers. Bundles parameters
+/// that would otherwise inflate every helper signature.
+struct BodyCtx<'a> {
+    buf: &'a mut TermBuffer,
+    overlay: Rect,
+    start_y: u16,
+    end_y: u16,
+    normal: Style,
+    sel: Style,
+}
+
+impl BodyCtx<'_> {
+    fn inner_w(&self) -> usize {
+        (self.overlay.width - 2) as usize
+    }
+
+    fn fill_row(&mut self, y: u16, style: Style) {
+        for x in self.overlay.x + 1..self.overlay.x + self.overlay.width - 1 {
+            self.buf.set_string(x, y, " ", style);
+        }
+    }
+
+    fn render_menu(&mut self, selected: usize) {
+        for (i, item) in MenuItem::ALL.iter().enumerate() {
+            let y = self.start_y + i as u16;
+            if y >= self.end_y {
+                break;
+            }
+            let is_sel = i == selected;
+            let style = if is_sel { self.sel } else { self.normal };
+            self.fill_row(y, style);
+            let marker = if is_sel { ">" } else { " " };
+            let line = format!(" {} {:<22}  {}", marker, item.label(), item.hint());
+            let line = clip(&line, self.inner_w());
+            self.buf.set_string(self.overlay.x + 1, y, &line, style);
+        }
+    }
+
+    fn render_text(&mut self, text: &str, scroll: usize) {
+        let inner_w = self.inner_w();
+        let lines: Vec<&str> = text.lines().collect();
+        let visible_rows = self.end_y.saturating_sub(self.start_y) as usize;
+        let max_scroll = lines.len().saturating_sub(visible_rows);
+        let scroll = scroll.min(max_scroll);
+
+        for (row_off, line) in lines.iter().skip(scroll).take(visible_rows).enumerate() {
+            let y = self.start_y + row_off as u16;
+            let display = clip(line, inner_w);
+            self.buf
+                .set_string(self.overlay.x + 1, y, &display, self.normal);
+        }
+
+        if lines.is_empty() && self.start_y < self.end_y {
+            self.buf
+                .set_string(self.overlay.x + 2, self.start_y, "(no output)", self.normal);
+        }
+    }
+
+    fn render_stage(&mut self, entries: &[StatusEntry], checked: &[bool], selected: usize) {
+        if entries.is_empty() {
+            if self.start_y < self.end_y {
+                self.buf.set_string(
+                    self.overlay.x + 2,
+                    self.start_y,
+                    "(working tree clean)",
+                    self.normal,
+                );
+            }
+            return;
+        }
+        let inner_w = self.inner_w();
+        let visible_rows = self.end_y.saturating_sub(self.start_y) as usize;
+        let scroll = if selected >= visible_rows {
+            selected - visible_rows + 1
+        } else {
+            0
+        };
+
+        for (row_off, idx) in (scroll..entries.len()).take(visible_rows).enumerate() {
+            let y = self.start_y + row_off as u16;
+            let entry = &entries[idx];
+            let is_sel = idx == selected;
+            let style = if is_sel { self.sel } else { self.normal };
+            self.fill_row(y, style);
+            let mark = if checked.get(idx).copied().unwrap_or(false) {
+                "[x]"
+            } else {
+                "[ ]"
+            };
+            let cursor = if is_sel { ">" } else { " " };
+            let xy = format!("{}{}", entry.index, entry.worktree);
+            let line = format!(
+                " {} {} {} {}",
+                cursor,
+                mark,
+                xy,
+                entry.path.to_string_lossy()
+            );
+            let line = clip(&line, inner_w);
+            self.buf.set_string(self.overlay.x + 1, y, &line, style);
+        }
+    }
+
+    fn render_branches(&mut self, entries: &[BranchEntry], selected: usize) {
+        if entries.is_empty() {
+            if self.start_y < self.end_y {
+                self.buf.set_string(
+                    self.overlay.x + 2,
+                    self.start_y,
+                    "(no branches)",
+                    self.normal,
+                );
+            }
+            return;
+        }
+        let inner_w = self.inner_w();
+        let visible_rows = self.end_y.saturating_sub(self.start_y) as usize;
+        let scroll = if selected >= visible_rows {
+            selected - visible_rows + 1
+        } else {
+            0
+        };
+
+        for (row_off, idx) in (scroll..entries.len()).take(visible_rows).enumerate() {
+            let y = self.start_y + row_off as u16;
+            let entry = &entries[idx];
+            let is_sel = idx == selected;
+            let style = if is_sel { self.sel } else { self.normal };
+            self.fill_row(y, style);
+            let cursor = if is_sel { ">" } else { " " };
+            let marker = if entry.current { "*" } else { " " };
+            let line = format!(" {} {} {}", cursor, marker, entry.name);
+            let line = clip(&line, inner_w);
+            self.buf.set_string(self.overlay.x + 1, y, &line, style);
+        }
+    }
+
+    fn render_stashes(&mut self, entries: &[StashEntry], selected: usize) {
+        if entries.is_empty() {
+            if self.start_y < self.end_y {
+                self.buf.set_string(
+                    self.overlay.x + 2,
+                    self.start_y,
+                    "(no stashes)",
+                    self.normal,
+                );
+            }
+            return;
+        }
+        let inner_w = self.inner_w();
+        let visible_rows = self.end_y.saturating_sub(self.start_y) as usize;
+        let scroll = if selected >= visible_rows {
+            selected - visible_rows + 1
+        } else {
+            0
+        };
+
+        for (row_off, idx) in (scroll..entries.len()).take(visible_rows).enumerate() {
+            let y = self.start_y + row_off as u16;
+            let entry = &entries[idx];
+            let is_sel = idx == selected;
+            let style = if is_sel { self.sel } else { self.normal };
+            self.fill_row(y, style);
+            let cursor = if is_sel { ">" } else { " " };
+            let line = format!(" {} stash@{{{}}}: {}", cursor, entry.index, entry.message);
+            let line = clip(&line, inner_w);
+            self.buf.set_string(self.overlay.x + 1, y, &line, style);
+        }
+    }
+
+    fn render_confirm(&mut self, prompt: &str) {
+        if self.start_y >= self.end_y {
+            return;
+        }
+        let line = clip(prompt, self.inner_w());
+        let cy = (self.start_y + self.end_y) / 2;
+        let cx = self.overlay.x + self.overlay.width.saturating_sub(line.len() as u16) / 2;
+        self.buf
+            .set_string(cx.max(self.overlay.x + 1), cy, &line, self.normal);
+    }
+}
+
+// ── Drawing helpers ──────────────────────────────────────────────────────────
+
+fn draw_border(buf: &mut TermBuffer, area: Rect, style: Style) {
+    if area.width < 2 || area.height < 2 {
+        return;
+    }
+    let (x0, y0) = (area.x, area.y);
+    let (x1, y1) = (area.x + area.width - 1, area.y + area.height - 1);
+
+    buf.set_string(x0, y0, "╭", style);
+    buf.set_string(x1, y0, "╮", style);
+    buf.set_string(x0, y1, "╰", style);
+    buf.set_string(x1, y1, "╯", style);
+    for x in x0 + 1..x1 {
+        buf.set_string(x, y0, "─", style);
+        buf.set_string(x, y1, "─", style);
+    }
+    for y in y0 + 1..y1 {
+        buf.set_string(x0, y, "│", style);
+        buf.set_string(x1, y, "│", style);
+    }
+}
+
+fn clip(s: &str, width: usize) -> String {
+    if s.len() <= width {
+        s.to_string()
+    } else {
+        let mut end = width;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        s[..end].to_string()
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_state_starts_at_menu() {
+        let s = GitDialogState::new();
+        assert!(matches!(s.screen, GitScreen::Menu { selected: 0 }));
+        assert!(s.history.is_empty());
+    }
+
+    #[test]
+    fn push_pop_round_trip() {
+        let mut s = GitDialogState::new();
+        s.push(GitScreen::Status {
+            output: "ok".into(),
+            scroll: 0,
+        });
+        assert!(matches!(s.screen, GitScreen::Status { .. }));
+        assert_eq!(s.history.len(), 1);
+        assert!(s.pop());
+        assert!(matches!(s.screen, GitScreen::Menu { .. }));
+        // Popping the menu (no history left) returns false → caller closes the dialog.
+        assert!(!s.pop());
+    }
+
+    #[test]
+    fn move_up_down_clamps() {
+        let mut s = GitScreen::Menu { selected: 0 };
+        s.move_up();
+        if let GitScreen::Menu { selected } = s {
+            assert_eq!(selected, 0);
+        }
+        for _ in 0..50 {
+            s.move_down();
+        }
+        if let GitScreen::Menu { selected } = s {
+            assert_eq!(selected, MenuItem::ALL.len() - 1);
+        }
+    }
+
+    #[test]
+    fn confirm_op_prompt_includes_target() {
+        let p = ConfirmOp::DropStash(2).prompt();
+        assert!(p.contains("2"));
+        let p = ConfirmOp::DeleteBranch("feature/x".into()).prompt();
+        assert!(p.contains("feature/x"));
+    }
+
+    #[test]
+    fn set_and_clear_error() {
+        let mut s = GitDialogState::new();
+        s.set_error("nope");
+        assert_eq!(s.last_error.as_deref(), Some("nope"));
+        s.clear_error();
+        assert!(s.last_error.is_none());
+    }
+
+    #[test]
+    fn render_does_not_panic_on_each_screen() {
+        let theme = crate::theme::ThemeColors::for_theme(&crate::config::Theme::Default);
+        let area = Rect::new(0, 0, 100, 40);
+
+        let screens = vec![
+            GitScreen::Menu { selected: 0 },
+            GitScreen::Status {
+                output: "M file.rs".into(),
+                scroll: 0,
+            },
+            GitScreen::Stage {
+                entries: vec![],
+                checked: vec![],
+                selected: 0,
+            },
+            GitScreen::Branches {
+                entries: vec![],
+                selected: 0,
+            },
+            GitScreen::Stashes {
+                entries: vec![],
+                selected: 0,
+            },
+            GitScreen::Confirm {
+                op: ConfirmOp::DropStash(0),
+            },
+            GitScreen::Output {
+                title: "".into(),
+                body: "done".into(),
+                scroll: 0,
+            },
+        ];
+        for screen in screens {
+            let s = GitDialogState {
+                screen,
+                history: Vec::new(),
+                last_error: None,
+            };
+            let mut buf = TermBuffer::empty(area);
+            render(&s, &theme, area, &mut buf);
+        }
+    }
+}

--- a/src/ui/help_overlay.rs
+++ b/src/ui/help_overlay.rs
@@ -305,6 +305,12 @@ const TEMPLATE: &[HelpEntry] = &[
         actions: &["open_lsp_config"],
         desc: "Configure LSP server",
     },
+    // ── Git ──────────────────────────────────────────────────────────
+    HelpEntry::Section("Git"),
+    HelpEntry::Binding {
+        actions: &["open_git_dialog"],
+        desc: "Open git operations dialog",
+    },
     HelpEntry::Static {
         key: "y / n",
         desc: "Approve / reject LSP binary (when prompted)",

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -3,6 +3,7 @@ pub mod command_palette;
 pub mod completion_popup;
 pub mod editor_view;
 pub mod fuzzy_picker;
+pub mod git_dialog;
 pub mod help_overlay;
 pub mod hover_popup;
 pub mod lsp_approval;
@@ -268,6 +269,11 @@ pub fn render(state: &mut AppState, frame: &mut Frame) {
     // ── LSP picker overlay ───────────────────────────────────────────────────
     if let Some(picker) = &state.lsp_picker {
         lsp_picker::render(picker, area, buf);
+    }
+
+    // ── Git operations dialog ────────────────────────────────────────────────
+    if let Some(dialog) = &state.git_dialog {
+        git_dialog::render(dialog, &theme, area, buf);
     }
 
     // ── LSP-binary trust approval overlay (security-critical, render last) ───

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -198,6 +198,9 @@ fn modal_prompt(mode: &InputMode) -> Option<String> {
         InputMode::RenamePath(_, s) => Some(format!(" Rename: {}_", s)),
         InputMode::NewFolderName(_, s) => Some(format!(" New folder: {}_", s)),
         InputMode::Rename(s) => Some(format!(" Rename: {}_", s)),
+        InputMode::GitCommitMessage(s) => Some(format!(" Commit message: {}_", s)),
+        InputMode::GitNewBranch(s) => Some(format!(" New branch: {}_", s)),
+        InputMode::GitStashMessage(s) => Some(format!(" Stash message (optional): {}_", s)),
     }
 }
 


### PR DESCRIPTION
Introduces a single overlay that exposes the common git workflow inside
the editor: status, stage/unstage files, commit, push, pull, switch /
create / delete branches, and stash management. Each operation either
runs immediately, advances to a list screen, or hands off to a
status-bar prompt for free-text input (commit message, new branch
name, stash message). Errors surface as a banner inside the dialog so
the user stays in flow.

Implementation extends the existing subprocess-based git module with a
new `git::ops` submodule (no new crate dependency) and follows the
established overlay pattern: an `Option<GitDialogState>` field on
`AppState`, a centered-float renderer, and a handler that returns
through the input priority chain so global actions still work.