### PR TITLE
Document missing keybindings in F1 help overlay

### DIFF
--- a/src/ui/help_overlay.rs
+++ b/src/ui/help_overlay.rs
@@ -58,16 +58,32 @@ const TEMPLATE: &[HelpEntry] = &[
         desc: "Line start / end",
     },
     HelpEntry::Binding {
+        actions: &["extend_selection_home", "extend_selection_end"],
+        desc: "Extend to line start / end",
+    },
+    HelpEntry::Binding {
         actions: &["move_cursor_file_start", "move_cursor_file_end"],
         desc: "File start / end",
+    },
+    HelpEntry::Binding {
+        actions: &["extend_selection_file_start", "extend_selection_file_end"],
+        desc: "Extend to file start / end",
     },
     HelpEntry::Binding {
         actions: &["move_cursor_page_up", "move_cursor_page_down"],
         desc: "Page up / down",
     },
     HelpEntry::Binding {
+        actions: &["extend_selection_page_up", "extend_selection_page_down"],
+        desc: "Extend page up / down",
+    },
+    HelpEntry::Binding {
         actions: &["go_to_matching_bracket"],
         desc: "Jump to matching bracket",
+    },
+    HelpEntry::Binding {
+        actions: &["scroll_up", "scroll_down"],
+        desc: "Scroll without moving cursor",
     },
     HelpEntry::Binding {
         actions: &["scroll_cursor_center"],
@@ -195,6 +211,10 @@ const TEMPLATE: &[HelpEntry] = &[
         key: "Ctrl+1..9",
         desc: "Go to tab N",
     },
+    HelpEntry::Binding {
+        actions: &["close_tab"],
+        desc: "Close tab",
+    },
     // ── Panels & Pickers ─────────────────────────────────────────────
     HelpEntry::Section("Panels & Pickers"),
     HelpEntry::Binding {
@@ -242,6 +262,10 @@ const TEMPLATE: &[HelpEntry] = &[
     HelpEntry::Binding {
         actions: &["search_toggle_case_sensitive"],
         desc: "Toggle case-sensitive",
+    },
+    HelpEntry::Binding {
+        actions: &["close_search"],
+        desc: "Close find / replace bar",
     },
     // ── LSP ──────────────────────────────────────────────────────────
     HelpEntry::Section("LSP (when active)"),


### PR DESCRIPTION
## Summary

- Six already-bound actions were missing from the F1 help overlay. This adds entries for them; no behavior change, no new bindings.

## Added entries

| Action(s) | Binding | Where |
|---|---|---|
| `extend_selection_home`, `extend_selection_end` | Shift+Home / Shift+End | Movement |
| `extend_selection_file_start`, `extend_selection_file_end` | Ctrl+Shift+Home / Ctrl+Shift+End | Movement |
| `extend_selection_page_up`, `extend_selection_page_down` | Shift+PageUp / Shift+PageDown | Movement |
| `scroll_up`, `scroll_down` | Ctrl+Up / Ctrl+Down | Movement |
| `close_tab` | Ctrl+F4 | Tabs |
| `close_search` | Esc | Find / Replace |

Entries are placed alongside their related move/scroll actions so the overlay groups them logically (e.g. extend-selection lines sit immediately after their move-cursor counterparts).

## Test plan

- [x] `scripts/check.sh` passes
- [ ] Open the editor, press F1, visually confirm the new lines appear in the expected sections and render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)