### PR TITLE
Allow Shift modifier for Ctrl+digit GoToTab shortcuts on AZERTY keyboards

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -47,9 +47,12 @@ impl InputHandler {
 
         // ── Phase 1: non-remappable hardcoded actions ────────────────────
 
-        // Ctrl+1..9 → GoToTab (index-parameterized, not configurable)
+        // Ctrl+1..9 → GoToTab (index-parameterized, not configurable).
+        // SHIFT is allowed because on AZERTY (French) and several other
+        // layouts, digits live on the shifted layer of the number row, so
+        // pressing what the user thinks of as "Ctrl+1" arrives as
+        // Ctrl+Shift+1.
         if ctrl
-            && !shift
             && !alt
             && let KeyCode::Char(c) = event.code
             && let Some(n) = c.to_digit(10)
@@ -546,6 +549,21 @@ mod tests {
         );
         assert_eq!(
             ih.handle_key(ctrl(KeyCode::Char('9'))),
+            EditorAction::GoToTab(8)
+        );
+    }
+
+    #[test]
+    fn go_to_tab_shortcuts_with_shift_for_azerty() {
+        // On AZERTY (French) keyboards, digits are on the shifted layer of
+        // the number row, so Ctrl+1 arrives as Ctrl+Shift+1.
+        let ih = handler();
+        assert_eq!(
+            ih.handle_key(ctrl_shift(KeyCode::Char('1'))),
+            EditorAction::GoToTab(0)
+        );
+        assert_eq!(
+            ih.handle_key(ctrl_shift(KeyCode::Char('9'))),
             EditorAction::GoToTab(8)
         );
     }


### PR DESCRIPTION
## Summary
Updated the GoToTab keyboard shortcut handling to accept the Shift modifier, which is necessary for AZERTY and other keyboard layouts where digits are located on the shifted layer of the number row.

## Changes
- **Modified shortcut detection logic**: Removed the `!shift` condition from the Ctrl+1..9 GoToTab shortcut handler, allowing `Ctrl+Shift+1..9` to trigger the same actions as `Ctrl+1..9`
- **Added explanatory comments**: Documented why Shift is allowed, clarifying that on AZERTY keyboards, pressing what users perceive as "Ctrl+1" actually arrives as `Ctrl+Shift+1` due to keyboard layout differences
- **Added test coverage**: Implemented `go_to_tab_shortcuts_with_shift_for_azerty()` test to verify that `Ctrl+Shift+1` through `Ctrl+Shift+9` correctly map to tabs 0-8

## Implementation Details
The change is minimal and backward compatible—it simply removes the shift key restriction while maintaining all other validation (ctrl must be pressed, alt must not be pressed, and the key must be a digit character). This allows the shortcut to work naturally on both QWERTY and AZERTY layouts without requiring users to reconfigure their keybindings.

https://claude.ai/code/session_0152994iSrRfvsixsPc7gnux