### PR TITLE
Allow global actions to pass through when sidebar has focus

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3045,9 +3045,37 @@ impl AppState {
                 }
                 true
             }
-            // Swallow all text-insertion actions so they don't reach the editor.
-            EditorAction::InsertChar(_) | EditorAction::InsertTab => true,
-            _ => false,
+            // Global actions that don't touch editor content are allowed to
+            // fall through to the main dispatcher.
+            EditorAction::Quit
+            | EditorAction::ForceQuit
+            | EditorAction::ToggleHelp
+            | EditorAction::ToggleSidebar
+            | EditorAction::OpenSettings
+            | EditorAction::OpenCommandPalette
+            | EditorAction::OpenFuzzyPicker
+            | EditorAction::OpenRecentFiles
+            | EditorAction::OpenLspConfig
+            | EditorAction::OpenGitDialog
+            | EditorAction::ReloadConfig
+            | EditorAction::ToggleWordWrap
+            | EditorAction::OpenFile
+            | EditorAction::SaveFile
+            | EditorAction::SaveFileAs
+            | EditorAction::NewFile
+            | EditorAction::NewTab
+            | EditorAction::CloseTab
+            | EditorAction::NextTab
+            | EditorAction::PrevTab
+            | EditorAction::GoToTab(_)
+            | EditorAction::MouseClick { .. }
+            | EditorAction::MouseDrag { .. }
+            | EditorAction::MouseUp { .. }
+            | EditorAction::MouseScroll { .. }
+            | EditorAction::Unhandled => false,
+            // Swallow everything else so editor content / cursor / search /
+            // LSP state isn't affected while the sidebar has focus.
+            _ => true,
         }
     }
 


### PR DESCRIPTION
## Summary
Changed the sidebar focus action filtering logic to allow global UI actions to pass through to the main dispatcher, while still blocking editor content-modifying actions.

## Key Changes
- Inverted the filtering logic from a blacklist (blocking text insertion) to a whitelist approach
- Global actions that don't modify editor content now fall through (return `false`):
  - Application control: Quit, ForceQuit
  - UI toggles: ToggleHelp, ToggleSidebar, ToggleWordWrap
  - Dialogs/pickers: OpenSettings, OpenCommandPalette, OpenFuzzyPicker, OpenRecentFiles, OpenLspConfig, OpenGitDialog
  - File operations: OpenFile, SaveFile, SaveFileAs, NewFile
  - Tab management: NewTab, CloseTab, NextTab, PrevTab, GoToTab
  - Mouse events: MouseClick, MouseDrag, MouseUp, MouseScroll
  - Configuration: ReloadConfig
  - Unhandled actions
- All other actions (editor content/cursor/search/LSP state modifications) are now blocked (return `true`) while sidebar has focus

## Implementation Details
This change ensures that users can still interact with global application features (like opening files, toggling UI elements, or quitting) while the sidebar has keyboard focus, while preventing accidental editor modifications through keyboard input.

https://claude.ai/code/session_018p7PPBe9gLpqy3qUPqSJn5