### PR TITLE
Fix Ctrl+1..9 tab switching on AZERTY (supersedes #36)

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -48,17 +48,19 @@ impl InputHandler {
         // ── Phase 1: non-remappable hardcoded actions ────────────────────
 
         // Ctrl+1..9 → GoToTab (index-parameterized, not configurable).
-        // SHIFT is allowed because on AZERTY (French) and several other
-        // layouts, digits live on the shifted layer of the number row, so
-        // pressing what the user thinks of as "Ctrl+1" arrives as
-        // Ctrl+Shift+1.
+        //
+        // We accept both QWERTY digits and the AZERTY layer-1 (unshifted)
+        // top-row glyphs because terminals do not translate the keystroke
+        // back to the digit on AZERTY: pressing what the user thinks of as
+        // "Ctrl+1" delivers `Char('&')`, with or without SHIFT depending on
+        // whether Shift was held. SHIFT is therefore ignored — only CTRL
+        // and the absence of ALT matter.
         if ctrl
             && !alt
             && let KeyCode::Char(c) = event.code
-            && let Some(n) = c.to_digit(10)
-            && (1..=9).contains(&n)
+            && let Some(n) = digit_for_tab_shortcut(c)
         {
-            return EditorAction::GoToTab(n as usize - 1);
+            return EditorAction::GoToTab(n - 1);
         }
 
         // Plain printable chars (no ctrl/alt) → InsertChar
@@ -113,6 +115,27 @@ impl InputHandler {
 impl Default for InputHandler {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Map a character delivered with Ctrl held to the tab number 1..=9.
+///
+/// QWERTY layouts deliver `'1'..'9'`; AZERTY layouts deliver the layer-1
+/// (unshifted) glyph from the top row, since the digit is on the shifted
+/// layer and terminals report the base glyph regardless of Shift state.
+fn digit_for_tab_shortcut(c: char) -> Option<usize> {
+    match c {
+        '1'..='9' => Some(c as usize - '0' as usize),
+        '&' => Some(1),
+        'é' => Some(2),
+        '"' => Some(3),
+        '\'' => Some(4),
+        '(' => Some(5),
+        '-' => Some(6),
+        'è' => Some(7),
+        '_' => Some(8),
+        'ç' => Some(9),
+        _ => None,
     }
 }
 
@@ -554,17 +577,34 @@ mod tests {
     }
 
     #[test]
-    fn go_to_tab_shortcuts_with_shift_for_azerty() {
-        // On AZERTY (French) keyboards, digits are on the shifted layer of
-        // the number row, so Ctrl+1 arrives as Ctrl+Shift+1.
+    fn go_to_tab_shortcuts_azerty_layer_1_chars() {
+        // On AZERTY, terminals deliver the unshifted top-row glyph
+        // regardless of Shift. Verified empirically with Ghostty: pressing
+        // "Ctrl+1" arrives as Char('&') + CONTROL; pressing
+        // "Ctrl+Shift+1" arrives as Char('&') + CONTROL|SHIFT.
         let ih = handler();
-        assert_eq!(
-            ih.handle_key(ctrl_shift(KeyCode::Char('1'))),
-            EditorAction::GoToTab(0)
-        );
-        assert_eq!(
-            ih.handle_key(ctrl_shift(KeyCode::Char('9'))),
-            EditorAction::GoToTab(8)
-        );
+        let cases = [
+            ('&', 0),
+            ('é', 1),
+            ('"', 2),
+            ('\'', 3),
+            ('(', 4),
+            ('-', 5),
+            ('è', 6),
+            ('_', 7),
+            ('ç', 8),
+        ];
+        for (ch, tab) in cases {
+            assert_eq!(
+                ih.handle_key(ctrl(KeyCode::Char(ch))),
+                EditorAction::GoToTab(tab),
+                "Ctrl+{ch} should map to tab {tab}"
+            );
+            assert_eq!(
+                ih.handle_key(ctrl_shift(KeyCode::Char(ch))),
+                EditorAction::GoToTab(tab),
+                "Ctrl+Shift+{ch} should map to tab {tab}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- **PR #36 didn't fix the bug.** It assumed AZERTY users would hold Shift to produce '1' from the shifted layer of the number row, and relaxed the matcher to accept `Ctrl+Shift+Char('1')`. In practice that event shape never arrives — terminals deliver the **unshifted layer-1 glyph** (`&`, `é`, `"`, `'`, `(`, `-`, `è`, `_`, `ç`) regardless of Shift state, because the OS keymap produces those characters when Ctrl is held.
- This PR replaces the digit-only matcher with one that also accepts the nine AZERTY top-row layer-1 chars and maps them to tabs 1..9. Shift remains permissive, so both `Ctrl+&-key` and `Ctrl+Shift+&-key` switch to tab 1.

## Empirical evidence

Captured in Ghostty (kitty `DISAMBIGUATE_ESCAPE_CODES` enabled, as already configured in `main.rs`) with French AZERTY layout active:

```
Ctrl + &-key      → Char('&')  + CONTROL
Ctrl + Shift + &  → Char('&')  + CONTROL|SHIFT
Ctrl + é-key      → Char('é')  + CONTROL
Ctrl + Shift + é  → Char('é')  + CONTROL|SHIFT
Ctrl + ç-key      → Char('ç')  + CONTROL
Ctrl + Shift + ç  → Char('ç')  + CONTROL|SHIFT
```

`Char('1')` never arrives. PR #36's relaxation of `!shift` matched a code path the user could not reach. Both Ctrl+1..9 and Ctrl+Shift+1..9 fell through to the configurable keybinding lookup, which has no entry for those layer-1 chars, and resolved to `Unhandled`.

## Changes

- **`src/input/mod.rs`** — `handle_key` now goes through a new `digit_for_tab_shortcut(c)` helper that maps both `'1'..'9'` and the AZERTY layer-1 chars (`& é " ' ( - è _ ç`) to tabs 1..9. Only Ctrl-without-Alt is required; Shift is ignored.
- **Test rewrite** — PR #36's `go_to_tab_shortcuts_with_shift_for_azerty` (which asserted on a `Char('1')` event the terminal never produces) is replaced with `go_to_tab_shortcuts_azerty_layer_1_chars`, asserting on the nine actual layer-1 chars with and without Shift.

## QWERTY impact

Pressing `Ctrl+-`, `Ctrl+'`, `Ctrl+(`, `Ctrl+"`, `Ctrl+_`, or `Ctrl+&` (typed as `Ctrl+Shift+7`) will now trigger GoToTab. None of those combos are bound by default. The Ctrl+1..9 matcher was already documented as non-overridable (`src/input/mod.rs:48`); this PR extends that non-overridable region to the AZERTY equivalents. If a QWERTY user reports an actual conflict with a custom binding, we can scope the AZERTY mapping behind a config flag — but no such report exists today, and adding a setting would mean French users have to discover a toggle to get tab-switching to work.

## Why not autodetect AZERTY?

Considered: OS keyboard-layout APIs (platform-specific code, fragile on Wayland, doesn't handle mid-session layout swaps), locale env vars (locale ≠ layout — `fr_CA` is QWERTY), and a runtime heuristic. All add real complexity for a problem the always-on mapping already solves at zero cost.

## Test plan

- [x] `scripts/check.sh` passes (fmt + build + clippy + 416 tests)
- [x] New test `go_to_tab_shortcuts_azerty_layer_1_chars` covers all nine layer-1 chars × {with-Shift, without-Shift} = 18 assertions
- [ ] Manual verification on French AZERTY in Ghostty: `Ctrl + &/é/"/'/(-/è/_/ç` switches to the corresponding tab; same with Shift held
- [ ] QWERTY regression check: `Ctrl + 1..9` still switches tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)