### PR TITLE
Set terminal window title to application name and file path

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3,6 +3,8 @@ use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use crossterm::event::{self, Event, KeyEventKind};
+use crossterm::execute;
+use crossterm::terminal::SetTitle;
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 use ratatui::layout::Rect;
@@ -4446,6 +4448,7 @@ impl App {
         // both untouched so the cursor is allowed to leave the screen.
         let mut prev_anchor: Option<(usize, usize)> = None; // (active tab, primary byte offset)
         let mut prev_size: Option<(usize, usize)> = None; // (text_h, text_w)
+        let mut prev_title: Option<String> = None;
 
         loop {
             let term_size = terminal.size()?;
@@ -4480,6 +4483,16 @@ impl App {
             }
             prev_anchor = Some(curr_anchor);
             prev_size = Some(curr_size);
+
+            let desired_title = if state.editor.active().path.is_some() {
+                format!("txt - {}", state.editor.active().display_name())
+            } else {
+                "txt".to_string()
+            };
+            if prev_title.as_deref() != Some(desired_title.as_str()) {
+                let _ = execute!(std::io::stdout(), SetTitle(&desired_title));
+                prev_title = Some(desired_title);
+            }
 
             // Check for external file changes (non-blocking).
             state.poll_file_watcher();

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,9 @@ use crossterm::{
         PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
     },
     execute,
-    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+    terminal::{
+        EnterAlternateScreen, LeaveAlternateScreen, SetTitle, disable_raw_mode, enable_raw_mode,
+    },
 };
 use ratatui::{Terminal, backend::CrosstermBackend};
 
@@ -86,7 +88,12 @@ fn main() -> Result<()> {
 fn init_terminal() -> Result<Terminal<CrosstermBackend<io::Stdout>>> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    execute!(
+        stdout,
+        EnterAlternateScreen,
+        EnableMouseCapture,
+        SetTitle("txt")
+    )?;
     // Enable keyboard enhancements so Ctrl+digit and Ctrl+Tab are transmitted
     // correctly by terminals that support the protocol (kitty, WezTerm, foot,
     // recent iTerm2). Terminals that don't support it silently ignore this.


### PR DESCRIPTION
## Summary
This PR adds functionality to set the terminal window title to display the application name ("txt") and the currently active file's display name when a file is open.

## Key Changes
- **src/main.rs**: Initialize terminal window title to "txt" during terminal setup in `init_terminal()`
- **src/app.rs**: Dynamically update the terminal window title in the main event loop to reflect the active file:
  - Track the previous title to avoid redundant updates
  - Set title to "txt - {filename}" when a file is open
  - Set title to "txt" when no file is open
  - Only update the title when it changes

## Implementation Details
- Uses `crossterm::terminal::SetTitle` to set the window title
- Implements change detection by comparing the desired title with the previously set title (`prev_title`)
- Only executes the title-setting command when the title actually changes, avoiding unnecessary system calls
- The title update occurs in the main event loop after checking for terminal size changes

https://claude.ai/code/session_01DV7bh5vB87X8b9qtLxCd5y