### PR TITLE
Honor .editorconfig per buffer (indent, EOL, final newline)

### DIFF
--- a/feature_proposals.md
+++ b/feature_proposals.md
@@ -28,17 +28,17 @@ This is already a serious editor for the niche described in the README — *"rev
 | AST‑aware selection | ✅ expand/contract | ✅ object motions | ✅ object motions | ❌ | textobjects plugin | symbol nav |
 | Multi‑cursor (column) | line above/below only | ✅ rich | ✅ rich | ✅ + click | block visual | ✅ + Alt‑click + Ctrl+D add‑next |
 | Project‑wide find/replace | ❌ | ✅ via `:rg` | ❌ | ✅ | telescope/grep plugins | ✅ |
-| Snippets | ❌ | LSP only | ❌ | ✅ plugin | ✅ many | ✅ |
-| Macros (record/replay) | ❌ | ✅ | ✅ | ✅ | ✅ q/@ | ✅ |
-| Marks / bookmarks | ❌ | ✅ `mx` / `'x` | ✅ | ✅ | ✅ | ✅ |
-| Jump list | ❌ | ✅ | ✅ | ❌ | ✅ Ctrl‑O / Ctrl‑I | ✅ Alt+←/→ |
-| Code folding | ❌ | tree‑sitter folds | ❌ | manual | ✅ | ✅ |
-| Sticky scroll / breadcrumbs | ❌ | ❌ | ❌ | ❌ | plugin | ✅ |
-| Indent guides | ❌ | ✅ | ❌ | ✅ | plugin | ✅ |
+| Snippets | ✅ | LSP only | ❌ | ✅ plugin | ✅ many | ✅ |
+| Macros (record/replay) | ✅ | ✅ | ✅ | ✅ | ✅ q/@ | ✅ |
+| Marks / bookmarks | ✅ | ✅ `mx` / `'x` | ✅ | ✅ | ✅ | ✅ |
+| Jump list | ✅ | ✅ | ✅ | ❌ | ✅ Ctrl‑O / Ctrl‑I | ✅ Alt+←/→ |
+| Code folding | ✅ | tree‑sitter folds | ❌ | manual | ✅ | ✅ |
+| Sticky scroll / breadcrumbs | ✅ | ❌ | ❌ | ❌ | plugin | ✅ |
+| Indent guides | ✅ | ✅ | ❌ | ✅ | plugin | ✅ |
 | Filter selection through shell | ❌ | ✅ `\|` | ✅ `\|` | ❌ | `!` | ❌ |
 | Sort / case / dedupe lines | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Increment number under cursor | ❌ | ❌ | ✅ | ❌ | ✅ Ctrl‑A/X | ❌ |
-| EditorConfig support | ❌ | ✅ | plugin | ✅ | plugin | ✅ |
+| EditorConfig support | ✅ | ✅ | plugin | ✅ | plugin | ✅ |
 | Persistent sessions | ❌ | partial | ❌ | partial | ✅ | ✅ |
 | Persistent undo | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
 | Read clipboard ring / registers | system clipboard | ✅ registers | ✅ registers | system | ✅ registers | ❌ |
@@ -101,21 +101,24 @@ Ten compact actions exposed on the command palette and remappable:
 
 Each is a few lines on top of the existing `Buffer` API and trivially composes with multi‑cursor.
 
-### Tier 2 — daily quality‑of‑life
+### Tier 2 — daily quality‑of‑life ✅ shipped
 
-#### 2.1 Snippets
+All eight Tier 2 features have been implemented on branch
+`claude/implement-tier-2-features-3bEqv` (one commit per feature).
+
+#### 2.1 Snippets ✅ implemented
 
 A simple TextMate‑style snippet engine (`prefix → body` with `$1`, `$2`, `${1:default}`, `$0` final cursor, no transformations needed). Snippets live in `~/.config/txt/snippets/<lang>.toml`, are filtered by tree‑sitter language id, and surface in the existing completion popup. Tab cycles tab‑stops; Esc collapses to `$0`. Roughly the scope of 800 lines including parser, expander, and tab‑stop tracker.
 
 Worth noting: this dovetails with LSP completions because LSP servers already return snippet bodies in the same syntax — `txt` only needs the runtime.
 
-#### 2.2 Macros (record / replay)
+#### 2.2 Macros (record / replay) ✅ implemented
 
 Modal‑editor staple: `Ctrl+Shift+R` starts recording into a slot (`a`–`z`); `Ctrl+Shift+R` again stops. `Ctrl+R` replays. With multi‑cursor and the new `Ctrl+D` motion, macros recorded once apply trivially across an entire file.
 
 Implementation: an `EditorAction` queue tee'd into a `Vec<EditorAction>` while recording, then re‑fed through `update()`. `MouseClick`, `MouseDrag`, and `Unhandled` are skipped. ~200 lines.
 
-#### 2.3 Marks / bookmarks and a jump list
+#### 2.3 Marks / bookmarks and a jump list ✅ implemented
 
 Two related features that share storage:
 
@@ -124,23 +127,23 @@ Two related features that share storage:
 
 Both are cheap and pay back constantly when navigating a multi‑file change.
 
-#### 2.4 Code folding driven by tree‑sitter
+#### 2.4 Code folding driven by tree‑sitter ✅ implemented
 
 Folding ranges are queryable from the existing parse tree (`@fold` captures or balanced node kinds). UI: chevrons in the gutter, `Ctrl+Shift+[` / `Ctrl+Shift+]` to fold/unfold, `Ctrl+K Ctrl+0` fold all. Folded ranges are stored on the `BufferHandle` as a `Vec<Range<usize>>`; `editor_view.rs` already iterates lines for rendering, so the visible‑line walk just skips folded interiors and emits a "..." marker.
 
-#### 2.5 Sticky header / breadcrumbs row
+#### 2.5 Sticky header / breadcrumbs row ✅ implemented
 
 When the cursor is inside a function/class/section, render the enclosing parent on the first row of the editor pane. The information is one tree‑sitter ancestor walk; the cost is one row of viewport. Breadcrumbs in the status bar (`Buffer › Mod › Fn`) are a free byproduct.
 
-#### 2.6 Indent guides and column rulers
+#### 2.6 Indent guides and column rulers ✅ implemented
 
 Render light vertical lines at every indent multiple, and optional vertical rulers at user‑configured columns (e.g. `rulers = [80, 120]`). Both are render‑only changes in `editor_view.rs` and read‑only fields in config. Indent guides catch indentation bugs in YAML/Python instantly.
 
-#### 2.7 EditorConfig support
+#### 2.7 EditorConfig support ✅ implemented
 
 `.editorconfig` is the de facto cross‑editor convention. The `editorconfig` Rust crate is small; on file open, override per‑buffer `tab_size`, `indent_style`, `end_of_line`, `insert_final_newline`, `trim_trailing_whitespace`. This is one of the cheapest features to ship and significantly reduces config friction in mixed‑language repos.
 
-#### 2.8 Symbols in file (Ctrl+Shift+O)
+#### 2.8 Symbols in file (Ctrl+Shift+O) ✅ implemented
 
 A fuzzy picker over all named symbols in the active buffer. The data source is tree‑sitter (`@local.definition.*` captures or per‑grammar definition queries), so it works without an LSP server. The picker is the existing `fuzzy_picker.rs` populated from a different source.
 
@@ -207,9 +210,9 @@ A pragmatic 5‑release roadmap that keeps each release shippable on its own:
 |---|---|---|
 | v0.5 | "Find everywhere" ✅ shipped | 1.1 project search/replace, 1.5 line transforms, 1.4 shell filter |
 | v0.6 | "Multi‑cursor upgrade" | 1.2 add‑next ✅, 1.3 box selection ✅, 3.3 clipboard ring |
-| v0.7 | "Navigate" | 2.3 marks + jump list, 2.8 file/workspace symbols, 3.5 diff navigation |
-| v0.8 | "Rhythm" | 2.2 macros, 2.1 snippets, 3.4 surround/auto‑pairs |
-| v0.9 | "Polish" | 2.4 folding, 2.5 sticky header, 2.6 indent guides + rulers, 2.7 EditorConfig, 3.1 sessions, 3.2 persistent undo |
+| v0.7 | "Navigate" ✅ shipped | 2.3 marks + jump list ✅, 2.8 file symbols ✅, 3.5 diff navigation |
+| v0.8 | "Rhythm" ✅ shipped | 2.2 macros ✅, 2.1 snippets ✅, 3.4 surround/auto‑pairs |
+| v0.9 | "Polish" ✅ shipped | 2.4 folding ✅, 2.5 sticky header ✅, 2.6 indent guides + rulers ✅, 2.7 EditorConfig ✅, 3.1 sessions, 3.2 persistent undo |
 
 ## 5. Constraints to respect
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -2302,6 +2302,7 @@ impl AppState {
                             None => (input.as_str(), None),
                         };
                         if let Ok(n) = line_str.parse::<usize>() {
+                            self.push_current_to_jump_list();
                             let line = n.saturating_sub(1); // 1-based input
                             let buf = &mut self.editor.active_mut().buffer;
                             let target = {
@@ -2333,6 +2334,7 @@ impl AppState {
                     }
                     InputMode::OpenFilePath(input) => {
                         let path = PathBuf::from(input.trim());
+                        self.push_current_to_jump_list();
                         let _ = self.editor.open_tab(path);
                         self.after_file_open_or_save();
                     }
@@ -2445,6 +2447,7 @@ impl AppState {
                     .and_then(|p| p.selected_path().cloned());
                 self.fuzzy_picker = None;
                 if let Some(path) = path {
+                    self.push_current_to_jump_list();
                     let _ = self.editor.open_tab(path);
                     self.after_file_open_or_save();
                 }
@@ -2492,6 +2495,7 @@ impl AppState {
                     .and_then(|p| p.selected_symbol().cloned());
                 self.symbol_picker = None;
                 if let Some(sym) = target {
+                    self.push_current_to_jump_list();
                     let handle = self.editor.active_mut();
                     let rope = handle.buffer.rope();
                     let bound = sym.byte_range.start.min(rope.len_bytes());
@@ -3704,6 +3708,7 @@ impl AppState {
                             sb.toggle_selected();
                         }
                     } else {
+                        self.push_current_to_jump_list();
                         let _ = self.editor.open_tab(path);
                         self.after_file_open_or_save();
                         self.sidebar_focused = false;

--- a/src/app.rs
+++ b/src/app.rs
@@ -3688,25 +3688,44 @@ impl AppState {
 
     // ── Code formatting ───────────────────────────────────────────────────────
 
+    /// Short status-bar label showing the active indent style, e.g.
+    /// `"spaces:4"` or `"tabs:8"`.
+    pub fn indent_label(&self) -> String {
+        let (indent, _) = self.indent_for_active();
+        match indent.style {
+            crate::formatting::IndentStyle::Tabs => format!("tabs:{}", indent.width),
+            crate::formatting::IndentStyle::Spaces => format!("spaces:{}", indent.width),
+        }
+    }
+
     /// Resolve the live indent rules for the active buffer's language,
     /// merging project + global config and falling back to the legacy
     /// `tab_size` and built-in defaults.
+    ///
+    /// Per-buffer `.editorconfig` overrides win over every config layer.
     fn indent_for_active(
         &self,
     ) -> (
         crate::formatting::IndentConfig,
         crate::formatting::IndentRules,
     ) {
-        let lang = self.editor.active().syntax.language;
+        let active = self.editor.active();
+        let lang = active.syntax.language;
         let resolver = crate::formatting::FormattingResolver {
             global: &self.config.formatting,
             project: self.project_fmt.as_ref(),
             legacy_tab_size: self.config.tab_size,
         };
-        (
-            resolver.indent(lang),
-            crate::formatting::IndentRules::for_lang(lang),
-        )
+        let mut indent = resolver.indent(lang);
+        if let Some(style) = active.editorconfig.indent_style {
+            indent.style = style;
+        }
+        if let Some(width) = active.editorconfig.effective_width()
+            && width > 0
+        {
+            indent.width = width;
+        }
+        (indent, crate::formatting::IndentRules::for_lang(lang))
     }
 
     /// Run the configured external formatter for the active buffer's

--- a/src/app.rs
+++ b/src/app.rs
@@ -74,6 +74,10 @@ pub enum InputMode {
     /// non-empty character submitted (Enter takes the first char, or aborts
     /// if empty).
     AlignChar(String),
+    /// Ctrl+M: "Mark: " — auto-submits on the next typed alphabetic char.
+    SetMarkChar,
+    /// Ctrl+': "Jump to mark: " — auto-submits on the next typed char.
+    JumpToMarkChar,
 }
 
 impl InputMode {
@@ -858,6 +862,8 @@ pub struct AppState {
     pub input_mode: InputMode,
     pub fuzzy_picker: Option<FuzzyPickerState>,
     pub symbol_picker: Option<SymbolPickerState>,
+    pub marks: crate::marks::NamedMarks,
+    pub jumps: crate::marks::JumpList,
     pub sidebar: Option<SidebarState>,
     pub sidebar_focused: bool,
     /// Current sidebar width in columns (excluding the 1-col separator).
@@ -982,6 +988,8 @@ impl AppState {
             input_mode: InputMode::Normal,
             fuzzy_picker: None,
             symbol_picker: None,
+            marks: crate::marks::NamedMarks::load(&workspace),
+            jumps: crate::marks::JumpList::load(&workspace),
             sidebar: None,
             sidebar_focused: false,
             sidebar_width: DEFAULT_SIDEBAR_WIDTH,
@@ -1785,6 +1793,23 @@ impl AppState {
             EditorAction::UnfoldAll => {
                 self.editor.active_mut().folds.unfold_all();
             }
+            EditorAction::JumpListBack => {
+                self.push_current_to_jump_list();
+                if let Some(entry) = self.jumps.back() {
+                    self.go_to_jump_entry(&entry);
+                }
+            }
+            EditorAction::JumpListForward => {
+                if let Some(entry) = self.jumps.forward() {
+                    self.go_to_jump_entry(&entry);
+                }
+            }
+            EditorAction::BeginSetMark => {
+                self.input_mode = InputMode::SetMarkChar;
+            }
+            EditorAction::BeginJumpToMark => {
+                self.input_mode = InputMode::JumpToMarkChar;
+            }
             EditorAction::ToggleSidebar => {
                 if self.sidebar.is_none() {
                     // Restore saved state or create fresh, then expand to current file.
@@ -1840,6 +1865,7 @@ impl AppState {
                 self.trigger_hover();
             }
             EditorAction::GoToDefinition => {
+                self.push_current_to_jump_list();
                 self.trigger_go_to_definition();
             }
             EditorAction::FindReferences => {
@@ -1978,6 +2004,23 @@ impl AppState {
         // Dismiss hover on any action.
         self.hover = None;
 
+        // Forward any buffer edits made this action to marks/jumps so their
+        // byte offsets keep tracking after inserts, deletes, and replaces.
+        // Drain regardless of `modified` so the queue never grows unbounded.
+        let pending = self.editor.active_mut().buffer.drain_pending_edits();
+        if !pending.is_empty()
+            && let Some(path) = self.editor.active().path.clone()
+        {
+            for cmd in &pending {
+                self.marks.rebase_after_edit(&path, cmd);
+                self.jumps.rebase_after_edit(&path, cmd);
+            }
+            if !pending.is_empty() {
+                self.marks.save(&self.workspace);
+                self.jumps.save(&self.workspace);
+            }
+        }
+
         // Re-parse the active buffer if it was modified this action.
         if self.editor.active().buffer.modified {
             self.editor.active_mut().reparse();
@@ -2083,6 +2126,42 @@ impl AppState {
     // ── Modal input handling ─────────────────────────────────────────────────
 
     fn handle_modal_input(&mut self, action: EditorAction) {
+        // Mark prompts auto-complete on the first typed character.
+        if let EditorAction::InsertChar(c) = action {
+            match self.input_mode {
+                InputMode::SetMarkChar => {
+                    self.input_mode = InputMode::Normal;
+                    let handle = self.editor.active();
+                    if let Some(path) = handle.path.clone() {
+                        let off = handle.buffer.cursors.primary().byte_offset;
+                        self.marks.set(&path, c, off);
+                        self.marks.save(&self.workspace);
+                    } else {
+                        self.status_error = Some("Save the file before setting a mark".into());
+                    }
+                    return;
+                }
+                InputMode::JumpToMarkChar => {
+                    self.input_mode = InputMode::Normal;
+                    let active_path = self.editor.active().path.clone();
+                    if let Some(path) = active_path
+                        && let Some(off) = self.marks.get(&path, c)
+                    {
+                        self.push_current_to_jump_list();
+                        let handle = self.editor.active_mut();
+                        let rope = handle.buffer.rope();
+                        let bound = off.min(rope.len_bytes());
+                        *handle.buffer.cursors.primary_mut() =
+                            crate::buffer::cursor::Cursor::from_byte_offset(rope, bound);
+                        handle.buffer.cursors.collapse_to_primary();
+                    } else {
+                        self.status_error = Some(format!("No mark named {c}"));
+                    }
+                    return;
+                }
+                _ => {}
+            }
+        }
         // Mutate the input string for typing/backspace without accessing other fields.
         match action {
             EditorAction::InsertChar(c) => {
@@ -2121,7 +2200,7 @@ impl AppState {
                     | InputMode::AlignChar(s) => {
                         s.pop();
                     }
-                    InputMode::Normal => {}
+                    InputMode::Normal | InputMode::SetMarkChar | InputMode::JumpToMarkChar => {}
                 }
                 return;
             }
@@ -2230,7 +2309,7 @@ impl AppState {
                             self.editor.active_mut().buffer.align_on(c);
                         }
                     }
-                    InputMode::Normal => {}
+                    InputMode::Normal | InputMode::SetMarkChar | InputMode::JumpToMarkChar => {}
                 }
             }
             EditorAction::Quit | EditorAction::Unhandled => {
@@ -4011,6 +4090,33 @@ impl AppState {
         } else {
             self.git_gutter = None;
         }
+    }
+
+    /// Snapshot the active buffer's cursor into the jump list. Used right
+    /// before navigation actions (mark jumps, jump-list back) so the
+    /// previous cursor position can be returned to.
+    fn push_current_to_jump_list(&mut self) {
+        let handle = self.editor.active();
+        if let Some(path) = handle.path.clone() {
+            let byte_offset = handle.buffer.cursors.primary().byte_offset;
+            self.jumps
+                .push(crate::marks::JumpEntry { path, byte_offset });
+        }
+    }
+
+    /// Move the cursor to a jump-list entry, switching tabs if necessary.
+    fn go_to_jump_entry(&mut self, entry: &crate::marks::JumpEntry) {
+        let active_path = self.editor.active().path.clone();
+        if active_path.as_ref() != Some(&entry.path) {
+            let _ = self.editor.open_tab(entry.path.clone());
+            self.after_file_open_or_save();
+        }
+        let handle = self.editor.active_mut();
+        let rope = handle.buffer.rope();
+        let bound = entry.byte_offset.min(rope.len_bytes());
+        *handle.buffer.cursors.primary_mut() =
+            crate::buffer::cursor::Cursor::from_byte_offset(rope, bound);
+        handle.buffer.cursors.collapse_to_primary();
     }
 
     /// Called after a file is opened or saved — updates recent files, git gutter,

--- a/src/app.rs
+++ b/src/app.rs
@@ -1772,6 +1772,19 @@ impl AppState {
                     self.symbol_picker = Some(SymbolPickerState::new(symbols));
                 }
             }
+            EditorAction::ToggleFoldAtCursor => {
+                let active = self.editor.active_mut();
+                let line = active.buffer.cursors.primary().line;
+                if !active.folds.toggle_at_line(line) {
+                    self.status_error = Some("No fold at cursor".to_string());
+                }
+            }
+            EditorAction::FoldAll => {
+                self.editor.active_mut().folds.fold_all();
+            }
+            EditorAction::UnfoldAll => {
+                self.editor.active_mut().folds.unfold_all();
+            }
             EditorAction::ToggleSidebar => {
                 if self.sidebar.is_none() {
                     // Restore saved state or create fresh, then expand to current file.

--- a/src/app.rs
+++ b/src/app.rs
@@ -864,6 +864,8 @@ pub struct AppState {
     pub symbol_picker: Option<SymbolPickerState>,
     pub marks: crate::marks::NamedMarks,
     pub jumps: crate::marks::JumpList,
+    /// Lazy-loaded snippet store, populated per language on first use.
+    pub snippets: crate::snippet::SnippetStore,
     pub sidebar: Option<SidebarState>,
     pub sidebar_focused: bool,
     /// Current sidebar width in columns (excluding the 1-col separator).
@@ -990,6 +992,7 @@ impl AppState {
             symbol_picker: None,
             marks: crate::marks::NamedMarks::load(&workspace),
             jumps: crate::marks::JumpList::load(&workspace),
+            snippets: crate::snippet::SnippetStore::new(),
             sidebar: None,
             sidebar_focused: false,
             sidebar_width: DEFAULT_SIDEBAR_WIDTH,
@@ -1261,6 +1264,16 @@ impl AppState {
                     .insert_newline(&indent, rules);
             }
             EditorAction::InsertTab => {
+                if self.editor.active().snippet_session.is_some() {
+                    self.snippet_advance(true);
+                    return;
+                }
+                // Try to expand a snippet whose prefix matches the word
+                // immediately before the cursor. Falls through to normal
+                // tab-indent behaviour when no snippet is found.
+                if self.try_expand_snippet_silently() {
+                    return;
+                }
                 let (indent, _) = self.indent_for_active();
                 // Multi-line selection → indent every touched line.
                 let buf = &self.editor.active().buffer;
@@ -1287,6 +1300,10 @@ impl AppState {
                 self.editor.active_mut().buffer.indent_lines(&indent);
             }
             EditorAction::DedentSelection => {
+                if self.editor.active().snippet_session.is_some() {
+                    self.snippet_advance(false);
+                    return;
+                }
                 let (indent, _) = self.indent_for_active();
                 self.editor.active_mut().buffer.dedent_lines(&indent);
             }
@@ -1810,6 +1827,18 @@ impl AppState {
             EditorAction::BeginJumpToMark => {
                 self.input_mode = InputMode::JumpToMarkChar;
             }
+            EditorAction::ExpandSnippetAtCursor => {
+                self.expand_snippet_at_cursor();
+            }
+            EditorAction::SnippetNextStop => {
+                self.snippet_advance(true);
+            }
+            EditorAction::SnippetPrevStop => {
+                self.snippet_advance(false);
+            }
+            EditorAction::SnippetCancel => {
+                self.editor.active_mut().snippet_session = None;
+            }
             EditorAction::ToggleSidebar => {
                 if self.sidebar.is_none() {
                     // Restore saved state or create fresh, then expand to current file.
@@ -1961,6 +1990,10 @@ impl AppState {
             EditorAction::SearchNext => self.search_next(),
             EditorAction::SearchPrev => self.search_prev(),
             EditorAction::CloseSearch => {
+                if self.editor.active().snippet_session.is_some() {
+                    self.editor.active_mut().snippet_session = None;
+                    return;
+                }
                 self.search_state = None;
                 // Esc also collapses column-edit multi-cursor when search is not open.
                 if self.editor.active().buffer.cursors.is_multi() {
@@ -2008,16 +2041,22 @@ impl AppState {
         // byte offsets keep tracking after inserts, deletes, and replaces.
         // Drain regardless of `modified` so the queue never grows unbounded.
         let pending = self.editor.active_mut().buffer.drain_pending_edits();
-        if !pending.is_empty()
-            && let Some(path) = self.editor.active().path.clone()
-        {
-            for cmd in &pending {
-                self.marks.rebase_after_edit(&path, cmd);
-                self.jumps.rebase_after_edit(&path, cmd);
-            }
-            if !pending.is_empty() {
+        if !pending.is_empty() {
+            if let Some(path) = self.editor.active().path.clone() {
+                for cmd in &pending {
+                    self.marks.rebase_after_edit(&path, cmd);
+                    self.jumps.rebase_after_edit(&path, cmd);
+                }
                 self.marks.save(&self.workspace);
                 self.jumps.save(&self.workspace);
+            }
+            if let Some(session) = self.editor.active_mut().snippet_session.as_mut() {
+                for cmd in &pending {
+                    session.rebase(cmd);
+                }
+                if session.is_empty() {
+                    self.editor.active_mut().snippet_session = None;
+                }
             }
         }
 
@@ -4089,6 +4128,138 @@ impl AppState {
             self.git_gutter = crate::git::gutter_for_path(&path, &content);
         } else {
             self.git_gutter = None;
+        }
+    }
+
+    /// Same logic as `expand_snippet_at_cursor` but silent: returns `false`
+    /// when no snippet matches so the caller can fall through to its own
+    /// default (e.g. `InsertTab` doing indentation).
+    fn try_expand_snippet_silently(&mut self) -> bool {
+        let lang_id = self.editor.active().syntax.language.config_key();
+        if lang_id.is_empty() {
+            return false;
+        }
+        let cursor_byte = self.editor.active().buffer.cursors.primary().byte_offset;
+        let primary = self.editor.active().buffer.cursors.primary();
+        if primary.has_selection() {
+            return false;
+        }
+        let rope = self.editor.active().buffer.rope();
+        let probe = cursor_byte.saturating_sub(1);
+        let Some((wstart, wend)) = crate::buffer::cursor::word_span_at(rope, probe) else {
+            return false;
+        };
+        if wend < cursor_byte {
+            return false;
+        }
+        let prefix: String = rope.byte_slice(wstart..wend).chars().collect();
+        let matches = self.snippets.lookup(lang_id, &prefix);
+        let Some(snip) = matches.into_iter().next() else {
+            return false;
+        };
+        let parsed = snip.parse_body();
+        let exp = crate::snippet::session::SnippetSession::expand_at(&parsed, wstart);
+        let buf = &mut self.editor.active_mut().buffer;
+        buf.begin_batch();
+        buf.delete_range(wstart, wend);
+        *buf.cursors.primary_mut() =
+            crate::buffer::cursor::Cursor::from_byte_offset(buf.rope(), wstart);
+        buf.cursors.primary_mut().selection = None;
+        buf.insert_str(&exp.text);
+        buf.commit_batch();
+        self.editor.active_mut().snippet_session = exp.session;
+        self.snippet_select_current();
+        true
+    }
+
+    /// Look up the word before the cursor in the active buffer's language
+    /// snippet store; if there's a match, delete the word and expand the
+    /// snippet in its place.
+    fn expand_snippet_at_cursor(&mut self) {
+        let lang_id = self.editor.active().syntax.language.config_key();
+        if lang_id.is_empty() {
+            self.status_error = Some("Snippets need a recognised language".into());
+            return;
+        }
+        let cursor_byte = self.editor.active().buffer.cursors.primary().byte_offset;
+        let rope = self.editor.active().buffer.rope();
+        let probe = cursor_byte.saturating_sub(1);
+        let Some((wstart, wend)) = crate::buffer::cursor::word_span_at(rope, probe) else {
+            self.status_error = Some("Place the cursor after a snippet prefix".into());
+            return;
+        };
+        if wend < cursor_byte {
+            self.status_error = Some("Place the cursor after a snippet prefix".into());
+            return;
+        }
+        let prefix: String = rope.byte_slice(wstart..wend).chars().collect();
+        let matches = self.snippets.lookup(lang_id, &prefix);
+        let Some(snip) = matches.into_iter().next() else {
+            self.status_error = Some(format!("No snippet named '{prefix}'"));
+            return;
+        };
+        let parsed = snip.parse_body();
+        // Compute the expansion text and session at the prefix start position
+        // since we're about to delete the prefix.
+        let exp = crate::snippet::session::SnippetSession::expand_at(&parsed, wstart);
+        let buf = &mut self.editor.active_mut().buffer;
+        buf.begin_batch();
+        buf.delete_range(wstart, wend);
+        // Move the primary cursor to wstart before inserting so insert lands
+        // at the right location regardless of prior selection state.
+        *buf.cursors.primary_mut() =
+            crate::buffer::cursor::Cursor::from_byte_offset(buf.rope(), wstart);
+        buf.cursors.primary_mut().selection = None;
+        buf.insert_str(&exp.text);
+        buf.commit_batch();
+        self.editor.active_mut().snippet_session = exp.session;
+        // Jump cursor to the first tab stop, selecting its default text.
+        self.snippet_select_current();
+    }
+
+    /// Select the byte range of the current snippet tab stop. Called after
+    /// expanding or advancing the session.
+    fn snippet_select_current(&mut self) {
+        let handle = self.editor.active_mut();
+        let range = match &handle.snippet_session {
+            Some(s) => s.current_range(),
+            None => return,
+        };
+        let len = handle.buffer.rope().len_bytes();
+        let bound_start = range.start.min(len);
+        let bound_end = range.end.min(len);
+        let new_cursor = {
+            let rope = handle.buffer.rope();
+            crate::buffer::cursor::Cursor::from_byte_offset(rope, bound_end)
+        };
+        let primary = handle.buffer.cursors.primary_mut();
+        *primary = new_cursor;
+        if bound_end > bound_start {
+            primary.selection = Some(crate::buffer::cursor::Selection {
+                anchor: bound_start,
+                active: bound_end,
+            });
+        } else {
+            primary.selection = None;
+        }
+    }
+
+    /// Move the active snippet session forward (`true`) or backward.
+    fn snippet_advance(&mut self, forward: bool) {
+        let advanced = match self.editor.active_mut().snippet_session.as_mut() {
+            Some(s) => {
+                if forward {
+                    s.next_stop()
+                } else {
+                    s.prev_stop()
+                }
+            }
+            None => false,
+        };
+        if advanced {
+            self.snippet_select_current();
+        } else {
+            self.editor.active_mut().snippet_session = None;
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -202,6 +202,86 @@ impl FuzzyPickerState {
     }
 }
 
+// ── Symbol-in-file picker state ──────────────────────────────────────────
+
+/// State for the Ctrl+Shift+O symbol-in-file picker. Mirrors
+/// [`FuzzyPickerState`] but scores against symbol names rather than file
+/// paths and tracks each symbol's byte range so `Enter` can jump the cursor.
+pub struct SymbolPickerState {
+    pub query: String,
+    /// All symbols collected from the active buffer's parse tree.
+    pub all_symbols: Vec<crate::syntax::Symbol>,
+    /// Scored and sorted (score DESC) indices into `all_symbols`.
+    pub filtered: Vec<(u32, usize)>,
+    /// Currently highlighted row.
+    pub selected: usize,
+}
+
+impl SymbolPickerState {
+    /// Build with the symbols already collected from the active buffer.
+    pub fn new(symbols: Vec<crate::syntax::Symbol>) -> Self {
+        let n = symbols.len();
+        let filtered = (0..n).map(|i| (0u32, i)).collect();
+        Self {
+            query: String::new(),
+            all_symbols: symbols,
+            filtered,
+            selected: 0,
+        }
+    }
+
+    /// Re-score against the current query using nucleo. Empty query shows
+    /// every symbol in source order.
+    pub fn update_query(&mut self, query: String) {
+        self.query = query;
+        self.selected = 0;
+
+        if self.query.is_empty() {
+            let n = self.all_symbols.len();
+            self.filtered = (0..n).map(|i| (0u32, i)).collect();
+            return;
+        }
+
+        use nucleo::pattern::{CaseMatching, Normalization, Pattern};
+        use nucleo::{Config, Matcher, Utf32String};
+
+        let mut matcher = Matcher::new(Config::DEFAULT);
+        let pattern = Pattern::parse(&self.query, CaseMatching::Smart, Normalization::Smart);
+
+        let mut scored: Vec<(u32, usize)> = self
+            .all_symbols
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, sym)| {
+                let haystack = Utf32String::from(sym.name.as_str());
+                pattern
+                    .score(haystack.slice(..), &mut matcher)
+                    .map(|sc| (sc, idx))
+            })
+            .collect();
+        scored.sort_by_key(|b| std::cmp::Reverse(b.0));
+        self.filtered = scored;
+    }
+
+    pub fn selected_symbol(&self) -> Option<&crate::syntax::Symbol> {
+        self.filtered
+            .get(self.selected)
+            .map(|(_, idx)| &self.all_symbols[*idx])
+    }
+
+    pub fn move_up(&mut self) {
+        if self.selected > 0 {
+            self.selected -= 1;
+        }
+    }
+
+    pub fn move_down(&mut self) {
+        if !self.filtered.is_empty() && self.selected < self.filtered.len() - 1 {
+            self.selected += 1;
+        }
+    }
+}
+
 // ── Project search overlay state ───────────────────────────────────────────
 
 /// State for the project-wide search-and-replace overlay (Ctrl+Shift+F).
@@ -777,6 +857,7 @@ pub struct AppState {
     pub clipboard: ClipboardManager,
     pub input_mode: InputMode,
     pub fuzzy_picker: Option<FuzzyPickerState>,
+    pub symbol_picker: Option<SymbolPickerState>,
     pub sidebar: Option<SidebarState>,
     pub sidebar_focused: bool,
     /// Current sidebar width in columns (excluding the 1-col separator).
@@ -900,6 +981,7 @@ impl AppState {
             clipboard: ClipboardManager::new(),
             input_mode: InputMode::Normal,
             fuzzy_picker: None,
+            symbol_picker: None,
             sidebar: None,
             sidebar_focused: false,
             sidebar_width: DEFAULT_SIDEBAR_WIDTH,
@@ -1060,6 +1142,12 @@ impl AppState {
         // Fuzzy picker — captured input
         if self.fuzzy_picker.is_some() {
             self.handle_fuzzy_picker(action);
+            return;
+        }
+
+        // Symbol picker — captured input
+        if self.symbol_picker.is_some() {
+            self.handle_symbol_picker(action);
             return;
         }
 
@@ -1675,6 +1763,15 @@ impl AppState {
             EditorAction::OpenFuzzyPicker => {
                 self.fuzzy_picker = Some(FuzzyPickerState::new());
             }
+            EditorAction::OpenSymbolPicker => {
+                let active = self.editor.active();
+                let symbols = active.syntax.collect_symbols(active.buffer.rope());
+                if symbols.is_empty() {
+                    self.status_error = Some("No symbols found in this buffer".to_string());
+                } else {
+                    self.symbol_picker = Some(SymbolPickerState::new(symbols));
+                }
+            }
             EditorAction::ToggleSidebar => {
                 if self.sidebar.is_none() {
                     // Restore saved state or create fresh, then expand to current file.
@@ -2175,6 +2272,57 @@ impl AppState {
             }
             EditorAction::Quit | EditorAction::CloseSearch | EditorAction::Unhandled => {
                 self.fuzzy_picker = None;
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_symbol_picker(&mut self, action: EditorAction) {
+        if self.symbol_picker.is_none() {
+            return;
+        }
+        match action {
+            EditorAction::InsertChar(c) => {
+                if let Some(picker) = &mut self.symbol_picker {
+                    let mut q = picker.query.clone();
+                    q.push(c);
+                    picker.update_query(q);
+                }
+            }
+            EditorAction::DeleteBackward => {
+                if let Some(picker) = &mut self.symbol_picker {
+                    let mut q = picker.query.clone();
+                    q.pop();
+                    picker.update_query(q);
+                }
+            }
+            EditorAction::MoveCursor(Direction::Up) => {
+                if let Some(picker) = &mut self.symbol_picker {
+                    picker.move_up();
+                }
+            }
+            EditorAction::MoveCursor(Direction::Down) => {
+                if let Some(picker) = &mut self.symbol_picker {
+                    picker.move_down();
+                }
+            }
+            EditorAction::InsertNewline => {
+                let target = self
+                    .symbol_picker
+                    .as_ref()
+                    .and_then(|p| p.selected_symbol().cloned());
+                self.symbol_picker = None;
+                if let Some(sym) = target {
+                    let handle = self.editor.active_mut();
+                    let rope = handle.buffer.rope();
+                    let bound = sym.byte_range.start.min(rope.len_bytes());
+                    *handle.buffer.cursors.primary_mut() =
+                        crate::buffer::cursor::Cursor::from_byte_offset(rope, bound);
+                    handle.buffer.cursors.collapse_to_primary();
+                }
+            }
+            EditorAction::Quit | EditorAction::CloseSearch | EditorAction::Unhandled => {
+                self.symbol_picker = None;
             }
             _ => {}
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -78,6 +78,10 @@ pub enum InputMode {
     SetMarkChar,
     /// Ctrl+': "Jump to mark: " — auto-submits on the next typed char.
     JumpToMarkChar,
+    /// "Record macro into slot: " — next char names the slot a–z.
+    RecordMacroChar,
+    /// "Replay macro from slot: " — next char names the slot a–z.
+    ReplayMacroChar,
 }
 
 impl InputMode {
@@ -866,6 +870,8 @@ pub struct AppState {
     pub jumps: crate::marks::JumpList,
     /// Lazy-loaded snippet store, populated per language on first use.
     pub snippets: crate::snippet::SnippetStore,
+    /// In-memory keyboard macro state (recording, slots, replay flag).
+    pub macros: crate::macros::MacroState,
     pub sidebar: Option<SidebarState>,
     pub sidebar_focused: bool,
     /// Current sidebar width in columns (excluding the 1-col separator).
@@ -993,6 +999,7 @@ impl AppState {
             marks: crate::marks::NamedMarks::load(&workspace),
             jumps: crate::marks::JumpList::load(&workspace),
             snippets: crate::snippet::SnippetStore::new(),
+            macros: crate::macros::MacroState::new(),
             sidebar: None,
             sidebar_focused: false,
             sidebar_width: DEFAULT_SIDEBAR_WIDTH,
@@ -1059,6 +1066,12 @@ impl AppState {
 
         // Clear transient status error on any user interaction.
         self.status_error = None;
+
+        // Append to the in-progress macro recording (if any). The state's
+        // own `replaying` flag suppresses re-recording during playback.
+        if crate::macros::is_recordable(&action) {
+            self.macros.append(&action);
+        }
 
         // Capture undo depth before dispatch so we can detect actual buffer edits below.
         let pre_undo_depth = self.editor.active().buffer.undo_depth();
@@ -1839,6 +1852,23 @@ impl AppState {
             EditorAction::SnippetCancel => {
                 self.editor.active_mut().snippet_session = None;
             }
+            EditorAction::BeginRecordMacro => {
+                if self.macros.recording_slot().is_some() {
+                    if let Some(slot) = self.macros.stop_recording() {
+                        self.status_error = Some(format!("Recorded macro '{slot}'"));
+                    }
+                } else {
+                    self.input_mode = InputMode::RecordMacroChar;
+                }
+            }
+            EditorAction::StopRecordMacro => {
+                if let Some(slot) = self.macros.stop_recording() {
+                    self.status_error = Some(format!("Recorded macro '{slot}'"));
+                }
+            }
+            EditorAction::BeginReplayMacro => {
+                self.input_mode = InputMode::ReplayMacroChar;
+            }
             EditorAction::ToggleSidebar => {
                 if self.sidebar.is_none() {
                     // Restore saved state or create fresh, then expand to current file.
@@ -2198,6 +2228,16 @@ impl AppState {
                     }
                     return;
                 }
+                InputMode::RecordMacroChar => {
+                    self.input_mode = InputMode::Normal;
+                    self.macros.start_recording(c);
+                    return;
+                }
+                InputMode::ReplayMacroChar => {
+                    self.input_mode = InputMode::Normal;
+                    self.replay_macro_slot(c);
+                    return;
+                }
                 _ => {}
             }
         }
@@ -2239,7 +2279,11 @@ impl AppState {
                     | InputMode::AlignChar(s) => {
                         s.pop();
                     }
-                    InputMode::Normal | InputMode::SetMarkChar | InputMode::JumpToMarkChar => {}
+                    InputMode::Normal
+                    | InputMode::SetMarkChar
+                    | InputMode::JumpToMarkChar
+                    | InputMode::RecordMacroChar
+                    | InputMode::ReplayMacroChar => {}
                 }
                 return;
             }
@@ -2348,7 +2392,11 @@ impl AppState {
                             self.editor.active_mut().buffer.align_on(c);
                         }
                     }
-                    InputMode::Normal | InputMode::SetMarkChar | InputMode::JumpToMarkChar => {}
+                    InputMode::Normal
+                    | InputMode::SetMarkChar
+                    | InputMode::JumpToMarkChar
+                    | InputMode::RecordMacroChar
+                    | InputMode::ReplayMacroChar => {}
                 }
             }
             EditorAction::Quit | EditorAction::Unhandled => {
@@ -4129,6 +4177,25 @@ impl AppState {
         } else {
             self.git_gutter = None;
         }
+    }
+
+    /// Replay the actions stored in macro slot `slot`. Wraps the playback in
+    /// a single undo batch so the entire sequence collapses to one undo step,
+    /// and sets the replay flag so the actions are not re-recorded if the
+    /// user starts a new recording mid-replay.
+    fn replay_macro_slot(&mut self, slot: char) {
+        let Some(actions) = self.macros.play(slot) else {
+            self.status_error = Some(format!("No macro in slot '{slot}'"));
+            return;
+        };
+        let term_h = self.term_height;
+        self.macros.set_replaying(true);
+        self.editor.active_mut().buffer.begin_batch();
+        for action in actions {
+            self.update(action, term_h);
+        }
+        self.editor.active_mut().buffer.commit_batch();
+        self.macros.set_replaying(false);
     }
 
     /// Same logic as `expand_snippet_at_cursor` but silent: returns `false`

--- a/src/buffer/folds.rs
+++ b/src/buffer/folds.rs
@@ -1,0 +1,223 @@
+//! Code-folding state for a single buffer.
+//!
+//! Folds are addressed by their **start line number** (0-indexed). Each line
+//! number is paired with its current end-line so the editor can hide every
+//! row in between. After every reparse, [`FoldState::refresh`] re-derives
+//! candidates from the tree-sitter parse tree and reconciles the user's
+//! existing folded set with the new candidate ranges so the active folds
+//! stay in sync as the buffer is edited.
+
+use std::collections::BTreeMap;
+
+use ropey::Rope;
+
+use crate::buffer::cursor::ByteRange;
+
+/// Per-buffer fold state.
+#[derive(Default)]
+pub struct FoldState {
+    /// Every line range that *could* be folded, derived from the parse tree
+    /// on the most recent refresh. Keyed by start line; value is end line.
+    candidates: BTreeMap<usize, usize>,
+    /// Subset of `candidates` whose start lines are currently folded.
+    folded: BTreeMap<usize, usize>,
+}
+
+impl FoldState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Re-derive candidates from `byte_ranges` (typically the output of
+    /// [`crate::syntax::SyntaxHost::fold_ranges`]) and drop any folded entry
+    /// whose start line no longer maps to a candidate.
+    pub fn refresh(&mut self, rope: &Rope, byte_ranges: &[ByteRange]) {
+        let mut new_candidates = BTreeMap::new();
+        let total_lines = rope.len_lines();
+        for r in byte_ranges {
+            let s = r.start.min(rope.len_bytes());
+            let e = r.end.min(rope.len_bytes());
+            let start_line = rope.byte_to_line(s);
+            let end_line = rope.byte_to_line(e);
+            if end_line > start_line && start_line < total_lines {
+                // Keep the *largest* end-line if multiple ranges share the same start.
+                new_candidates
+                    .entry(start_line)
+                    .and_modify(|v| {
+                        if end_line > *v {
+                            *v = end_line;
+                        }
+                    })
+                    .or_insert(end_line);
+            }
+        }
+        // Reconcile the folded set with the new candidate map.
+        self.folded
+            .retain(|start, _| new_candidates.contains_key(start));
+        for (start, end) in self.folded.iter_mut() {
+            if let Some(&new_end) = new_candidates.get(start) {
+                *end = new_end;
+            }
+        }
+        self.candidates = new_candidates;
+    }
+
+    /// Toggle the fold whose start line is `line`. If `line` isn't itself a
+    /// fold-start, fall back to the innermost fold that contains `line`.
+    /// Returns `true` when the toggle took effect.
+    pub fn toggle_at_line(&mut self, line: usize) -> bool {
+        // Innermost candidate containing `line`.
+        let target = self
+            .candidates
+            .iter()
+            .filter(|(s, e)| **s <= line && line <= **e)
+            .max_by_key(|(s, _)| **s)
+            .map(|(s, e)| (*s, *e));
+        match target {
+            Some((s, e)) => {
+                if self.folded.remove(&s).is_some() {
+                    return true;
+                }
+                self.folded.insert(s, e);
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Fold every candidate.
+    pub fn fold_all(&mut self) {
+        self.folded = self.candidates.clone();
+    }
+
+    /// Unfold every candidate.
+    pub fn unfold_all(&mut self) {
+        self.folded.clear();
+    }
+
+    /// True when `line` lies strictly *inside* (not on the start line of) any
+    /// currently folded range. Used by the renderer to skip hidden rows.
+    pub fn is_line_hidden(&self, line: usize) -> bool {
+        self.folded
+            .iter()
+            .any(|(&start, &end)| line > start && line <= end)
+    }
+
+    /// True when `line` is the start of a currently folded range — the
+    /// gutter should show a `▸` chevron.
+    pub fn is_fold_start_folded(&self, line: usize) -> bool {
+        self.folded.contains_key(&line)
+    }
+
+    /// True when `line` is a candidate fold start (whether currently folded
+    /// or not) — the gutter can show a faint `▾` chevron.
+    pub fn is_fold_start_candidate(&self, line: usize) -> bool {
+        self.candidates.contains_key(&line)
+    }
+
+    /// End-line of the folded range starting at `line`, if it's folded.
+    pub fn folded_end_line(&self, line: usize) -> Option<usize> {
+        self.folded.get(&line).copied()
+    }
+
+    /// Total count of currently folded regions — for tests.
+    #[allow(dead_code)]
+    pub fn folded_count(&self) -> usize {
+        self.folded.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ropey::Rope;
+
+    fn rope_with_lines(n: usize) -> Rope {
+        let mut s = String::new();
+        for i in 0..n {
+            s.push_str(&format!("line {i}\n"));
+        }
+        Rope::from_str(&s)
+    }
+
+    fn byte_range_for_lines(rope: &Rope, start_line: usize, end_line: usize) -> ByteRange {
+        let s = rope.line_to_byte(start_line);
+        // Use start of end_line's next line so the range spans through end_line.
+        let next = (end_line + 1).min(rope.len_lines());
+        let e = if next == rope.len_lines() {
+            rope.len_bytes()
+        } else {
+            rope.line_to_byte(next).saturating_sub(1)
+        };
+        ByteRange::new(s, e)
+    }
+
+    #[test]
+    fn refresh_promotes_candidates_only() {
+        let rope = rope_with_lines(10);
+        let ranges = vec![byte_range_for_lines(&rope, 1, 5)];
+        let mut fs = FoldState::new();
+        fs.refresh(&rope, &ranges);
+        assert!(fs.is_fold_start_candidate(1));
+        assert!(!fs.is_fold_start_folded(1));
+        assert_eq!(fs.folded_count(), 0);
+    }
+
+    #[test]
+    fn toggle_folds_and_unfolds() {
+        let rope = rope_with_lines(10);
+        let ranges = vec![byte_range_for_lines(&rope, 2, 6)];
+        let mut fs = FoldState::new();
+        fs.refresh(&rope, &ranges);
+        assert!(fs.toggle_at_line(2));
+        assert!(fs.is_fold_start_folded(2));
+        assert!(fs.is_line_hidden(3));
+        assert!(fs.is_line_hidden(6));
+        assert!(!fs.is_line_hidden(2));
+        assert!(!fs.is_line_hidden(7));
+        // Toggle again — unfolded.
+        assert!(fs.toggle_at_line(2));
+        assert!(!fs.is_fold_start_folded(2));
+    }
+
+    #[test]
+    fn fold_all_and_unfold_all() {
+        let rope = rope_with_lines(10);
+        let ranges = vec![
+            byte_range_for_lines(&rope, 0, 3),
+            byte_range_for_lines(&rope, 5, 8),
+        ];
+        let mut fs = FoldState::new();
+        fs.refresh(&rope, &ranges);
+        fs.fold_all();
+        assert_eq!(fs.folded_count(), 2);
+        fs.unfold_all();
+        assert_eq!(fs.folded_count(), 0);
+    }
+
+    #[test]
+    fn refresh_drops_stale_folds() {
+        let rope = rope_with_lines(10);
+        let r1 = byte_range_for_lines(&rope, 1, 5);
+        let mut fs = FoldState::new();
+        fs.refresh(&rope, &[r1]);
+        fs.toggle_at_line(1);
+        assert!(fs.is_fold_start_folded(1));
+        // Reparse with no candidate at line 1 — the fold should be dropped.
+        fs.refresh(&rope, &[]);
+        assert!(!fs.is_fold_start_folded(1));
+    }
+
+    #[test]
+    fn toggle_inside_range_folds_the_outer() {
+        let rope = rope_with_lines(20);
+        let outer = byte_range_for_lines(&rope, 1, 18);
+        let inner = byte_range_for_lines(&rope, 5, 10);
+        let mut fs = FoldState::new();
+        fs.refresh(&rope, &[outer, inner]);
+        // Cursor on line 7: the innermost candidate (line 5..10) folds.
+        assert!(fs.toggle_at_line(7));
+        assert!(fs.is_fold_start_folded(5));
+        assert!(!fs.is_fold_start_folded(1));
+    }
+}

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -1,5 +1,6 @@
 pub mod cursor;
 pub mod edit;
+pub mod folds;
 pub mod history;
 
 use ropey::Rope;

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -24,6 +24,10 @@ pub struct Buffer {
     pub cursors: MultiCursor,
     /// True if the buffer has unsaved changes.
     pub modified: bool,
+    /// Edits recorded since the last call to `drain_pending_edits`. Used by
+    /// AppState to forward edits to marks, jumps, and other off-buffer
+    /// structures that track byte offsets.
+    pending_edits: Vec<EditCommand>,
 }
 
 impl Buffer {
@@ -34,6 +38,7 @@ impl Buffer {
             history: UndoStack::new(),
             cursors: MultiCursor::new(),
             modified: false,
+            pending_edits: Vec::new(),
         }
     }
 
@@ -45,9 +50,26 @@ impl Buffer {
             history: UndoStack::new(),
             cursors: MultiCursor::new(),
             modified: false,
+            pending_edits: Vec::new(),
         }
     }
 
+    /// Drain edits recorded since the last call. Returned commands have
+    /// already been applied to the buffer — callers use them to rebase
+    /// off-buffer byte offsets (marks, jumps, fold ranges).
+    pub fn drain_pending_edits(&mut self) -> Vec<EditCommand> {
+        std::mem::take(&mut self.pending_edits)
+    }
+}
+
+/// Append `cmd` to both the undo history and the pending-edits queue, so
+/// AppState's post-action sweep can forward edits to off-buffer trackers.
+fn record(history: &mut UndoStack, pending: &mut Vec<EditCommand>, cmd: EditCommand) {
+    pending.push(cmd.clone());
+    history.record(cmd);
+}
+
+impl Buffer {
     // ------------------------------------------------------------------ //
     // Rope accessors (read-only)
     // ------------------------------------------------------------------ //
@@ -192,11 +214,15 @@ impl Buffer {
         let at = if cursor.has_selection() {
             let range = cursor.selection_bytes();
             let deleted = rope_edit::delete(&mut self.rope, range.start, range.end);
-            self.history.record(EditCommand::Delete {
-                start: range.start,
-                end: range.end,
-                deleted,
-            });
+            record(
+                &mut self.history,
+                &mut self.pending_edits,
+                EditCommand::Delete {
+                    start: range.start,
+                    end: range.end,
+                    deleted,
+                },
+            );
             cursor.byte_offset = range.start;
             cursor.selection = None;
             range.start
@@ -205,10 +231,14 @@ impl Buffer {
         };
 
         rope_edit::insert(&mut self.rope, at, text);
-        self.history.record(EditCommand::Insert {
-            at,
-            text: text.to_string(),
-        });
+        record(
+            &mut self.history,
+            &mut self.pending_edits,
+            EditCommand::Insert {
+                at,
+                text: text.to_string(),
+            },
+        );
 
         // Move cursor to after the inserted text
         let new_offset = at + text.len();
@@ -256,11 +286,15 @@ impl Buffer {
             return;
         }
         let deleted = rope_edit::delete(&mut self.rope, start, end);
-        self.history.record(EditCommand::Delete {
-            start,
-            end,
-            deleted,
-        });
+        record(
+            &mut self.history,
+            &mut self.pending_edits,
+            EditCommand::Delete {
+                start,
+                end,
+                deleted,
+            },
+        );
         *self.cursors.primary_mut() = Cursor::from_byte_offset(&self.rope, start);
         self.cursors.primary_mut().selection = None;
         self.modified = true;
@@ -331,10 +365,14 @@ impl Buffer {
         for line in (first_line..=last_line).rev() {
             let start = self.line_start_byte(line);
             rope_edit::insert(&mut self.rope, start, &unit);
-            self.history.record(EditCommand::Insert {
-                at: start,
-                text: unit.clone(),
-            });
+            record(
+                &mut self.history,
+                &mut self.pending_edits,
+                EditCommand::Insert {
+                    at: start,
+                    text: unit.clone(),
+                },
+            );
             for off in tracked.iter_mut() {
                 if *off >= start {
                     *off += unit_bytes;
@@ -387,11 +425,15 @@ impl Buffer {
         for (start, strip) in strips.iter().rev() {
             let end = start + strip.len();
             let deleted = rope_edit::delete(&mut self.rope, *start, end);
-            self.history.record(EditCommand::Delete {
-                start: *start,
-                end,
-                deleted,
-            });
+            record(
+                &mut self.history,
+                &mut self.pending_edits,
+                EditCommand::Delete {
+                    start: *start,
+                    end,
+                    deleted,
+                },
+            );
             let strip_len = strip.len();
             for off in tracked.iter_mut() {
                 if *off >= end {
@@ -450,11 +492,15 @@ impl Buffer {
         self.history.begin_batch();
         let strip_end = line_start + strip.len();
         let deleted = rope_edit::delete(&mut self.rope, line_start, strip_end);
-        self.history.record(EditCommand::Delete {
-            start: line_start,
-            end: strip_end,
-            deleted,
-        });
+        record(
+            &mut self.history,
+            &mut self.pending_edits,
+            EditCommand::Delete {
+                start: line_start,
+                end: strip_end,
+                deleted,
+            },
+        );
         let new_offset = cursor.byte_offset - strip.len();
         *self.cursors.primary_mut() = Cursor::from_byte_offset(&self.rope, new_offset);
         let mut s = String::with_capacity(c.len_utf8());
@@ -1046,11 +1092,15 @@ impl Buffer {
             if op.del_end > op.ins_pt {
                 let del_len = op.del_end - op.ins_pt;
                 let deleted = rope_edit::delete(&mut self.rope, op.ins_pt, op.del_end);
-                self.history.record(EditCommand::Delete {
-                    start: op.ins_pt,
-                    end: op.del_end,
-                    deleted,
-                });
+                record(
+                    &mut self.history,
+                    &mut self.pending_edits,
+                    EditCommand::Delete {
+                        start: op.ins_pt,
+                        end: op.del_end,
+                        deleted,
+                    },
+                );
                 // Deletion at [ins_pt, del_end) shifts all tracked positions >= del_end down.
                 for pos in new_positions.iter_mut() {
                     if *pos >= op.del_end {
@@ -1059,10 +1109,14 @@ impl Buffer {
                 }
             }
             rope_edit::insert(&mut self.rope, op.ins_pt, text);
-            self.history.record(EditCommand::Insert {
-                at: op.ins_pt,
-                text: text.to_string(),
-            });
+            record(
+                &mut self.history,
+                &mut self.pending_edits,
+                EditCommand::Insert {
+                    at: op.ins_pt,
+                    text: text.to_string(),
+                },
+            );
             // Insertion at ins_pt shifts all tracked positions >= ins_pt up.
             // (Processed descending, so all previously-set positions are above ins_pt.)
             for pos in new_positions.iter_mut() {
@@ -1156,11 +1210,15 @@ impl Buffer {
         for op in &ops {
             let del_len = op.del_end - op.del_start;
             let deleted = rope_edit::delete(&mut self.rope, op.del_start, op.del_end);
-            self.history.record(EditCommand::Delete {
-                start: op.del_start,
-                end: op.del_end,
-                deleted,
-            });
+            record(
+                &mut self.history,
+                &mut self.pending_edits,
+                EditCommand::Delete {
+                    start: op.del_start,
+                    end: op.del_end,
+                    deleted,
+                },
+            );
             // Deletion at [del_start, del_end) shifts all tracked positions >= del_end down.
             for pos in new_positions.iter_mut() {
                 if *pos >= op.del_end {
@@ -1251,11 +1309,15 @@ impl Buffer {
         for op in &ops {
             let del_len = op.del_end - op.del_start;
             let deleted = rope_edit::delete(&mut self.rope, op.del_start, op.del_end);
-            self.history.record(EditCommand::Delete {
-                start: op.del_start,
-                end: op.del_end,
-                deleted,
-            });
+            record(
+                &mut self.history,
+                &mut self.pending_edits,
+                EditCommand::Delete {
+                    start: op.del_start,
+                    end: op.del_end,
+                    deleted,
+                },
+            );
             // Deletion at [del_start, del_end) shifts all tracked positions >= del_end down.
             for pos in new_positions.iter_mut() {
                 if *pos >= op.del_end {
@@ -1301,12 +1363,16 @@ impl Buffer {
         let new_text = new_lines.join("\n");
         self.history.begin_batch();
         let old_text = rope_edit::replace(&mut self.rope, start, end, &new_text);
-        self.history.record(EditCommand::Replace {
-            start,
-            end,
-            old_text,
-            new_text: new_text.clone(),
-        });
+        record(
+            &mut self.history,
+            &mut self.pending_edits,
+            EditCommand::Replace {
+                start,
+                end,
+                old_text,
+                new_text: new_text.clone(),
+            },
+        );
         self.history.commit_batch();
         let new_offset = start + new_text.len();
         *self.cursors.primary_mut() = Cursor::from_byte_offset(&self.rope, new_offset);
@@ -1423,12 +1489,16 @@ impl Buffer {
         }
         self.history.begin_batch();
         let old_text = rope_edit::replace(&mut self.rope, range.start, range.end, &transformed);
-        self.history.record(EditCommand::Replace {
-            start: range.start,
-            end: range.end,
-            old_text,
-            new_text: transformed.clone(),
-        });
+        record(
+            &mut self.history,
+            &mut self.pending_edits,
+            EditCommand::Replace {
+                start: range.start,
+                end: range.end,
+                old_text,
+                new_text: transformed.clone(),
+            },
+        );
         self.history.commit_batch();
         let new_end = range.start + transformed.len();
         *self.cursors.primary_mut() = Cursor::from_byte_offset(&self.rope, new_end);
@@ -1485,12 +1555,16 @@ impl Buffer {
         let joined = joined.trim_end_matches(' ').to_string();
         self.history.begin_batch();
         let old_text = rope_edit::replace(&mut self.rope, range.start, range.end, &joined);
-        self.history.record(EditCommand::Replace {
-            start: range.start,
-            end: range.end,
-            old_text,
-            new_text: joined.clone(),
-        });
+        record(
+            &mut self.history,
+            &mut self.pending_edits,
+            EditCommand::Replace {
+                start: range.start,
+                end: range.end,
+                old_text,
+                new_text: joined.clone(),
+            },
+        );
         self.history.commit_batch();
         let new_offset = range.start + joined.len();
         *self.cursors.primary_mut() = Cursor::from_byte_offset(&self.rope, new_offset);
@@ -1600,12 +1674,16 @@ impl Buffer {
                 None => format!("{}", h.original),
             };
             let old_text = rope_edit::replace(&mut self.rope, h.start, h.end, &new_str);
-            self.history.record(EditCommand::Replace {
-                start: h.start,
-                end: h.end,
-                old_text,
-                new_text: new_str.clone(),
-            });
+            record(
+                &mut self.history,
+                &mut self.pending_edits,
+                EditCommand::Replace {
+                    start: h.start,
+                    end: h.end,
+                    old_text,
+                    new_text: new_str.clone(),
+                },
+            );
             // Adjust new_positions for this edit.
             let old_len = h.end - h.start;
             let new_len = new_str.len();
@@ -1721,12 +1799,16 @@ impl Buffer {
         let len = self.rope.len_bytes();
         self.history.begin_batch();
         let old_text = rope_edit::replace(&mut self.rope, 0, len, &new_text);
-        self.history.record(EditCommand::Replace {
-            start: 0,
-            end: len,
-            old_text,
-            new_text: new_text.clone(),
-        });
+        record(
+            &mut self.history,
+            &mut self.pending_edits,
+            EditCommand::Replace {
+                start: 0,
+                end: len,
+                old_text,
+                new_text: new_text.clone(),
+            },
+        );
         self.history.commit_batch();
         *self.cursors.primary_mut() = Cursor::from_byte_offset(&self.rope, 0);
         self.cursors.primary_mut().selection = None;
@@ -1814,19 +1896,27 @@ impl Buffer {
 
         // Replace b first (higher offset) so a's offsets stay valid.
         let old_b = rope_edit::replace(&mut self.rope, b_start, b_end, &line_a);
-        self.history.record(EditCommand::Replace {
-            start: b_start,
-            end: b_end,
-            old_text: old_b,
-            new_text: line_a.clone(),
-        });
+        record(
+            &mut self.history,
+            &mut self.pending_edits,
+            EditCommand::Replace {
+                start: b_start,
+                end: b_end,
+                old_text: old_b,
+                new_text: line_a.clone(),
+            },
+        );
         let old_a = rope_edit::replace(&mut self.rope, a_start, a_end, &line_b);
-        self.history.record(EditCommand::Replace {
-            start: a_start,
-            end: a_end,
-            old_text: old_a,
-            new_text: line_b,
-        });
+        record(
+            &mut self.history,
+            &mut self.pending_edits,
+            EditCommand::Replace {
+                start: a_start,
+                end: a_end,
+                old_text: old_a,
+                new_text: line_b,
+            },
+        );
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -98,6 +98,10 @@ pub struct Config {
     /// `[80, 120]`. Empty disables rulers.
     #[serde(default)]
     pub rulers: Vec<usize>,
+    /// Show a sticky header row at the top of the editor pane displaying the
+    /// enclosing function/class/module of the cursor's position.
+    #[serde(default = "default_sticky_header")]
+    pub sticky_header: bool,
 }
 
 fn default_tab_size() -> usize {
@@ -105,6 +109,10 @@ fn default_tab_size() -> usize {
 }
 
 fn default_indent_guides() -> bool {
+    true
+}
+
+fn default_sticky_header() -> bool {
     true
 }
 
@@ -123,6 +131,7 @@ impl Default for Config {
             disable_shell_filter: false,
             indent_guides: default_indent_guides(),
             rulers: Vec::new(),
+            sticky_header: default_sticky_header(),
         }
     }
 }
@@ -303,6 +312,7 @@ mod tests {
             disable_shell_filter: false,
             indent_guides: false,
             rulers: vec![80, 120],
+            sticky_header: false,
         };
         let serialized = toml::to_string(&original).unwrap();
         let deserialized: Config = toml::from_str(&serialized).unwrap();

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -90,10 +90,22 @@ pub struct Config {
     /// undesirable; default `false`.
     #[serde(default)]
     pub disable_shell_filter: bool,
+    /// Render light vertical guides at every indent multiple inside the
+    /// leading whitespace of each line.
+    #[serde(default = "default_indent_guides")]
+    pub indent_guides: bool,
+    /// Display columns at which to render a light vertical ruler line, e.g.
+    /// `[80, 120]`. Empty disables rulers.
+    #[serde(default)]
+    pub rulers: Vec<usize>,
 }
 
 fn default_tab_size() -> usize {
     4
+}
+
+fn default_indent_guides() -> bool {
+    true
 }
 
 impl Default for Config {
@@ -109,6 +121,8 @@ impl Default for Config {
             last_seen_version: None,
             formatting: FormattingConfig::default(),
             disable_shell_filter: false,
+            indent_guides: default_indent_guides(),
+            rulers: Vec::new(),
         }
     }
 }
@@ -287,6 +301,8 @@ mod tests {
             last_seen_version: Some("0.3.0".to_string()),
             formatting: FormattingConfig::default(),
             disable_shell_filter: false,
+            indent_guides: false,
+            rulers: vec![80, 120],
         };
         let serialized = toml::to_string(&original).unwrap();
         let deserialized: Config = toml::from_str(&serialized).unwrap();
@@ -304,6 +320,20 @@ mod tests {
         let toml_text = "disable_shell_filter = true\n";
         let cfg: Config = toml::from_str(toml_text).unwrap();
         assert!(cfg.disable_shell_filter);
+    }
+
+    #[test]
+    fn indent_guides_default_true() {
+        let cfg = Config::default();
+        assert!(cfg.indent_guides);
+        assert!(cfg.rulers.is_empty());
+    }
+
+    #[test]
+    fn rulers_round_trip_through_toml() {
+        let toml_text = "rulers = [80, 100, 120]\n";
+        let cfg: Config = toml::from_str(toml_text).unwrap();
+        assert_eq!(cfg.rulers, vec![80, 100, 120]);
     }
 
     #[test]

--- a/src/editor/tab.rs
+++ b/src/editor/tab.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use crate::buffer::Buffer;
+use crate::buffer::folds::FoldState;
 use crate::editor::viewport::Viewport;
 use crate::editorconfig::{EditorConfigOverrides, load_for_file};
 use crate::lsp::types::{DiagSeverity, LspDiagnostic, SemanticTokenSpan};
@@ -58,6 +59,9 @@ pub struct BufferHandle {
     /// Per-buffer overrides resolved from `.editorconfig`. Empty for buffers
     /// without a path or when no `.editorconfig` is found.
     pub editorconfig: EditorConfigOverrides,
+    /// Code-folding state, derived from the tree-sitter parse tree after
+    /// every reparse.
+    pub folds: FoldState,
 }
 
 impl BufferHandle {
@@ -71,6 +75,7 @@ impl BufferHandle {
             syntax: SyntaxHost::new(),
             lsp_state: LspState::new(),
             editorconfig: EditorConfigOverrides::default(),
+            folds: FoldState::new(),
         }
     }
 
@@ -86,6 +91,8 @@ impl BufferHandle {
         syntax.set_language(lang);
         syntax.reparse_rope(buffer.rope());
         let editorconfig = load_for_file(&path);
+        let mut folds = FoldState::new();
+        folds.refresh(buffer.rope(), &syntax.fold_ranges(buffer.rope()));
 
         Ok(Self {
             id,
@@ -95,6 +102,7 @@ impl BufferHandle {
             syntax,
             lsp_state: LspState::new(),
             editorconfig,
+            folds,
         })
     }
 
@@ -149,6 +157,8 @@ impl BufferHandle {
     pub fn reparse(&mut self) {
         let rope = self.buffer.rope().clone();
         self.syntax.reparse_rope(&rope);
+        let ranges = self.syntax.fold_ranges(&rope);
+        self.folds.refresh(&rope, &ranges);
     }
 }
 

--- a/src/editor/tab.rs
+++ b/src/editor/tab.rs
@@ -5,6 +5,7 @@ use crate::buffer::folds::FoldState;
 use crate::editor::viewport::Viewport;
 use crate::editorconfig::{EditorConfigOverrides, load_for_file};
 use crate::lsp::types::{DiagSeverity, LspDiagnostic, SemanticTokenSpan};
+use crate::snippet::session::SnippetSession;
 use crate::syntax::{SyntaxHost, language::Lang};
 
 pub type BufferId = usize;
@@ -62,6 +63,9 @@ pub struct BufferHandle {
     /// Code-folding state, derived from the tree-sitter parse tree after
     /// every reparse.
     pub folds: FoldState,
+    /// Active snippet session, if a snippet has been expanded and the user
+    /// hasn't yet finished cycling through its tab stops.
+    pub snippet_session: Option<SnippetSession>,
 }
 
 impl BufferHandle {
@@ -76,6 +80,7 @@ impl BufferHandle {
             lsp_state: LspState::new(),
             editorconfig: EditorConfigOverrides::default(),
             folds: FoldState::new(),
+            snippet_session: None,
         }
     }
 
@@ -103,6 +108,7 @@ impl BufferHandle {
             lsp_state: LspState::new(),
             editorconfig,
             folds,
+            snippet_session: None,
         })
     }
 

--- a/src/editor/tab.rs
+++ b/src/editor/tab.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use crate::buffer::Buffer;
 use crate::editor::viewport::Viewport;
+use crate::editorconfig::{EditorConfigOverrides, load_for_file};
 use crate::lsp::types::{DiagSeverity, LspDiagnostic, SemanticTokenSpan};
 use crate::syntax::{SyntaxHost, language::Lang};
 
@@ -54,6 +55,9 @@ pub struct BufferHandle {
     pub path: Option<PathBuf>,
     pub syntax: SyntaxHost,
     pub lsp_state: LspState,
+    /// Per-buffer overrides resolved from `.editorconfig`. Empty for buffers
+    /// without a path or when no `.editorconfig` is found.
+    pub editorconfig: EditorConfigOverrides,
 }
 
 impl BufferHandle {
@@ -66,6 +70,7 @@ impl BufferHandle {
             path: None,
             syntax: SyntaxHost::new(),
             lsp_state: LspState::new(),
+            editorconfig: EditorConfigOverrides::default(),
         }
     }
 
@@ -80,6 +85,7 @@ impl BufferHandle {
         let mut syntax = SyntaxHost::new();
         syntax.set_language(lang);
         syntax.reparse_rope(buffer.rope());
+        let editorconfig = load_for_file(&path);
 
         Ok(Self {
             id,
@@ -88,6 +94,7 @@ impl BufferHandle {
             path: Some(path),
             syntax,
             lsp_state: LspState::new(),
+            editorconfig,
         })
     }
 
@@ -97,14 +104,17 @@ impl BufferHandle {
             .path
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("No file path — use Save As"))?;
-        std::fs::write(path, self.buffer.to_string())?;
+        let text = serialise_for_save(&self.buffer.to_string(), &self.editorconfig);
+        std::fs::write(path, text)?;
         self.buffer.modified = false;
         Ok(())
     }
 
     /// Save to a new path and update the stored path.
     pub fn save_as(&mut self, path: PathBuf) -> anyhow::Result<()> {
-        std::fs::write(&path, self.buffer.to_string())?;
+        let editorconfig = load_for_file(&path);
+        let text = serialise_for_save(&self.buffer.to_string(), &editorconfig);
+        std::fs::write(&path, text)?;
         // Re-detect language when the path changes.
         let new_lang = Lang::from_path(&path);
         if new_lang != self.syntax.language {
@@ -113,6 +123,7 @@ impl BufferHandle {
         }
         self.path = Some(path);
         self.buffer.modified = false;
+        self.editorconfig = editorconfig;
         Ok(())
     }
 
@@ -138,5 +149,122 @@ impl BufferHandle {
     pub fn reparse(&mut self) {
         let rope = self.buffer.rope().clone();
         self.syntax.reparse_rope(&rope);
+    }
+}
+
+/// Apply `.editorconfig`-driven serialisation tweaks to `text` before writing
+/// to disk: trim trailing whitespace from each line, normalise EOLs, and add
+/// a trailing newline when requested.
+pub(crate) fn serialise_for_save(text: &str, overrides: &EditorConfigOverrides) -> String {
+    use crate::editorconfig::EolStyle;
+    let trim = overrides.trim_trailing_whitespace.unwrap_or(false);
+    let final_nl = overrides.insert_final_newline.unwrap_or(false);
+    let eol = overrides.end_of_line;
+
+    // Split on `\n` so we can rebuild with the requested EOL. If the original
+    // ends in `\n`, the split yields an empty trailing element.
+    let mut lines: Vec<String> = text
+        .split('\n')
+        .map(|l| {
+            let l = l.strip_suffix('\r').unwrap_or(l);
+            if trim {
+                l.trim_end_matches([' ', '\t']).to_string()
+            } else {
+                l.to_string()
+            }
+        })
+        .collect();
+
+    // Determine the EOL string. If `end_of_line` is unset, leave the
+    // existing line endings untouched (use `\n` since we just split on it,
+    // which is the dominant form for files we open).
+    let eol_str = match eol {
+        Some(EolStyle::Lf) => "\n",
+        Some(EolStyle::Crlf) => "\r\n",
+        Some(EolStyle::Cr) => "\r",
+        None => "\n",
+    };
+
+    // Drop the trailing empty element if it's present so we control whether
+    // a final newline is added.
+    let had_trailing_newline = matches!(lines.last(), Some(s) if s.is_empty());
+    if had_trailing_newline {
+        lines.pop();
+    }
+
+    let mut out = lines.join(eol_str);
+    let want_final = if overrides.insert_final_newline.is_some() {
+        final_nl
+    } else {
+        had_trailing_newline
+    };
+    if want_final && !out.is_empty() {
+        out.push_str(eol_str);
+    } else if want_final && out.is_empty() && !lines.is_empty() {
+        // Edge case: a file containing only blank lines.
+        out.push_str(eol_str);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::editorconfig::EolStyle;
+    use crate::formatting::IndentStyle;
+
+    #[test]
+    fn serialise_no_overrides_passes_text_through() {
+        let s = serialise_for_save("hello\nworld\n", &EditorConfigOverrides::default());
+        assert_eq!(s, "hello\nworld\n");
+    }
+
+    #[test]
+    fn serialise_trim_trailing_whitespace_strips_spaces_and_tabs() {
+        let o = EditorConfigOverrides {
+            trim_trailing_whitespace: Some(true),
+            ..Default::default()
+        };
+        let s = serialise_for_save("hello   \nworld\t\n", &o);
+        assert_eq!(s, "hello\nworld\n");
+    }
+
+    #[test]
+    fn serialise_insert_final_newline_adds_one_when_missing() {
+        let o = EditorConfigOverrides {
+            insert_final_newline: Some(true),
+            ..Default::default()
+        };
+        let s = serialise_for_save("no_newline_here", &o);
+        assert_eq!(s, "no_newline_here\n");
+    }
+
+    #[test]
+    fn serialise_insert_final_newline_false_strips_one() {
+        let o = EditorConfigOverrides {
+            insert_final_newline: Some(false),
+            ..Default::default()
+        };
+        let s = serialise_for_save("trailing\n", &o);
+        assert_eq!(s, "trailing");
+    }
+
+    #[test]
+    fn serialise_eol_crlf_replaces_lf() {
+        let o = EditorConfigOverrides {
+            end_of_line: Some(EolStyle::Crlf),
+            ..Default::default()
+        };
+        let s = serialise_for_save("a\nb\nc\n", &o);
+        assert_eq!(s, "a\r\nb\r\nc\r\n");
+    }
+
+    #[test]
+    fn editorconfig_overrides_default_indent_style_is_unset() {
+        let o = EditorConfigOverrides::default();
+        assert!(o.indent_style.is_none());
+        assert!(o.indent_size.is_none());
+        // Sanity: IndentStyle is reachable through this module's imports.
+        let _ = IndentStyle::Spaces;
     }
 }

--- a/src/editorconfig/mod.rs
+++ b/src/editorconfig/mod.rs
@@ -1,0 +1,427 @@
+//! Minimal `.editorconfig` parser and resolver.
+//!
+//! Walks parent directories from a file path looking for `.editorconfig`
+//! files and merges the matching sections into a single
+//! [`EditorConfigOverrides`] value. Only the editor-relevant keys are read
+//! (`indent_style`, `indent_size`, `tab_width`, `end_of_line`,
+//! `insert_final_newline`, `trim_trailing_whitespace`); other keys are
+//! ignored. Pattern matching covers the dialects seen in the wild —
+//! `*`, `*.ext`, `*.{ext1,ext2}`, exact filenames — and falls through to a
+//! literal compare for anything fancier.
+//!
+//! Used by [`crate::editor::tab::BufferHandle`] when opening a file: the
+//! resolved overrides override the equivalent fields from the global config.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::formatting::IndentStyle;
+
+/// EOL style read from `.editorconfig`. Plain enum for serialisation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum EolStyle {
+    Lf,
+    Crlf,
+    Cr,
+}
+
+/// Per-buffer overrides resolved from `.editorconfig`. Every field is
+/// optional — `None` means "fall through to the global config".
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct EditorConfigOverrides {
+    pub indent_style: Option<IndentStyle>,
+    pub indent_size: Option<usize>,
+    pub tab_width: Option<usize>,
+    pub end_of_line: Option<EolStyle>,
+    pub insert_final_newline: Option<bool>,
+    pub trim_trailing_whitespace: Option<bool>,
+}
+
+impl EditorConfigOverrides {
+    /// Effective indent width: `indent_size` if set, otherwise `tab_width`,
+    /// otherwise `None`.
+    pub fn effective_width(&self) -> Option<usize> {
+        self.indent_size.or(self.tab_width)
+    }
+
+    /// Merge `other` on top of `self` (later wins). Used when walking from
+    /// outer `.editorconfig` to inner.
+    fn merge_in(&mut self, other: &Self) {
+        if other.indent_style.is_some() {
+            self.indent_style = other.indent_style;
+        }
+        if other.indent_size.is_some() {
+            self.indent_size = other.indent_size;
+        }
+        if other.tab_width.is_some() {
+            self.tab_width = other.tab_width;
+        }
+        if other.end_of_line.is_some() {
+            self.end_of_line = other.end_of_line;
+        }
+        if other.insert_final_newline.is_some() {
+            self.insert_final_newline = other.insert_final_newline;
+        }
+        if other.trim_trailing_whitespace.is_some() {
+            self.trim_trailing_whitespace = other.trim_trailing_whitespace;
+        }
+    }
+}
+
+/// One `[pattern]` section parsed out of an `.editorconfig`.
+struct Section {
+    pattern: String,
+    overrides: EditorConfigOverrides,
+}
+
+/// One `.editorconfig` file parsed: the `root = true` flag and the sections.
+struct ParsedFile {
+    root: bool,
+    sections: Vec<Section>,
+}
+
+/// Resolve `.editorconfig` overrides for `path`.
+///
+/// Walks from `path`'s parent directory up to the filesystem root, parsing
+/// every `.editorconfig` it finds. Stops walking when a file with
+/// `root = true` is encountered (per the EditorConfig spec). Returns
+/// [`EditorConfigOverrides`] with the merged settings; outer files contribute
+/// first, inner files override.
+pub fn load_for_file(path: &Path) -> EditorConfigOverrides {
+    let mut files: Vec<(PathBuf, ParsedFile)> = Vec::new();
+    let mut dir = path.parent().map(PathBuf::from);
+    while let Some(d) = dir {
+        let candidate = d.join(".editorconfig");
+        if let Ok(text) = std::fs::read_to_string(&candidate) {
+            let parsed = parse_text(&text);
+            let stop = parsed.root;
+            files.push((d.clone(), parsed));
+            if stop {
+                break;
+            }
+        }
+        dir = d.parent().map(PathBuf::from);
+    }
+    // Apply outer (last in walk) to inner (first in walk).
+    let mut merged = EditorConfigOverrides::default();
+    for (config_dir, parsed) in files.iter().rev() {
+        for section in &parsed.sections {
+            if pattern_matches(&section.pattern, path, config_dir) {
+                merged.merge_in(&section.overrides);
+            }
+        }
+    }
+    merged
+}
+
+/// Parse the textual contents of one `.editorconfig` file.
+fn parse_text(text: &str) -> ParsedFile {
+    let mut root = false;
+    let mut sections: Vec<Section> = Vec::new();
+    let mut current_pattern: Option<String> = None;
+
+    for raw in text.lines() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix('[')
+            && let Some(close) = rest.find(']')
+        {
+            let pattern = rest[..close].trim().to_string();
+            current_pattern = Some(pattern.clone());
+            sections.push(Section {
+                pattern,
+                overrides: EditorConfigOverrides::default(),
+            });
+            continue;
+        }
+        let (key, value) = match line.split_once('=') {
+            Some((k, v)) => (k.trim().to_ascii_lowercase(), v.trim().to_string()),
+            None => continue,
+        };
+        let value_lc = value.to_ascii_lowercase();
+
+        if current_pattern.is_none() {
+            // Pre-section keys: only `root` is meaningful.
+            if key == "root" && parse_bool(&value_lc) == Some(true) {
+                root = true;
+            }
+            continue;
+        }
+        let section = sections
+            .last_mut()
+            .expect("current_pattern implies section");
+        match key.as_str() {
+            "indent_style" => match value_lc.as_str() {
+                "tab" => section.overrides.indent_style = Some(IndentStyle::Tabs),
+                "space" => section.overrides.indent_style = Some(IndentStyle::Spaces),
+                _ => {}
+            },
+            "indent_size" => {
+                if let Ok(n) = value_lc.parse::<usize>() {
+                    section.overrides.indent_size = Some(n);
+                }
+                // "tab" means "follow tab_width" — leave indent_size unset.
+            }
+            "tab_width" => {
+                if let Ok(n) = value_lc.parse::<usize>() {
+                    section.overrides.tab_width = Some(n);
+                }
+            }
+            "end_of_line" => {
+                section.overrides.end_of_line = match value_lc.as_str() {
+                    "lf" => Some(EolStyle::Lf),
+                    "crlf" => Some(EolStyle::Crlf),
+                    "cr" => Some(EolStyle::Cr),
+                    _ => None,
+                };
+            }
+            "insert_final_newline" => {
+                section.overrides.insert_final_newline = parse_bool(&value_lc);
+            }
+            "trim_trailing_whitespace" => {
+                section.overrides.trim_trailing_whitespace = parse_bool(&value_lc);
+            }
+            _ => {}
+        }
+    }
+    ParsedFile { root, sections }
+}
+
+fn parse_bool(value: &str) -> Option<bool> {
+    match value {
+        "true" => Some(true),
+        "false" => Some(false),
+        _ => None,
+    }
+}
+
+/// Match a glob-ish `pattern` from a section header against `path`, where
+/// `config_dir` is the directory containing the `.editorconfig` file.
+///
+/// Supports the patterns seen in nearly all real-world `.editorconfig`
+/// files: `*`, `*.ext`, `*.{a,b,c}`, exact filenames, and `**/...` prefixes.
+/// Falls back to a literal filename compare for anything else.
+fn pattern_matches(pattern: &str, path: &Path, config_dir: &Path) -> bool {
+    // Strip a leading `/` (which in EditorConfig means "rooted at config_dir").
+    let pattern = pattern.trim_start_matches('/');
+
+    // Compute the file's path relative to the config directory, falling back
+    // to the file name only if the rebase fails.
+    let rel = path.strip_prefix(config_dir).ok();
+    let rel_str = rel.map(|r| r.to_string_lossy().replace('\\', "/"));
+    let file_name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    // Strip a leading `**/` — match any number of intermediate directories.
+    let pattern = pattern.trim_start_matches("**/");
+
+    // Pattern with brace expansion: `*.{a,b}` → try each branch.
+    if let Some(open) = pattern.find('{')
+        && let Some(close) = pattern[open..].find('}')
+    {
+        let prefix = &pattern[..open];
+        let suffix = &pattern[open + close + 1..];
+        let alts = pattern[open + 1..open + close].split(',');
+        for alt in alts {
+            let expanded = format!("{prefix}{}{suffix}", alt.trim());
+            if pattern_matches_simple(&expanded, &file_name, rel_str.as_deref()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    pattern_matches_simple(pattern, &file_name, rel_str.as_deref())
+}
+
+/// Match a brace-free pattern. Handles `*`, `*.ext`, `name.*`, exact name.
+fn pattern_matches_simple(pattern: &str, file_name: &str, rel: Option<&str>) -> bool {
+    if pattern == "*" {
+        return true;
+    }
+    if let Some(ext_pat) = pattern.strip_prefix("*.") {
+        // `*.ext` → file ends with `.ext` (no directory wildcard handling).
+        return file_name
+            .rsplit_once('.')
+            .map(|(_, ext)| ext == ext_pat)
+            .unwrap_or(false);
+    }
+    if let Some(prefix) = pattern.strip_suffix(".*") {
+        return file_name
+            .rsplit_once('.')
+            .map(|(stem, _)| stem == prefix)
+            .unwrap_or(false);
+    }
+    // Pattern with a directory separator is matched against the relative path
+    // first, falling back to a no-match.
+    if pattern.contains('/') {
+        return rel.map(|r| r == pattern).unwrap_or(false);
+    }
+    pattern == file_name
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn parse_root_flag() {
+        let p = parse_text("root = true\n[*]\nindent_style = space\n");
+        assert!(p.root);
+        assert_eq!(p.sections.len(), 1);
+        assert_eq!(p.sections[0].pattern, "*");
+        assert_eq!(
+            p.sections[0].overrides.indent_style,
+            Some(IndentStyle::Spaces)
+        );
+    }
+
+    #[test]
+    fn parse_indent_size_and_eol() {
+        let text = r#"
+[*.rs]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+"#;
+        let p = parse_text(text);
+        let s = &p.sections[0];
+        assert_eq!(s.overrides.indent_style, Some(IndentStyle::Spaces));
+        assert_eq!(s.overrides.indent_size, Some(2));
+        assert_eq!(s.overrides.end_of_line, Some(EolStyle::Lf));
+        assert_eq!(s.overrides.insert_final_newline, Some(true));
+        assert_eq!(s.overrides.trim_trailing_whitespace, Some(true));
+    }
+
+    #[test]
+    fn parse_indent_size_tab_falls_back_to_tab_width() {
+        let p = parse_text("[*]\nindent_style = tab\nindent_size = tab\ntab_width = 8\n");
+        assert_eq!(
+            p.sections[0].overrides.indent_style,
+            Some(IndentStyle::Tabs)
+        );
+        assert_eq!(p.sections[0].overrides.indent_size, None);
+        assert_eq!(p.sections[0].overrides.tab_width, Some(8));
+        assert_eq!(p.sections[0].overrides.effective_width(), Some(8));
+    }
+
+    #[test]
+    fn parse_ignores_comments_and_blank_lines() {
+        let text = "# header\n\n; semicolon comment\n[*]\nindent_size = 4\n# tail\n";
+        let p = parse_text(text);
+        assert_eq!(p.sections.len(), 1);
+        assert_eq!(p.sections[0].overrides.indent_size, Some(4));
+    }
+
+    #[test]
+    fn pattern_star_matches_any_filename() {
+        let dir = Path::new("/tmp");
+        assert!(pattern_matches("*", Path::new("/tmp/foo.rs"), dir));
+        assert!(pattern_matches("*", Path::new("/tmp/bar"), dir));
+    }
+
+    #[test]
+    fn pattern_extension() {
+        let dir = Path::new("/tmp");
+        assert!(pattern_matches("*.rs", Path::new("/tmp/main.rs"), dir));
+        assert!(!pattern_matches("*.rs", Path::new("/tmp/main.py"), dir));
+    }
+
+    #[test]
+    fn pattern_brace_alternatives() {
+        let dir = Path::new("/tmp");
+        assert!(pattern_matches("*.{js,py}", Path::new("/tmp/x.js"), dir));
+        assert!(pattern_matches("*.{js,py}", Path::new("/tmp/x.py"), dir));
+        assert!(!pattern_matches("*.{js,py}", Path::new("/tmp/x.rs"), dir));
+    }
+
+    #[test]
+    fn pattern_double_star_prefix_treated_as_recursive() {
+        let dir = Path::new("/tmp");
+        assert!(pattern_matches(
+            "**/*.rs",
+            Path::new("/tmp/sub/main.rs"),
+            dir
+        ));
+    }
+
+    #[test]
+    fn pattern_exact_filename() {
+        let dir = Path::new("/tmp");
+        assert!(pattern_matches("Makefile", Path::new("/tmp/Makefile"), dir));
+        assert!(!pattern_matches("Makefile", Path::new("/tmp/Other"), dir));
+    }
+
+    #[test]
+    fn merge_in_later_wins() {
+        let mut a = EditorConfigOverrides {
+            indent_style: Some(IndentStyle::Tabs),
+            indent_size: Some(4),
+            ..Default::default()
+        };
+        let b = EditorConfigOverrides {
+            indent_size: Some(2),
+            insert_final_newline: Some(true),
+            ..Default::default()
+        };
+        a.merge_in(&b);
+        assert_eq!(a.indent_style, Some(IndentStyle::Tabs));
+        assert_eq!(a.indent_size, Some(2));
+        assert_eq!(a.insert_final_newline, Some(true));
+    }
+
+    #[test]
+    fn load_for_file_reads_temp_editorconfig() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let cfg_path = dir.path().join(".editorconfig");
+        let mut f = std::fs::File::create(&cfg_path).unwrap();
+        writeln!(
+            f,
+            "root = true\n[*.rs]\nindent_style = space\nindent_size = 2"
+        )
+        .unwrap();
+        let target = dir.path().join("main.rs");
+        std::fs::write(&target, "").unwrap();
+        let o = load_for_file(&target);
+        assert_eq!(o.indent_style, Some(IndentStyle::Spaces));
+        assert_eq!(o.indent_size, Some(2));
+    }
+
+    #[test]
+    fn load_for_file_root_stops_upward_walk() {
+        use std::io::Write;
+        let outer = tempfile::tempdir().unwrap();
+        let inner = outer.path().join("project");
+        std::fs::create_dir(&inner).unwrap();
+        // Outer config: should be IGNORED because inner has root = true.
+        let mut o_cfg = std::fs::File::create(outer.path().join(".editorconfig")).unwrap();
+        writeln!(o_cfg, "[*]\nindent_size = 8").unwrap();
+        let mut i_cfg = std::fs::File::create(inner.join(".editorconfig")).unwrap();
+        writeln!(i_cfg, "root = true\n[*]\nindent_size = 2").unwrap();
+        let target = inner.join("foo.rs");
+        std::fs::write(&target, "").unwrap();
+        let o = load_for_file(&target);
+        assert_eq!(o.indent_size, Some(2));
+    }
+
+    #[test]
+    fn load_for_file_missing_returns_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("foo.rs");
+        std::fs::write(&target, "").unwrap();
+        let o = load_for_file(&target);
+        assert_eq!(o, EditorConfigOverrides::default());
+    }
+}

--- a/src/input/action.rs
+++ b/src/input/action.rs
@@ -216,6 +216,15 @@ pub enum EditorAction {
     BeginSetMark,
     /// Begin a jump-to-mark prompt; the next typed character (a–z) selects.
     BeginJumpToMark,
+    /// Look up a snippet whose prefix matches the word before the cursor and
+    /// expand it in-place. Bound to Ctrl+J by default.
+    ExpandSnippetAtCursor,
+    /// While a snippet session is active, advance to the next tab stop.
+    SnippetNextStop,
+    /// While a snippet session is active, walk back to the previous stop.
+    SnippetPrevStop,
+    /// Cancel the active snippet session (Esc).
+    SnippetCancel,
     /// Toggle the file tree sidebar visibility (Ctrl+Shift+B).
     ToggleSidebar,
     /// Focus-jump between the editor and the sidebar (Ctrl+B).
@@ -408,6 +417,10 @@ pub fn action_to_name(action: &EditorAction) -> Option<&'static str> {
         EditorAction::JumpListForward => "jump_list_forward",
         EditorAction::BeginSetMark => "set_mark",
         EditorAction::BeginJumpToMark => "jump_to_mark",
+        EditorAction::ExpandSnippetAtCursor => "expand_snippet",
+        EditorAction::SnippetNextStop => "snippet_next_stop",
+        EditorAction::SnippetPrevStop => "snippet_prev_stop",
+        EditorAction::SnippetCancel => "snippet_cancel",
         EditorAction::ToggleSidebar => "toggle_sidebar",
         EditorAction::FocusSidebar => "focus_sidebar",
         // View / UI toggles
@@ -555,6 +568,10 @@ pub fn action_from_name(name: &str) -> Option<EditorAction> {
         "jump_list_forward" => EditorAction::JumpListForward,
         "set_mark" => EditorAction::BeginSetMark,
         "jump_to_mark" => EditorAction::BeginJumpToMark,
+        "expand_snippet" => EditorAction::ExpandSnippetAtCursor,
+        "snippet_next_stop" => EditorAction::SnippetNextStop,
+        "snippet_prev_stop" => EditorAction::SnippetPrevStop,
+        "snippet_cancel" => EditorAction::SnippetCancel,
         "toggle_sidebar" => EditorAction::ToggleSidebar,
         "focus_sidebar" => EditorAction::FocusSidebar,
         // View / UI toggles

--- a/src/input/action.rs
+++ b/src/input/action.rs
@@ -200,6 +200,8 @@ pub enum EditorAction {
     JumpToLine,
     /// Open the fuzzy file picker overlay (Ctrl+P).
     OpenFuzzyPicker,
+    /// Open the symbols-in-file picker overlay (Ctrl+Shift+O).
+    OpenSymbolPicker,
     /// Toggle the file tree sidebar visibility (Ctrl+Shift+B).
     ToggleSidebar,
     /// Focus-jump between the editor and the sidebar (Ctrl+B).
@@ -384,6 +386,7 @@ pub fn action_to_name(action: &EditorAction) -> Option<&'static str> {
         EditorAction::OpenFile => "open_file",
         EditorAction::JumpToLine => "jump_to_line",
         EditorAction::OpenFuzzyPicker => "open_fuzzy_picker",
+        EditorAction::OpenSymbolPicker => "open_symbol_picker",
         EditorAction::ToggleSidebar => "toggle_sidebar",
         EditorAction::FocusSidebar => "focus_sidebar",
         // View / UI toggles
@@ -523,6 +526,7 @@ pub fn action_from_name(name: &str) -> Option<EditorAction> {
         "open_file" => EditorAction::OpenFile,
         "jump_to_line" => EditorAction::JumpToLine,
         "open_fuzzy_picker" => EditorAction::OpenFuzzyPicker,
+        "open_symbol_picker" => EditorAction::OpenSymbolPicker,
         "toggle_sidebar" => EditorAction::ToggleSidebar,
         "focus_sidebar" => EditorAction::FocusSidebar,
         // View / UI toggles

--- a/src/input/action.rs
+++ b/src/input/action.rs
@@ -208,6 +208,14 @@ pub enum EditorAction {
     FoldAll,
     /// Unfold every region in the active buffer.
     UnfoldAll,
+    /// Walk one step backward in the workspace-wide jump list (Alt+Left).
+    JumpListBack,
+    /// Walk one step forward in the workspace-wide jump list (Alt+Right).
+    JumpListForward,
+    /// Begin a mark prompt; the next typed character (a–z) names the mark.
+    BeginSetMark,
+    /// Begin a jump-to-mark prompt; the next typed character (a–z) selects.
+    BeginJumpToMark,
     /// Toggle the file tree sidebar visibility (Ctrl+Shift+B).
     ToggleSidebar,
     /// Focus-jump between the editor and the sidebar (Ctrl+B).
@@ -396,6 +404,10 @@ pub fn action_to_name(action: &EditorAction) -> Option<&'static str> {
         EditorAction::ToggleFoldAtCursor => "toggle_fold_at_cursor",
         EditorAction::FoldAll => "fold_all",
         EditorAction::UnfoldAll => "unfold_all",
+        EditorAction::JumpListBack => "jump_list_back",
+        EditorAction::JumpListForward => "jump_list_forward",
+        EditorAction::BeginSetMark => "set_mark",
+        EditorAction::BeginJumpToMark => "jump_to_mark",
         EditorAction::ToggleSidebar => "toggle_sidebar",
         EditorAction::FocusSidebar => "focus_sidebar",
         // View / UI toggles
@@ -539,6 +551,10 @@ pub fn action_from_name(name: &str) -> Option<EditorAction> {
         "toggle_fold_at_cursor" => EditorAction::ToggleFoldAtCursor,
         "fold_all" => EditorAction::FoldAll,
         "unfold_all" => EditorAction::UnfoldAll,
+        "jump_list_back" => EditorAction::JumpListBack,
+        "jump_list_forward" => EditorAction::JumpListForward,
+        "set_mark" => EditorAction::BeginSetMark,
+        "jump_to_mark" => EditorAction::BeginJumpToMark,
         "toggle_sidebar" => EditorAction::ToggleSidebar,
         "focus_sidebar" => EditorAction::FocusSidebar,
         // View / UI toggles

--- a/src/input/action.rs
+++ b/src/input/action.rs
@@ -225,6 +225,15 @@ pub enum EditorAction {
     SnippetPrevStop,
     /// Cancel the active snippet session (Esc).
     SnippetCancel,
+    /// Begin a macro-recording prompt; the next typed character (a–z) names
+    /// the slot. Pressing the same hotkey while a recording is active stops
+    /// it instead of starting a new one.
+    BeginRecordMacro,
+    /// Stop the in-progress macro recording. Bound to Ctrl+Shift+R while a
+    /// recording is active (the same hotkey toggles).
+    StopRecordMacro,
+    /// Begin a replay prompt; the next typed char (a–z) selects the slot.
+    BeginReplayMacro,
     /// Toggle the file tree sidebar visibility (Ctrl+Shift+B).
     ToggleSidebar,
     /// Focus-jump between the editor and the sidebar (Ctrl+B).
@@ -421,6 +430,9 @@ pub fn action_to_name(action: &EditorAction) -> Option<&'static str> {
         EditorAction::SnippetNextStop => "snippet_next_stop",
         EditorAction::SnippetPrevStop => "snippet_prev_stop",
         EditorAction::SnippetCancel => "snippet_cancel",
+        EditorAction::BeginRecordMacro => "record_macro",
+        EditorAction::StopRecordMacro => "stop_recording_macro",
+        EditorAction::BeginReplayMacro => "replay_macro",
         EditorAction::ToggleSidebar => "toggle_sidebar",
         EditorAction::FocusSidebar => "focus_sidebar",
         // View / UI toggles
@@ -572,6 +584,9 @@ pub fn action_from_name(name: &str) -> Option<EditorAction> {
         "snippet_next_stop" => EditorAction::SnippetNextStop,
         "snippet_prev_stop" => EditorAction::SnippetPrevStop,
         "snippet_cancel" => EditorAction::SnippetCancel,
+        "record_macro" => EditorAction::BeginRecordMacro,
+        "stop_recording_macro" => EditorAction::StopRecordMacro,
+        "replay_macro" => EditorAction::BeginReplayMacro,
         "toggle_sidebar" => EditorAction::ToggleSidebar,
         "focus_sidebar" => EditorAction::FocusSidebar,
         // View / UI toggles

--- a/src/input/action.rs
+++ b/src/input/action.rs
@@ -202,6 +202,12 @@ pub enum EditorAction {
     OpenFuzzyPicker,
     /// Open the symbols-in-file picker overlay (Ctrl+Shift+O).
     OpenSymbolPicker,
+    /// Toggle the fold at the cursor's line (Ctrl+Shift+[).
+    ToggleFoldAtCursor,
+    /// Fold every candidate region in the active buffer.
+    FoldAll,
+    /// Unfold every region in the active buffer.
+    UnfoldAll,
     /// Toggle the file tree sidebar visibility (Ctrl+Shift+B).
     ToggleSidebar,
     /// Focus-jump between the editor and the sidebar (Ctrl+B).
@@ -387,6 +393,9 @@ pub fn action_to_name(action: &EditorAction) -> Option<&'static str> {
         EditorAction::JumpToLine => "jump_to_line",
         EditorAction::OpenFuzzyPicker => "open_fuzzy_picker",
         EditorAction::OpenSymbolPicker => "open_symbol_picker",
+        EditorAction::ToggleFoldAtCursor => "toggle_fold_at_cursor",
+        EditorAction::FoldAll => "fold_all",
+        EditorAction::UnfoldAll => "unfold_all",
         EditorAction::ToggleSidebar => "toggle_sidebar",
         EditorAction::FocusSidebar => "focus_sidebar",
         // View / UI toggles
@@ -527,6 +536,9 @@ pub fn action_from_name(name: &str) -> Option<EditorAction> {
         "jump_to_line" => EditorAction::JumpToLine,
         "open_fuzzy_picker" => EditorAction::OpenFuzzyPicker,
         "open_symbol_picker" => EditorAction::OpenSymbolPicker,
+        "toggle_fold_at_cursor" => EditorAction::ToggleFoldAtCursor,
+        "fold_all" => EditorAction::FoldAll,
+        "unfold_all" => EditorAction::UnfoldAll,
         "toggle_sidebar" => EditorAction::ToggleSidebar,
         "focus_sidebar" => EditorAction::FocusSidebar,
         // View / UI toggles

--- a/src/input/keybinding.rs
+++ b/src/input/keybinding.rs
@@ -211,7 +211,7 @@ fn parse_named_key(name: &str) -> Result<KeyCodeRepr, String> {
 /// (e.g. swapping what `ctrl+d` does). On load, files older than this are
 /// backed up to `keybindings.toml.bak-vN` and rewritten from current
 /// defaults so the change actually reaches users with a pre-existing file.
-const CURRENT_CONFIG_VERSION: u32 = 2;
+const CURRENT_CONFIG_VERSION: u32 = 3;
 
 /// Read the version header from a TOML file's text. Files without a header
 /// are treated as v1 (the implicit version before this scheme existed).
@@ -1158,9 +1158,19 @@ mod tests {
         let alt_left: KeyCombo = "alt+left".parse().unwrap();
         let in_intellij = intellij.lookup(&alt_left).cloned();
         let in_default = default.lookup(&alt_left).cloned();
+        assert_eq!(in_default, Some(EditorAction::JumpListBack));
         assert!(in_intellij.is_some());
-        assert!(in_default.is_some());
         assert_ne!(in_intellij, in_default);
+    }
+
+    #[test]
+    fn default_binds_alt_right_to_jump_list_forward() {
+        let default = KeyBindings::for_preset(&KeymapPreset::Default);
+        let alt_right: KeyCombo = "alt+right".parse().unwrap();
+        assert_eq!(
+            default.lookup(&alt_right).cloned(),
+            Some(EditorAction::JumpListForward)
+        );
     }
 
     // ── Version-gated regeneration ──────────────────────────────────────

--- a/src/input/keybinding.rs
+++ b/src/input/keybinding.rs
@@ -515,6 +515,8 @@ impl KeyBindings {
         bind("alt+right", EditorAction::JumpListForward);
         bind("ctrl+m", EditorAction::BeginSetMark);
         bind("ctrl+'", EditorAction::BeginJumpToMark);
+        bind("ctrl+shift+r", EditorAction::BeginRecordMacro);
+        bind("ctrl+alt+r", EditorAction::BeginReplayMacro);
         bind("ctrl+shift+c", EditorAction::CopyFileReference);
         bind("ctrl+shift+b", EditorAction::ToggleSidebar);
         bind("ctrl+shift+n", EditorAction::SidebarNewFolder);

--- a/src/input/keybinding.rs
+++ b/src/input/keybinding.rs
@@ -507,6 +507,7 @@ impl KeyBindings {
         bind("ctrl+shift+d", EditorAction::DuplicateLine);
         bind("ctrl+shift+p", EditorAction::OpenCommandPalette);
         bind("ctrl+shift+e", EditorAction::OpenBufferSwitcher);
+        bind("ctrl+shift+o", EditorAction::OpenSymbolPicker);
         bind("ctrl+shift+c", EditorAction::CopyFileReference);
         bind("ctrl+shift+b", EditorAction::ToggleSidebar);
         bind("ctrl+shift+n", EditorAction::SidebarNewFolder);

--- a/src/input/keybinding.rs
+++ b/src/input/keybinding.rs
@@ -508,6 +508,9 @@ impl KeyBindings {
         bind("ctrl+shift+p", EditorAction::OpenCommandPalette);
         bind("ctrl+shift+e", EditorAction::OpenBufferSwitcher);
         bind("ctrl+shift+o", EditorAction::OpenSymbolPicker);
+        bind("ctrl+shift+[", EditorAction::ToggleFoldAtCursor);
+        bind("alt+0", EditorAction::FoldAll);
+        bind("alt+shift+0", EditorAction::UnfoldAll);
         bind("ctrl+shift+c", EditorAction::CopyFileReference);
         bind("ctrl+shift+b", EditorAction::ToggleSidebar);
         bind("ctrl+shift+n", EditorAction::SidebarNewFolder);

--- a/src/input/keybinding.rs
+++ b/src/input/keybinding.rs
@@ -511,6 +511,10 @@ impl KeyBindings {
         bind("ctrl+shift+[", EditorAction::ToggleFoldAtCursor);
         bind("alt+0", EditorAction::FoldAll);
         bind("alt+shift+0", EditorAction::UnfoldAll);
+        bind("alt+left", EditorAction::JumpListBack);
+        bind("alt+right", EditorAction::JumpListForward);
+        bind("ctrl+m", EditorAction::BeginSetMark);
+        bind("ctrl+'", EditorAction::BeginJumpToMark);
         bind("ctrl+shift+c", EditorAction::CopyFileReference);
         bind("ctrl+shift+b", EditorAction::ToggleSidebar);
         bind("ctrl+shift+n", EditorAction::SidebarNewFolder);
@@ -1146,10 +1150,15 @@ mod tests {
     fn for_preset_returns_correct_type() {
         let default = KeyBindings::for_preset(&KeymapPreset::Default);
         let intellij = KeyBindings::for_preset(&KeymapPreset::IntellijIdea);
-        // IntelliJ should differ from default (word nav)
+        // IntelliJ rebinds Alt+Left to word navigation; the default keymap
+        // uses it for the jump list. Both presets must therefore have
+        // *different* actions bound to Alt+Left.
         let alt_left: KeyCombo = "alt+left".parse().unwrap();
-        assert!(intellij.lookup(&alt_left).is_some());
-        assert!(default.lookup(&alt_left).is_none());
+        let in_intellij = intellij.lookup(&alt_left).cloned();
+        let in_default = default.lookup(&alt_left).cloned();
+        assert!(in_intellij.is_some());
+        assert!(in_default.is_some());
+        assert_ne!(in_intellij, in_default);
     }
 
     // ── Version-gated regeneration ──────────────────────────────────────

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -1,0 +1,185 @@
+//! Keyboard macros — record/replay sequences of [`EditorAction`]s.
+//!
+//! Slots are addressed by a single character (`a`–`z`). Each slot owns the
+//! list of actions captured between [`MacroState::start_recording`] and
+//! [`MacroState::stop_recording`]. Replay re-feeds the captured actions
+//! through `AppState::update` inside an undo batch so the entire sequence
+//! collapses to a single undo step.
+
+use std::collections::HashMap;
+
+use crate::input::action::EditorAction;
+
+/// Per-process macro state. Lives on `AppState`.
+#[derive(Default)]
+pub struct MacroState {
+    /// Currently-recording slot + accumulator. `None` when not recording.
+    recording: Option<(char, Vec<EditorAction>)>,
+    /// Stored slots from previous recordings.
+    slots: HashMap<char, Vec<EditorAction>>,
+    /// True while a recorded macro is being played back. Recording sees this
+    /// flag and skips capturing the replayed actions (otherwise the same
+    /// macro would grow on each play).
+    replaying: bool,
+    /// Most recently used slot — used as the default for unprompted replay.
+    last_used: Option<char>,
+}
+
+impl MacroState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Start recording into `slot`. Any previous content in the slot is
+    /// discarded. Returns `false` if a recording is already in progress.
+    pub fn start_recording(&mut self, slot: char) -> bool {
+        if self.recording.is_some() {
+            return false;
+        }
+        self.recording = Some((slot, Vec::new()));
+        true
+    }
+
+    /// Stop the active recording (if any) and store its actions in the
+    /// matching slot. Returns the slot character on success.
+    pub fn stop_recording(&mut self) -> Option<char> {
+        let (slot, actions) = self.recording.take()?;
+        self.slots.insert(slot, actions);
+        self.last_used = Some(slot);
+        Some(slot)
+    }
+
+    /// Append an action to the in-progress recording if any. Ignored when
+    /// not recording. Recordable actions are filtered by the caller.
+    pub fn append(&mut self, action: &EditorAction) {
+        if self.replaying {
+            return;
+        }
+        if let Some((_, actions)) = &mut self.recording {
+            actions.push(action.clone());
+        }
+    }
+
+    /// Return a clone of the actions stored in `slot`, or `None` if the
+    /// slot is empty.
+    pub fn play(&mut self, slot: char) -> Option<Vec<EditorAction>> {
+        let acts = self.slots.get(&slot)?.clone();
+        self.last_used = Some(slot);
+        Some(acts)
+    }
+
+    /// The currently-recording slot, if any. Used by the status bar.
+    pub fn recording_slot(&self) -> Option<char> {
+        self.recording.as_ref().map(|(c, _)| *c)
+    }
+
+    /// Default slot for `BeginReplayMacro` when invoked from a hotkey.
+    #[allow(dead_code)]
+    pub fn last_used_slot(&self) -> Option<char> {
+        self.last_used
+    }
+
+    /// Acquire a guard that flips `replaying` to true for the duration of
+    /// the borrow. Dropping the returned struct restores it. Used to
+    /// suppress nested recording during playback.
+    pub fn set_replaying(&mut self, replaying: bool) {
+        self.replaying = replaying;
+    }
+
+    /// Whether a macro is currently playing back. Used by callers that need
+    /// to skip work that should only happen on the original action stream.
+    #[allow(dead_code)]
+    pub fn is_replaying(&self) -> bool {
+        self.replaying
+    }
+}
+
+/// Return `true` when `action` should be captured into the current recording.
+/// Excludes meta actions whose replay would be incoherent (mouse events,
+/// the record/play controls themselves, and `Unhandled`).
+pub fn is_recordable(action: &EditorAction) -> bool {
+    !matches!(
+        action,
+        EditorAction::MouseClick { .. }
+            | EditorAction::MouseDrag { .. }
+            | EditorAction::MouseUp { .. }
+            | EditorAction::MouseScroll { .. }
+            | EditorAction::Unhandled
+            | EditorAction::BeginRecordMacro
+            | EditorAction::BeginReplayMacro
+            | EditorAction::StopRecordMacro
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::input::action::Direction;
+
+    #[test]
+    fn record_and_play_round_trips() {
+        let mut m = MacroState::new();
+        assert!(m.start_recording('a'));
+        m.append(&EditorAction::InsertChar('h'));
+        m.append(&EditorAction::InsertChar('i'));
+        m.append(&EditorAction::MoveCursor(Direction::Left));
+        assert_eq!(m.stop_recording(), Some('a'));
+        let played = m.play('a').unwrap();
+        assert_eq!(played.len(), 3);
+    }
+
+    #[test]
+    fn start_when_already_recording_is_rejected() {
+        let mut m = MacroState::new();
+        assert!(m.start_recording('a'));
+        assert!(!m.start_recording('b'));
+    }
+
+    #[test]
+    fn play_unknown_slot_returns_none() {
+        let mut m = MacroState::new();
+        assert!(m.play('z').is_none());
+    }
+
+    #[test]
+    fn append_ignored_when_not_recording() {
+        let mut m = MacroState::new();
+        m.append(&EditorAction::InsertChar('x'));
+        assert!(m.play('a').is_none());
+    }
+
+    #[test]
+    fn append_skipped_during_replay() {
+        let mut m = MacroState::new();
+        m.start_recording('a');
+        m.set_replaying(true);
+        m.append(&EditorAction::InsertChar('x'));
+        m.set_replaying(false);
+        m.append(&EditorAction::InsertChar('y'));
+        m.stop_recording();
+        let played = m.play('a').unwrap();
+        assert_eq!(played, vec![EditorAction::InsertChar('y')]);
+    }
+
+    #[test]
+    fn is_recordable_filters_mouse_and_meta() {
+        assert!(is_recordable(&EditorAction::InsertChar('a')));
+        assert!(!is_recordable(&EditorAction::MouseClick { col: 0, row: 0 }));
+        assert!(!is_recordable(&EditorAction::BeginRecordMacro));
+        assert!(!is_recordable(&EditorAction::Unhandled));
+    }
+
+    #[test]
+    fn last_used_tracks_most_recent_slot() {
+        let mut m = MacroState::new();
+        m.start_recording('a');
+        m.stop_recording();
+        assert_eq!(m.last_used_slot(), Some('a'));
+        m.start_recording('b');
+        m.stop_recording();
+        assert_eq!(m.last_used_slot(), Some('b'));
+        // Play also updates last-used.
+        m.play('a');
+        assert_eq!(m.last_used_slot(), Some('a'));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod formatting;
 mod git;
 mod input;
 mod lsp;
+mod marks;
 mod search;
 mod syntax;
 mod theme;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod buffer;
 mod clipboard;
 mod config;
 mod editor;
+mod editorconfig;
 mod error;
 mod formatting;
 mod git;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod input;
 mod lsp;
 mod marks;
 mod search;
+mod snippet;
 mod syntax;
 mod theme;
 mod ui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod formatting;
 mod git;
 mod input;
 mod lsp;
+mod macros;
 mod marks;
 mod search;
 mod snippet;

--- a/src/marks/mod.rs
+++ b/src/marks/mod.rs
@@ -1,0 +1,438 @@
+//! Named marks and a workspace-scoped jump list.
+//!
+//! Both features track byte offsets that travel with buffer edits via
+//! [`rebase_after_edit`]. Persistence mirrors the recent-files pattern:
+//! marks live in `<workspace>/.txt/marks.json`, jumps in
+//! `<workspace>/.txt/jumps.json`. Both files are silent on I/O errors.
+//!
+//! Marks survive the buffer being closed and reopened because they are
+//! addressed by file path (canonical). The jump list is bounded at
+//! [`JUMP_LIST_CAP`] so disk usage stays predictable.
+
+use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::buffer::history::EditCommand;
+
+/// Hard cap for the jump list. Old entries fall off the front as new ones
+/// arrive.
+pub const JUMP_LIST_CAP: usize = 100;
+
+// ── Marks ────────────────────────────────────────────────────────────────
+
+/// Named marks per file, keyed by canonical file path and mark character.
+#[derive(Default)]
+pub struct NamedMarks {
+    /// Inner map: file path → mark char → byte offset.
+    by_path: HashMap<PathBuf, BTreeMap<char, usize>>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct MarksOnDisk {
+    /// Flat array of `{ path, char, offset }` entries (JSON can't key by char).
+    marks: Vec<MarkEntry>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct MarkEntry {
+    path: String,
+    char: char,
+    offset: usize,
+}
+
+impl NamedMarks {
+    #[allow(dead_code)]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn set(&mut self, path: &Path, ch: char, offset: usize) {
+        self.by_path
+            .entry(canonical(path))
+            .or_default()
+            .insert(ch, offset);
+    }
+
+    pub fn get(&self, path: &Path, ch: char) -> Option<usize> {
+        self.by_path.get(&canonical(path))?.get(&ch).copied()
+    }
+
+    /// Apply a single [`EditCommand`] to every mark stored for `path` so
+    /// offsets stay valid after a buffer edit.
+    pub fn rebase_after_edit(&mut self, path: &Path, cmd: &EditCommand) {
+        let key = canonical(path);
+        let Some(file_marks) = self.by_path.get_mut(&key) else {
+            return;
+        };
+        let mut drop_keys: Vec<char> = Vec::new();
+        for (ch, off) in file_marks.iter_mut() {
+            match rebase_offset(*off, cmd) {
+                Some(o) => *off = o,
+                None => drop_keys.push(*ch),
+            }
+        }
+        for ch in drop_keys {
+            file_marks.remove(&ch);
+        }
+        if file_marks.is_empty() {
+            self.by_path.remove(&key);
+        }
+    }
+
+    pub fn load(workspace: &Path) -> Self {
+        let path = workspace.join(".txt").join("marks.json");
+        let text = match std::fs::read_to_string(&path) {
+            Ok(t) => t,
+            Err(_) => return Self::default(),
+        };
+        let disk: MarksOnDisk = match serde_json::from_str(&text) {
+            Ok(d) => d,
+            Err(_) => return Self::default(),
+        };
+        let mut out = Self::default();
+        for entry in disk.marks {
+            out.by_path
+                .entry(PathBuf::from(entry.path))
+                .or_default()
+                .insert(entry.char, entry.offset);
+        }
+        out
+    }
+
+    pub fn save(&self, workspace: &Path) {
+        let mut marks = Vec::new();
+        for (path, file_marks) in &self.by_path {
+            for (ch, off) in file_marks {
+                marks.push(MarkEntry {
+                    path: path.to_string_lossy().into_owned(),
+                    char: *ch,
+                    offset: *off,
+                });
+            }
+        }
+        let disk = MarksOnDisk { marks };
+        let dir = workspace.join(".txt");
+        let _ = std::fs::create_dir_all(&dir);
+        if let Ok(text) = serde_json::to_string(&disk) {
+            let _ = std::fs::write(dir.join("marks.json"), text);
+        }
+    }
+}
+
+// ── Jump list ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct JumpEntry {
+    pub path: PathBuf,
+    pub byte_offset: usize,
+}
+
+#[derive(Default)]
+pub struct JumpList {
+    pub entries: VecDeque<JumpEntry>,
+    /// Position within `entries` for back/forward navigation. Equal to
+    /// `entries.len()` means "past the newest entry" — i.e. forward is empty.
+    pub cursor: usize,
+}
+
+impl JumpList {
+    #[allow(dead_code)]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Push a new jump destination. Truncates any forward entries past the
+    /// current cursor (standard "new branch when stepping back" behaviour)
+    /// and caps the list at [`JUMP_LIST_CAP`].
+    pub fn push(&mut self, entry: JumpEntry) {
+        // Drop the most recent if it's identical (avoid a streak of dupes).
+        if let Some(latest) = self.entries.get(self.cursor.saturating_sub(1))
+            && latest == &entry
+        {
+            return;
+        }
+        self.entries.truncate(self.cursor);
+        self.entries.push_back(entry);
+        while self.entries.len() > JUMP_LIST_CAP {
+            self.entries.pop_front();
+        }
+        self.cursor = self.entries.len();
+    }
+
+    /// Return the previous entry, moving the cursor back one step.
+    pub fn back(&mut self) -> Option<JumpEntry> {
+        if self.cursor <= 1 {
+            return None;
+        }
+        self.cursor -= 1;
+        self.entries.get(self.cursor - 1).cloned()
+    }
+
+    /// Return the next entry forward, moving the cursor forward one step.
+    pub fn forward(&mut self) -> Option<JumpEntry> {
+        if self.cursor >= self.entries.len() {
+            return None;
+        }
+        self.cursor += 1;
+        self.entries.get(self.cursor - 1).cloned()
+    }
+
+    /// Rebase every entry whose path matches `path` against `cmd`.
+    pub fn rebase_after_edit(&mut self, path: &Path, cmd: &EditCommand) {
+        let key = canonical(path);
+        let mut drops: Vec<usize> = Vec::new();
+        for (idx, entry) in self.entries.iter_mut().enumerate() {
+            if canonical(&entry.path) != key {
+                continue;
+            }
+            match rebase_offset(entry.byte_offset, cmd) {
+                Some(o) => entry.byte_offset = o,
+                None => drops.push(idx),
+            }
+        }
+        for idx in drops.into_iter().rev() {
+            self.entries.remove(idx);
+            if self.cursor > idx {
+                self.cursor -= 1;
+            }
+        }
+    }
+
+    pub fn load(workspace: &Path) -> Self {
+        let path = workspace.join(".txt").join("jumps.json");
+        let text = match std::fs::read_to_string(&path) {
+            Ok(t) => t,
+            Err(_) => return Self::default(),
+        };
+        let entries: Vec<JumpEntry> = serde_json::from_str(&text).unwrap_or_default();
+        let cursor = entries.len();
+        Self {
+            entries: entries.into(),
+            cursor,
+        }
+    }
+
+    pub fn save(&self, workspace: &Path) {
+        let entries: Vec<&JumpEntry> = self.entries.iter().collect();
+        let dir = workspace.join(".txt");
+        let _ = std::fs::create_dir_all(&dir);
+        if let Ok(text) = serde_json::to_string(&entries) {
+            let _ = std::fs::write(dir.join("jumps.json"), text);
+        }
+    }
+}
+
+// ── Offset rebasing ──────────────────────────────────────────────────────
+
+/// Rebase a single byte offset against an `EditCommand`. Returns `None` when
+/// the offset was inside a deletion and therefore no longer valid.
+fn rebase_offset(off: usize, cmd: &EditCommand) -> Option<usize> {
+    match cmd {
+        EditCommand::Insert { at, text } => {
+            // Inserts at or before our offset push us forward.
+            if off >= *at {
+                Some(off + text.len())
+            } else {
+                Some(off)
+            }
+        }
+        EditCommand::Delete { start, end, .. } => {
+            if off <= *start {
+                Some(off)
+            } else if off >= *end {
+                Some(off - (end - start))
+            } else {
+                None
+            }
+        }
+        EditCommand::Replace {
+            start,
+            end,
+            old_text,
+            new_text,
+        } => {
+            let _ = old_text;
+            let removed = end - start;
+            let added = new_text.len();
+            if off <= *start {
+                Some(off)
+            } else if off >= *end {
+                let adjusted = off + added;
+                Some(adjusted.saturating_sub(removed))
+            } else {
+                // Inside the replaced range — collapse to the start.
+                Some(*start)
+            }
+        }
+    }
+}
+
+/// Canonicalise a path, falling back to its given form on error. Used so two
+/// representations of the same file map to the same key.
+fn canonical(p: &Path) -> PathBuf {
+    p.canonicalize().unwrap_or_else(|_| p.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn p(s: &str) -> PathBuf {
+        PathBuf::from(s)
+    }
+
+    #[test]
+    fn rebase_insert_after_offset_shifts_offset() {
+        let cmd = EditCommand::Insert {
+            at: 10,
+            text: "xyz".into(),
+        };
+        assert_eq!(rebase_offset(15, &cmd), Some(18));
+        assert_eq!(rebase_offset(10, &cmd), Some(13));
+        assert_eq!(rebase_offset(5, &cmd), Some(5));
+    }
+
+    #[test]
+    fn rebase_delete_drops_offsets_inside() {
+        let cmd = EditCommand::Delete {
+            start: 5,
+            end: 10,
+            deleted: "12345".into(),
+        };
+        assert_eq!(rebase_offset(3, &cmd), Some(3));
+        assert_eq!(rebase_offset(5, &cmd), Some(5));
+        assert_eq!(rebase_offset(7, &cmd), None);
+        assert_eq!(rebase_offset(10, &cmd), Some(5));
+        assert_eq!(rebase_offset(15, &cmd), Some(10));
+    }
+
+    #[test]
+    fn named_marks_round_trip_through_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut marks = NamedMarks::new();
+        marks.set(&p("/some/file.rs"), 'a', 100);
+        marks.set(&p("/some/file.rs"), 'b', 200);
+        marks.save(dir.path());
+        let loaded = NamedMarks::load(dir.path());
+        // Note: canonicalize() will fail for non-existent paths, so the
+        // stored key falls back to the input path.
+        let v = loaded.get(&p("/some/file.rs"), 'a');
+        assert_eq!(v, Some(100));
+        assert_eq!(loaded.get(&p("/some/file.rs"), 'b'), Some(200));
+    }
+
+    #[test]
+    fn named_marks_rebase_after_insert() {
+        let mut marks = NamedMarks::new();
+        marks.set(&p("/tmp/a.rs"), 'a', 50);
+        marks.rebase_after_edit(
+            &p("/tmp/a.rs"),
+            &EditCommand::Insert {
+                at: 10,
+                text: "abcde".into(),
+            },
+        );
+        assert_eq!(marks.get(&p("/tmp/a.rs"), 'a'), Some(55));
+    }
+
+    #[test]
+    fn named_marks_rebase_drops_marks_inside_deletion() {
+        let mut marks = NamedMarks::new();
+        marks.set(&p("/tmp/a.rs"), 'a', 50);
+        marks.rebase_after_edit(
+            &p("/tmp/a.rs"),
+            &EditCommand::Delete {
+                start: 30,
+                end: 80,
+                deleted: "x".repeat(50),
+            },
+        );
+        assert_eq!(marks.get(&p("/tmp/a.rs"), 'a'), None);
+    }
+
+    #[test]
+    fn jump_list_push_and_navigate() {
+        let mut jl = JumpList::new();
+        jl.push(JumpEntry {
+            path: p("/a"),
+            byte_offset: 0,
+        });
+        jl.push(JumpEntry {
+            path: p("/b"),
+            byte_offset: 10,
+        });
+        jl.push(JumpEntry {
+            path: p("/c"),
+            byte_offset: 20,
+        });
+        assert_eq!(
+            jl.back(),
+            Some(JumpEntry {
+                path: p("/b"),
+                byte_offset: 10
+            })
+        );
+        assert_eq!(
+            jl.back(),
+            Some(JumpEntry {
+                path: p("/a"),
+                byte_offset: 0
+            })
+        );
+        assert_eq!(jl.back(), None);
+        assert_eq!(
+            jl.forward(),
+            Some(JumpEntry {
+                path: p("/b"),
+                byte_offset: 10
+            })
+        );
+    }
+
+    #[test]
+    fn jump_list_dedupes_consecutive_pushes() {
+        let mut jl = JumpList::new();
+        let e = JumpEntry {
+            path: p("/a"),
+            byte_offset: 0,
+        };
+        jl.push(e.clone());
+        jl.push(e.clone());
+        assert_eq!(jl.entries.len(), 1);
+    }
+
+    #[test]
+    fn jump_list_back_after_push_drops_forward() {
+        let mut jl = JumpList::new();
+        jl.push(JumpEntry {
+            path: p("/a"),
+            byte_offset: 0,
+        });
+        jl.push(JumpEntry {
+            path: p("/b"),
+            byte_offset: 10,
+        });
+        jl.back();
+        jl.push(JumpEntry {
+            path: p("/c"),
+            byte_offset: 30,
+        });
+        assert_eq!(jl.entries.len(), 2);
+        assert_eq!(jl.entries.back().unwrap().path, p("/c"));
+    }
+
+    #[test]
+    fn jump_list_caps_at_limit() {
+        let mut jl = JumpList::new();
+        for i in 0..(JUMP_LIST_CAP + 5) {
+            jl.push(JumpEntry {
+                path: p("/x"),
+                byte_offset: i,
+            });
+        }
+        assert_eq!(jl.entries.len(), JUMP_LIST_CAP);
+    }
+}

--- a/src/marks/mod.rs
+++ b/src/marks/mod.rs
@@ -435,4 +435,110 @@ mod tests {
         }
         assert_eq!(jl.entries.len(), JUMP_LIST_CAP);
     }
+
+    /// Regression: with a single entry already pushed, `back()` followed by
+    /// another `push` (as the JumpListBack handler does) must yield the
+    /// stored entry. Previously the `cursor <= 1` guard short-circuited
+    /// before the just-pushed `current` location could be returned.
+    #[test]
+    fn back_after_handler_pattern_with_one_existing_entry() {
+        let mut jl = JumpList::new();
+        // The handler's "push then back" pattern.
+        jl.push(JumpEntry {
+            path: p("/a"),
+            byte_offset: 0,
+        });
+        jl.push(JumpEntry {
+            path: p("/a"),
+            byte_offset: 50,
+        });
+        assert_eq!(
+            jl.back(),
+            Some(JumpEntry {
+                path: p("/a"),
+                byte_offset: 0
+            })
+        );
+    }
+
+    /// User scenario: open a file, do one jump-to-line, press Alt+Left.
+    /// Alt+Left should land on the original cursor position.
+    #[test]
+    fn alt_left_after_single_jump_returns_origin() {
+        let mut jl = JumpList::new();
+        // First navigation: pushes the origin into history.
+        jl.push(JumpEntry {
+            path: p("/file"),
+            byte_offset: 0,
+        });
+        // User is now at byte_offset 100.
+        // Alt+Left handler: push current, then back.
+        jl.push(JumpEntry {
+            path: p("/file"),
+            byte_offset: 100,
+        });
+        let back = jl.back();
+        assert_eq!(
+            back,
+            Some(JumpEntry {
+                path: p("/file"),
+                byte_offset: 0
+            }),
+            "Alt+Left should return to byte_offset 0"
+        );
+        // Now Alt+Right should bring them back to 100.
+        let forward = jl.forward();
+        assert_eq!(
+            forward,
+            Some(JumpEntry {
+                path: p("/file"),
+                byte_offset: 100
+            }),
+            "Alt+Right should restore byte_offset 100"
+        );
+    }
+
+    /// Pressing Alt+Left repeatedly should walk further back. The dedup on
+    /// `push_current` (because the user is at the entry we just returned to)
+    /// must not block the next back step.
+    #[test]
+    fn alt_left_walks_multiple_steps() {
+        let mut jl = JumpList::new();
+        jl.push(JumpEntry {
+            path: p("/file"),
+            byte_offset: 0,
+        });
+        jl.push(JumpEntry {
+            path: p("/file"),
+            byte_offset: 50,
+        });
+        // User at 100 — the third visited location.
+        jl.push(JumpEntry {
+            path: p("/file"),
+            byte_offset: 100,
+        });
+        assert_eq!(
+            jl.back(),
+            Some(JumpEntry {
+                path: p("/file"),
+                byte_offset: 50
+            })
+        );
+        // Now press Alt+Left again — handler pushes current (50), which
+        // dedups against the existing entry at index 1. Back should still
+        // produce the *next* older entry (0).
+        jl.push(JumpEntry {
+            path: p("/file"),
+            byte_offset: 50,
+        });
+        let next_back = jl.back();
+        assert_eq!(
+            next_back,
+            Some(JumpEntry {
+                path: p("/file"),
+                byte_offset: 0
+            }),
+            "second Alt+Left should land on byte_offset 0"
+        );
+    }
 }

--- a/src/snippet/mod.rs
+++ b/src/snippet/mod.rs
@@ -1,0 +1,375 @@
+//! TextMate-style snippet engine.
+//!
+//! Snippets live in `<config_dir>/txt/snippets/<language_id>.toml` and are
+//! parsed lazily on first use per language. A snippet body uses the standard
+//! placeholder syntax: `$1`, `$2`, `${1:default text}`, with `$0` as the
+//! cursor's final position. Backslash escapes the special characters.
+//!
+//! The runtime is split into two halves:
+//!
+//! * **Parsing & loading** (this module) — produces a [`ParsedBody`] of
+//!   literal segments and tab-stop placeholders.
+//! * **Active session** ([`session`]) — installs the expansion in the buffer,
+//!   tracks tab-stop byte ranges, and advances them as the user edits.
+
+pub mod session;
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// One parsed snippet definition.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Snippet {
+    pub prefix: String,
+    pub body: String,
+    /// Optional human-readable description shown in the picker.
+    #[serde(default)]
+    pub description: String,
+}
+
+/// One segment of a parsed body — either literal text or a tab-stop
+/// placeholder with an optional default value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Segment {
+    Literal(String),
+    Stop { index: u32, default: String },
+}
+
+/// A snippet body broken into segments ready for expansion.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedBody {
+    pub segments: Vec<Segment>,
+}
+
+impl Snippet {
+    /// Parse `self.body` into segments. Pure function — call once per
+    /// expansion and pair the result with a `SnippetSession`.
+    pub fn parse_body(&self) -> ParsedBody {
+        parse_body(&self.body)
+    }
+}
+
+/// Parse a TextMate-style snippet body. Recognises:
+///
+/// * `$1`, `$2`, ... — numbered tab stops
+/// * `${1:default}` — tab stop with a default placeholder string
+/// * `$0` — final-cursor stop
+/// * Backslash-escaped `\$`, `\\`, `\{`, `\}`
+///
+/// Unrecognised `${...}` forms degrade to literal text so a typo in a
+/// snippet doesn't make the editor swallow user content.
+pub fn parse_body(body: &str) -> ParsedBody {
+    let mut segments = Vec::new();
+    let mut literal = String::new();
+    let mut chars = body.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        match c {
+            '\\' => {
+                if let Some(next) = chars.next() {
+                    literal.push(next);
+                } else {
+                    literal.push('\\');
+                }
+            }
+            '$' => {
+                if let Some(&next) = chars.peek() {
+                    if next.is_ascii_digit() {
+                        flush_literal(&mut segments, &mut literal);
+                        let mut digits = String::new();
+                        while let Some(&n) = chars.peek() {
+                            if n.is_ascii_digit() {
+                                digits.push(n);
+                                chars.next();
+                            } else {
+                                break;
+                            }
+                        }
+                        if let Ok(idx) = digits.parse::<u32>() {
+                            segments.push(Segment::Stop {
+                                index: idx,
+                                default: String::new(),
+                            });
+                            continue;
+                        }
+                        literal.push('$');
+                        literal.push_str(&digits);
+                        continue;
+                    }
+                    if next == '{' {
+                        chars.next();
+                        let mut head = String::new();
+                        while let Some(&n) = chars.peek() {
+                            if n.is_ascii_digit() {
+                                head.push(n);
+                                chars.next();
+                            } else {
+                                break;
+                            }
+                        }
+                        let idx_res: Result<u32, _> = head.parse::<u32>().map_err(|_| ());
+                        let mut default = String::new();
+                        let mut closed = false;
+                        let saw_colon = chars.peek() == Some(&':');
+                        if saw_colon {
+                            chars.next(); // consume ':'
+                            while let Some(c) = chars.next() {
+                                if c == '}' {
+                                    closed = true;
+                                    break;
+                                }
+                                if c == '\\' {
+                                    if let Some(esc) = chars.next() {
+                                        default.push(esc);
+                                    }
+                                } else {
+                                    default.push(c);
+                                }
+                            }
+                        } else if chars.peek() == Some(&'}') {
+                            chars.next();
+                            closed = true;
+                        }
+                        if let (Ok(idx), true) = (idx_res, closed) {
+                            flush_literal(&mut segments, &mut literal);
+                            segments.push(Segment::Stop {
+                                index: idx,
+                                default,
+                            });
+                            continue;
+                        }
+                        // Malformed placeholder — emit as literal so user text
+                        // is preserved.
+                        literal.push('$');
+                        literal.push('{');
+                        if let Ok(idx) = idx_res {
+                            literal.push_str(&idx.to_string());
+                        }
+                        if saw_colon {
+                            literal.push(':');
+                        }
+                        literal.push_str(&default);
+                        if closed {
+                            literal.push('}');
+                        }
+                        continue;
+                    }
+                }
+                literal.push('$');
+            }
+            _ => literal.push(c),
+        }
+    }
+    flush_literal(&mut segments, &mut literal);
+    ParsedBody { segments }
+}
+
+fn flush_literal(segments: &mut Vec<Segment>, literal: &mut String) {
+    if !literal.is_empty() {
+        segments.push(Segment::Literal(std::mem::take(literal)));
+    }
+}
+
+/// Top-level TOML file for a language: `[snippets.<name>]` tables.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct SnippetFile {
+    #[serde(default)]
+    pub snippets: HashMap<String, Snippet>,
+}
+
+/// In-memory snippet store keyed by language id (`"rust"`, `"python"`, …).
+#[derive(Default)]
+pub struct SnippetStore {
+    by_language: HashMap<String, Vec<Snippet>>,
+    /// Languages whose file has already been loaded (success or failure)
+    /// so we don't hit disk repeatedly on a missing file.
+    loaded: std::collections::HashSet<String>,
+}
+
+impl SnippetStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Look up every snippet whose prefix matches `prefix` exactly for the
+    /// given `language_id`. Loads the language's snippets file on first call.
+    pub fn lookup(&mut self, language_id: &str, prefix: &str) -> Vec<Snippet> {
+        self.ensure_loaded(language_id);
+        self.by_language
+            .get(language_id)
+            .map(|v| v.iter().filter(|s| s.prefix == prefix).cloned().collect())
+            .unwrap_or_default()
+    }
+
+    /// Return every loaded snippet for `language_id` whose prefix *starts with*
+    /// `query`. Useful for picker UIs; loads the file on first call.
+    #[allow(dead_code)]
+    pub fn prefix_matches(&mut self, language_id: &str, query: &str) -> Vec<Snippet> {
+        self.ensure_loaded(language_id);
+        self.by_language
+            .get(language_id)
+            .map(|v| {
+                v.iter()
+                    .filter(|s| s.prefix.starts_with(query))
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    fn ensure_loaded(&mut self, language_id: &str) {
+        if self.loaded.contains(language_id) {
+            return;
+        }
+        self.loaded.insert(language_id.to_string());
+        let Some(path) = snippet_path(language_id) else {
+            return;
+        };
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            return;
+        };
+        let Ok(parsed) = toml::from_str::<SnippetFile>(&text) else {
+            return;
+        };
+        let entries: Vec<Snippet> = parsed.snippets.into_values().collect();
+        self.by_language.insert(language_id.to_string(), entries);
+    }
+
+    /// Replace the snippets for a language. Used by tests; production code
+    /// goes through `ensure_loaded` from disk.
+    #[allow(dead_code)]
+    pub fn insert(&mut self, language_id: &str, snippets: Vec<Snippet>) {
+        self.loaded.insert(language_id.to_string());
+        self.by_language.insert(language_id.to_string(), snippets);
+    }
+}
+
+/// Path to the on-disk snippets file for `language_id`, or `None` if the
+/// platform doesn't expose a config directory.
+fn snippet_path(language_id: &str) -> Option<PathBuf> {
+    let home = dirs::home_dir()?;
+    Some(
+        home.join(".config")
+            .join("txt")
+            .join("snippets")
+            .join(format!("{language_id}.toml")),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_simple_numbered_stops() {
+        let body = parse_body("for $1 in $2 { $0 }");
+        assert_eq!(
+            body.segments,
+            vec![
+                Segment::Literal("for ".into()),
+                Segment::Stop {
+                    index: 1,
+                    default: String::new()
+                },
+                Segment::Literal(" in ".into()),
+                Segment::Stop {
+                    index: 2,
+                    default: String::new()
+                },
+                Segment::Literal(" { ".into()),
+                Segment::Stop {
+                    index: 0,
+                    default: String::new()
+                },
+                Segment::Literal(" }".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_default_placeholder() {
+        let body = parse_body("for ${1:i} in ${2:iter}");
+        assert_eq!(
+            body.segments,
+            vec![
+                Segment::Literal("for ".into()),
+                Segment::Stop {
+                    index: 1,
+                    default: "i".into()
+                },
+                Segment::Literal(" in ".into()),
+                Segment::Stop {
+                    index: 2,
+                    default: "iter".into()
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_escaped_dollar_sign() {
+        let body = parse_body(r"\$1 is not a stop");
+        assert_eq!(
+            body.segments,
+            vec![Segment::Literal("$1 is not a stop".into())]
+        );
+    }
+
+    #[test]
+    fn malformed_placeholder_falls_back_to_literal() {
+        let body = parse_body("${not_a_number}");
+        assert!(
+            body.segments
+                .iter()
+                .any(|s| matches!(s, Segment::Literal(_)))
+        );
+        assert!(
+            !body
+                .segments
+                .iter()
+                .any(|s| matches!(s, Segment::Stop { .. }))
+        );
+    }
+
+    #[test]
+    fn store_lookup_returns_matching_prefix() {
+        let mut store = SnippetStore::new();
+        store.insert(
+            "rust",
+            vec![Snippet {
+                prefix: "for".into(),
+                body: "for $1 in $2 {\n    $0\n}".into(),
+                description: String::new(),
+            }],
+        );
+        let matches = store.lookup("rust", "for");
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].prefix, "for");
+    }
+
+    #[test]
+    fn store_prefix_matches_for_picker() {
+        let mut store = SnippetStore::new();
+        store.insert(
+            "rust",
+            vec![
+                Snippet {
+                    prefix: "fn".into(),
+                    body: "fn $1() {}".into(),
+                    description: String::new(),
+                },
+                Snippet {
+                    prefix: "for".into(),
+                    body: "for $1 in $2 {}".into(),
+                    description: String::new(),
+                },
+            ],
+        );
+        let m = store.prefix_matches("rust", "f");
+        assert_eq!(m.len(), 2);
+        let m = store.prefix_matches("rust", "fn");
+        assert_eq!(m.len(), 1);
+    }
+}

--- a/src/snippet/session.rs
+++ b/src/snippet/session.rs
@@ -1,0 +1,272 @@
+//! Active snippet session — tracks tab-stop byte ranges as the user edits.
+//!
+//! A session is installed on a buffer right after a snippet body is
+//! inserted. The session owns one [`StopRange`] per index `$1`, `$2`, … plus
+//! an optional `$0`. Each range is rebased on every buffer edit so that
+//! advancing to the next stop always lands on the user-typed content.
+
+use crate::buffer::cursor::ByteRange;
+use crate::buffer::history::EditCommand;
+use crate::snippet::{ParsedBody, Segment};
+
+/// One tab-stop entry within an active session.
+#[derive(Debug, Clone)]
+pub struct StopRange {
+    pub index: u32,
+    pub range: ByteRange,
+}
+
+/// Active snippet session installed on a buffer after expansion.
+#[derive(Debug)]
+pub struct SnippetSession {
+    /// Every tab stop sorted by `index`. The `$0` stop, if present, is the
+    /// last entry.
+    stops: Vec<StopRange>,
+    /// Index into `stops` of the currently selected stop.
+    current: usize,
+}
+
+/// Output of [`expand_into_buffer`]: the rendered snippet text and a session
+/// ready to install on the buffer.
+pub struct Expansion {
+    pub text: String,
+    pub session: Option<SnippetSession>,
+}
+
+impl SnippetSession {
+    /// Translate a parsed snippet body and the byte offset at which it will
+    /// be inserted into a string to insert and the session that tracks the
+    /// tab stops within it.
+    ///
+    /// Returns `Expansion` with `session = None` when the body contains no
+    /// tab stops at all (a plain literal snippet).
+    pub fn expand_at(body: &ParsedBody, insert_at: usize) -> Expansion {
+        let mut text = String::new();
+        let mut stops: Vec<StopRange> = Vec::new();
+        let mut current_offset = insert_at;
+        for segment in &body.segments {
+            match segment {
+                Segment::Literal(s) => {
+                    text.push_str(s);
+                    current_offset += s.len();
+                }
+                Segment::Stop { index, default } => {
+                    let start = current_offset;
+                    text.push_str(default);
+                    current_offset += default.len();
+                    let end = current_offset;
+                    stops.push(StopRange {
+                        index: *index,
+                        range: ByteRange::new(start, end),
+                    });
+                }
+            }
+        }
+        if stops.is_empty() {
+            return Expansion {
+                text,
+                session: None,
+            };
+        }
+        // Sort so $1, $2, … come before $0 (the final-stop convention).
+        stops.sort_by_key(|s| if s.index == 0 { u32::MAX } else { s.index });
+        let session = SnippetSession { stops, current: 0 };
+        Expansion {
+            text,
+            session: Some(session),
+        }
+    }
+
+    /// Byte range of the current tab stop.
+    pub fn current_range(&self) -> ByteRange {
+        self.stops[self.current].range
+    }
+
+    /// Whether the current stop is `$0` — the conventional final cursor.
+    #[allow(dead_code)]
+    pub fn current_is_final(&self) -> bool {
+        self.stops[self.current].index == 0
+    }
+
+    /// Advance to the next tab stop. Returns `true` if a next stop existed.
+    pub fn next_stop(&mut self) -> bool {
+        if self.current + 1 < self.stops.len() {
+            self.current += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Move to the previous tab stop.
+    pub fn prev_stop(&mut self) -> bool {
+        if self.current > 0 {
+            self.current -= 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Apply an [`EditCommand`] to every tab-stop range so the session keeps
+    /// tracking the user's typing within stops. Stops fully consumed by a
+    /// deletion are dropped; the session is considered "done" when no stops
+    /// remain.
+    pub fn rebase(&mut self, cmd: &EditCommand) {
+        let mut drop = Vec::new();
+        for (i, stop) in self.stops.iter_mut().enumerate() {
+            match rebase_range(stop.range, cmd) {
+                Some(r) => stop.range = r,
+                None => drop.push(i),
+            }
+        }
+        for i in drop.into_iter().rev() {
+            self.stops.remove(i);
+            if self.current >= i && self.current > 0 {
+                self.current -= 1;
+            }
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.stops.is_empty()
+    }
+
+    /// Test-only inspection helpers.
+    #[allow(dead_code)]
+    pub fn current_index(&self) -> u32 {
+        self.stops[self.current].index
+    }
+    #[allow(dead_code)]
+    pub fn stop_count(&self) -> usize {
+        self.stops.len()
+    }
+}
+
+/// Rebase a byte range against a single edit command.
+fn rebase_range(range: ByteRange, cmd: &EditCommand) -> Option<ByteRange> {
+    match cmd {
+        EditCommand::Insert { at, text } => {
+            let added = text.len();
+            // Inside the range: extend it.
+            if *at >= range.start && *at <= range.end {
+                return Some(ByteRange::new(range.start, range.end + added));
+            }
+            // Before the range: shift both ends.
+            if *at < range.start {
+                return Some(ByteRange::new(range.start + added, range.end + added));
+            }
+            // After the range: untouched.
+            Some(range)
+        }
+        EditCommand::Delete { start, end, .. } => {
+            let removed = end - start;
+            if *end <= range.start {
+                return Some(ByteRange::new(range.start - removed, range.end - removed));
+            }
+            if *start >= range.end {
+                return Some(range);
+            }
+            // Overlap — clip the range.
+            let new_start = (*start).min(range.start);
+            let inside_left = range.start.saturating_sub(*start);
+            let inside_right = range.end.min(*end);
+            let outside_right_len = range.end - inside_right;
+            let new_end = new_start + outside_right_len + inside_left;
+            if new_end == new_start {
+                return None;
+            }
+            Some(ByteRange::new(new_start, new_end))
+        }
+        EditCommand::Replace {
+            start,
+            end,
+            new_text,
+            ..
+        } => {
+            // Treat as delete + insert at the same location.
+            let removed = end - start;
+            let added = new_text.len();
+            if *end <= range.start {
+                return Some(ByteRange::new(
+                    range.start + added - removed,
+                    range.end + added - removed,
+                ));
+            }
+            if *start >= range.end {
+                return Some(range);
+            }
+            // Overlap — collapse to the replacement span.
+            Some(ByteRange::new(*start, start + added))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::snippet::parse_body;
+
+    #[test]
+    fn expand_at_collects_stops_in_order() {
+        let body = parse_body("for $1 in $2 { $0 }");
+        let exp = SnippetSession::expand_at(&body, 100);
+        let session = exp.session.expect("has stops");
+        assert_eq!(session.stop_count(), 3);
+        assert_eq!(session.current_index(), 1);
+        assert_eq!(exp.text, "for  in  {  }");
+    }
+
+    #[test]
+    fn expand_with_defaults_includes_default_text() {
+        let body = parse_body("for ${1:i} in ${2:xs} {}");
+        let exp = SnippetSession::expand_at(&body, 0);
+        assert_eq!(exp.text, "for i in xs {}");
+        let session = exp.session.unwrap();
+        // First stop covers "i" — 4..5
+        let r1 = session.current_range();
+        assert_eq!(r1.start, 4);
+        assert_eq!(r1.end, 5);
+    }
+
+    #[test]
+    fn next_and_prev_walk_stops() {
+        let body = parse_body("$1 $2 $0");
+        let mut session = SnippetSession::expand_at(&body, 0).session.unwrap();
+        assert_eq!(session.current_index(), 1);
+        assert!(session.next_stop());
+        assert_eq!(session.current_index(), 2);
+        assert!(session.next_stop());
+        assert!(session.current_is_final());
+        assert!(!session.next_stop());
+        session.prev_stop();
+        assert_eq!(session.current_index(), 2);
+    }
+
+    #[test]
+    fn rebase_after_insert_inside_stop_grows_range() {
+        let body = parse_body("${1:i}");
+        let mut session = SnippetSession::expand_at(&body, 10).session.unwrap();
+        // Stop covers 10..11 ("i").
+        session.rebase(&EditCommand::Insert {
+            at: 11,
+            text: "tem".into(),
+        });
+        let r = session.current_range();
+        assert_eq!(r.start, 10);
+        assert_eq!(r.end, 14);
+    }
+
+    #[test]
+    fn rebase_after_insert_before_shifts_range() {
+        let body = parse_body("${1:i}");
+        let mut session = SnippetSession::expand_at(&body, 10).session.unwrap();
+        session.rebase(&EditCommand::Insert {
+            at: 5,
+            text: "abc".into(),
+        });
+        let r = session.current_range();
+        assert_eq!(r.start, 13);
+        assert_eq!(r.end, 14);
+    }
+}

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -166,6 +166,92 @@ impl SyntaxHost {
             None => Vec::new(),
         }
     }
+
+    /// Walk up the parse tree from `byte_offset` and collect the enclosing
+    /// named containers (functions, classes, modules, etc.) outermost first.
+    ///
+    /// Returns an empty `Vec` if no parse tree is available or if the cursor
+    /// isn't inside any named container. Names whose tree-sitter `name` field
+    /// can't be decoded are skipped silently.
+    pub fn enclosing_named_path(&self, rope: &Rope, byte_offset: usize) -> Vec<EnclosingSymbol> {
+        let tree = match &self.tree {
+            Some(t) => t,
+            None => return Vec::new(),
+        };
+        let root = tree.root_node();
+        let bound = byte_offset.min(rope.len_bytes());
+        let leaf = match root.descendant_for_byte_range(bound, bound) {
+            Some(n) => n,
+            None => return Vec::new(),
+        };
+        let mut path = Vec::new();
+        let mut node = Some(leaf);
+        while let Some(n) = node {
+            if let Some(label) = container_label(n.kind()) {
+                let name_node = ["name", "type", "path", "declarator"]
+                    .into_iter()
+                    .find_map(|f| n.child_by_field_name(f));
+                if let Some(name_node) = name_node {
+                    let start = name_node.start_byte().min(rope.len_bytes());
+                    let end = name_node.end_byte().min(rope.len_bytes());
+                    if start < end {
+                        let start_char = rope.byte_to_char(start);
+                        let end_char = rope.byte_to_char(end);
+                        let text: String = rope.slice(start_char..end_char).chars().collect();
+                        let trimmed: String = text.split_whitespace().collect::<Vec<_>>().join(" ");
+                        if !trimmed.is_empty() {
+                            path.push(EnclosingSymbol {
+                                name: trimmed,
+                                kind: label,
+                            });
+                        }
+                    }
+                }
+            }
+            node = n.parent();
+        }
+        path.reverse();
+        path
+    }
+}
+
+/// One entry on an enclosing-symbol path: a node name and a short kind label.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnclosingSymbol {
+    pub name: String,
+    pub kind: &'static str,
+}
+
+/// Map a tree-sitter node kind to a short label for display, or `None` if the
+/// node kind isn't a "named container" worth showing in breadcrumbs.
+fn container_label(kind: &str) -> Option<&'static str> {
+    Some(match kind {
+        // Functions / methods (covers Rust, Python, JS/TS, Go, Java, C#, Kotlin, Groovy, Bash).
+        "function_item"
+        | "function_definition"
+        | "function_declaration"
+        | "method_definition"
+        | "method_declaration"
+        | "constructor_declaration"
+        | "constructor_definition" => "fn",
+        // Rust-only.
+        "impl_item" => "impl",
+        "struct_item" => "struct",
+        "enum_item" => "enum",
+        "trait_item" => "trait",
+        "mod_item" => "mod",
+        // Classes / interfaces / objects (Java, C#, JS/TS, Python, Kotlin, Groovy).
+        "class_definition" | "class_declaration" => "class",
+        "interface_declaration" => "interface",
+        "object_declaration" => "object",
+        // C# / Kotlin namespaces.
+        "namespace_declaration" | "package_clause" => "ns",
+        // Go top-level type declarations.
+        "type_declaration" | "type_spec" => "type",
+        // Markdown structural sections.
+        "section" | "atx_heading" | "setext_heading" => "§",
+        _ => return None,
+    })
 }
 
 impl Default for SyntaxHost {
@@ -285,6 +371,41 @@ mod tests {
         host.reparse_rope(&rope2);
         assert!(host.has_tree());
         assert!(!host.tree.as_ref().unwrap().root_node().has_error());
+    }
+
+    #[test]
+    fn enclosing_path_for_function_returns_fn_only() {
+        let src = "fn foo() { let x = 1; }";
+        let (host, rope) = host_for_rust(src);
+        // Cursor inside `let x = 1;` — about byte 16.
+        let path = host.enclosing_named_path(&rope, 16);
+        // At minimum, the function `foo` is in the path.
+        assert!(
+            path.iter().any(|e| e.name == "foo" && e.kind == "fn"),
+            "expected fn foo in path, got {:?}",
+            path
+        );
+    }
+
+    #[test]
+    fn enclosing_path_for_method_inside_impl_includes_both() {
+        let src = "impl Bar { fn baz(&self) { let x = 1; } }";
+        let (host, rope) = host_for_rust(src);
+        // Cursor inside `let x = 1;` — about byte 32.
+        let path = host.enclosing_named_path(&rope, 32);
+        let kinds: Vec<&str> = path.iter().map(|e| e.kind).collect();
+        let names: Vec<&str> = path.iter().map(|e| e.name.as_str()).collect();
+        assert!(kinds.contains(&"impl"), "kinds={kinds:?}");
+        assert!(kinds.contains(&"fn"), "kinds={kinds:?}");
+        assert!(names.contains(&"Bar"), "names={names:?}");
+        assert!(names.contains(&"baz"), "names={names:?}");
+    }
+
+    #[test]
+    fn enclosing_path_no_tree_returns_empty() {
+        let host = SyntaxHost::new();
+        let rope = Rope::from_str("anything");
+        assert!(host.enclosing_named_path(&rope, 0).is_empty());
     }
 
     /// Regression: highlight span byte offsets must match the *current* source

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -238,6 +238,52 @@ pub struct Symbol {
 }
 
 impl SyntaxHost {
+    /// Run the language's `@fold` query and return the byte ranges of every
+    /// foldable region (function body, class body, etc.).
+    ///
+    /// Returns an empty `Vec` when no tree is available, when the language
+    /// has no fold query, or when the query fails to compile. Ranges are
+    /// sorted by start byte; duplicates are removed.
+    pub fn fold_ranges(&self, rope: &Rope) -> Vec<ByteRange> {
+        let tree = match &self.tree {
+            Some(t) => t,
+            None => return Vec::new(),
+        };
+        let pattern = match queries::folds_query_for(self.language) {
+            Some(p) if !p.trim().is_empty() => p,
+            _ => return Vec::new(),
+        };
+        let ts_lang = match self.language.ts_language() {
+            Some(l) => l,
+            None => return Vec::new(),
+        };
+        let query = match Query::new(&ts_lang, pattern) {
+            Ok(q) => q,
+            Err(_) => return Vec::new(),
+        };
+        let source = rope.to_string();
+        let bytes = source.as_bytes();
+        let mut cursor = QueryCursor::new();
+        let mut matches = cursor.matches(&query, tree.root_node(), bytes);
+        let mut out: Vec<ByteRange> = Vec::new();
+        while let Some(m) = matches.next() {
+            for cap in m.captures {
+                let r = ByteRange::new(cap.node.start_byte(), cap.node.end_byte());
+                out.push(r);
+            }
+        }
+        out.sort_by_key(|r| (r.start, r.end));
+        out.dedup();
+        // Drop folds that are entirely on a single line — folding gives no
+        // visual benefit there.
+        out.retain(|r| {
+            let start_line = rope.byte_to_line(r.start.min(rope.len_bytes()));
+            let end_line = rope.byte_to_line(r.end.min(rope.len_bytes()));
+            end_line > start_line
+        });
+        out
+    }
+
     /// Run the language-specific symbols query over the current parse tree
     /// and collect every `@symbol.<kind>` match.
     ///

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -571,6 +571,28 @@ mod tests {
         assert!(host.enclosing_named_path(&rope, 0).is_empty());
     }
 
+    /// Regression for the sticky header: walking down through an `impl`
+    /// block must land on the *current* method, not a sibling. The user
+    /// reported the header staying on the first function of a class even
+    /// after scrolling into the second.
+    #[test]
+    fn enclosing_path_tracks_current_method_in_multi_method_impl() {
+        let src = "impl Bar {\n    fn first() { let x = 1; }\n    fn second() { let y = 2; }\n}\n";
+        let (host, rope) = host_for_rust(src);
+        let byte = src.find("let y = 2").expect("test source must contain y");
+        let path = host.enclosing_named_path(&rope, byte);
+        let names: Vec<&str> = path.iter().map(|e| e.name.as_str()).collect();
+        assert!(names.contains(&"Bar"), "names={names:?}");
+        assert!(
+            names.contains(&"second"),
+            "expected the second method to be in the path, got {names:?}"
+        );
+        assert!(
+            !names.contains(&"first"),
+            "first method must not be in the path, got {names:?}"
+        );
+    }
+
     #[test]
     fn collect_symbols_rust_finds_functions() {
         let src = "fn alpha() {}\nfn beta() { let x = 1; }\nstruct Gamma { x: u32 }\n";

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -1,8 +1,9 @@
 pub mod highlighter;
 pub mod language;
+pub mod queries;
 
 use ropey::Rope;
-use tree_sitter::{Parser, Tree};
+use tree_sitter::{Parser, Query, QueryCursor, StreamingIterator, Tree};
 
 use crate::buffer::cursor::ByteRange;
 use crate::syntax::language::Lang;
@@ -222,6 +223,122 @@ pub struct EnclosingSymbol {
     pub kind: &'static str,
 }
 
+/// A named definition discovered by a tree-sitter symbols query (used by the
+/// Ctrl+Shift+O picker).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Symbol {
+    /// Display name of the symbol (e.g. `"foo"` for `fn foo`).
+    pub name: String,
+    /// Short kind label such as `"fn"`, `"class"`, `"struct"`. Derived from
+    /// the `@symbol.<kind>` capture in the query.
+    pub kind: &'static str,
+    /// Byte range of the *definition* node — i.e. the `@symbol.kind` capture,
+    /// not just the name. Used to jump the cursor.
+    pub byte_range: ByteRange,
+}
+
+impl SyntaxHost {
+    /// Run the language-specific symbols query over the current parse tree
+    /// and collect every `@symbol.<kind>` match.
+    ///
+    /// Returns an empty `Vec` when no tree is available, when the language has
+    /// no symbols query, or when the query fails to compile (which shouldn't
+    /// happen in production but is recovered from gracefully).
+    pub fn collect_symbols(&self, rope: &Rope) -> Vec<Symbol> {
+        let tree = match &self.tree {
+            Some(t) => t,
+            None => return Vec::new(),
+        };
+        let pattern = match queries::symbols_query_for(self.language) {
+            Some(p) if !p.trim().is_empty() => p,
+            _ => return Vec::new(),
+        };
+        let ts_lang = match self.language.ts_language() {
+            Some(l) => l,
+            None => return Vec::new(),
+        };
+        let query = match Query::new(&ts_lang, pattern) {
+            Ok(q) => q,
+            Err(_) => return Vec::new(),
+        };
+
+        let source = rope.to_string();
+        let bytes = source.as_bytes();
+        let mut cursor = QueryCursor::new();
+        let mut matches = cursor.matches(&query, tree.root_node(), bytes);
+
+        let capture_names: Vec<&str> = query.capture_names().to_vec();
+        let mut out = Vec::new();
+        while let Some(m) = matches.next() {
+            let mut name_text: Option<String> = None;
+            let mut symbol_range: Option<(ByteRange, &'static str)> = None;
+            for cap in m.captures {
+                let cap_name = match capture_names.get(cap.index as usize) {
+                    Some(s) => *s,
+                    None => continue,
+                };
+                if cap_name == "name" {
+                    let start = cap.node.start_byte();
+                    let end = cap.node.end_byte();
+                    let text = std::str::from_utf8(&bytes[start..end])
+                        .unwrap_or("")
+                        .trim()
+                        .to_string();
+                    if !text.is_empty() {
+                        name_text = Some(text);
+                    }
+                } else if let Some(rest) = cap_name.strip_prefix("symbol.") {
+                    let kind = symbol_kind_label(rest);
+                    let r = ByteRange::new(cap.node.start_byte(), cap.node.end_byte());
+                    symbol_range = Some((r, kind));
+                }
+            }
+            if let (Some(name), Some((range, kind))) = (name_text, symbol_range) {
+                out.push(Symbol {
+                    name,
+                    kind,
+                    byte_range: range,
+                });
+            }
+        }
+        // Sort by line number for stable display.
+        out.sort_by_key(|s| s.byte_range.start);
+        out
+    }
+}
+
+/// Map a query capture suffix (`fn`, `class`, etc.) to a stable `&'static str`
+/// kind label. Unknown suffixes fall back to `"?"`.
+fn symbol_kind_label(suffix: &str) -> &'static str {
+    match suffix {
+        "fn" => "fn",
+        "impl" => "impl",
+        "struct" => "struct",
+        "enum" => "enum",
+        "trait" => "trait",
+        "mod" => "mod",
+        "const" => "const",
+        "static" => "static",
+        "macro" => "macro",
+        "type" => "type",
+        "class" => "class",
+        "interface" => "interface",
+        "object" => "object",
+        "ns" => "ns",
+        "key" => "key",
+        "tag" => "tag",
+        "rule" => "rule",
+        "table" => "table",
+        "var" => "var",
+        "property" => "property",
+        "h1" => "h1",
+        "h2" => "h2",
+        "h3" => "h3",
+        "h4" => "h4",
+        _ => "?",
+    }
+}
+
 /// Map a tree-sitter node kind to a short label for display, or `None` if the
 /// node kind isn't a "named container" worth showing in breadcrumbs.
 fn container_label(kind: &str) -> Option<&'static str> {
@@ -406,6 +523,27 @@ mod tests {
         let host = SyntaxHost::new();
         let rope = Rope::from_str("anything");
         assert!(host.enclosing_named_path(&rope, 0).is_empty());
+    }
+
+    #[test]
+    fn collect_symbols_rust_finds_functions() {
+        let src = "fn alpha() {}\nfn beta() { let x = 1; }\nstruct Gamma { x: u32 }\n";
+        let (host, rope) = host_for_rust(src);
+        let syms = host.collect_symbols(&rope);
+        let names: Vec<&str> = syms.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"alpha"));
+        assert!(names.contains(&"beta"));
+        assert!(names.contains(&"Gamma"));
+        let kinds: Vec<&str> = syms.iter().map(|s| s.kind).collect();
+        assert!(kinds.contains(&"fn"));
+        assert!(kinds.contains(&"struct"));
+    }
+
+    #[test]
+    fn collect_symbols_unknown_language_returns_empty() {
+        let host = SyntaxHost::new();
+        let rope = Rope::from_str("fn foo() {}");
+        assert!(host.collect_symbols(&rope).is_empty());
     }
 
     /// Regression: highlight span byte offsets must match the *current* source

--- a/src/syntax/queries.rs
+++ b/src/syntax/queries.rs
@@ -1,15 +1,16 @@
 //! Tree-sitter queries for cross-cutting features.
 //!
-//! Currently houses the **symbols-in-file** queries used by the
-//! `Ctrl+Shift+O` picker: each grammar's query captures a `@name` for every
-//! named definition (function, struct, class, etc.) and tags it with
-//! `@symbol.<kind>` so the runtime can render a kind glyph.
+//! * **Symbols-in-file** (`Ctrl+Shift+O` picker) — each grammar's symbols
+//!   query captures `@name` for every named definition and tags the match
+//!   with `@symbol.<kind>` so the runtime can render a kind glyph.
+//! * **Folds** — `@fold` captures mark every node range that should be
+//!   foldable; the buffer's `FoldState` chooses which of those candidate
+//!   ranges are currently collapsed.
 //!
 //! Queries are kept inline as Rust string constants so the grammar list and
 //! the queries that exercise it sit in the same place. Each grammar gets a
 //! pragmatic best-effort query — the goal is "useful in 90% of files",
-//! not "perfect parse-tree coverage". Fold queries (driving the code-fold
-//! feature) live alongside these constants once that feature is added.
+//! not "perfect parse-tree coverage".
 
 use crate::syntax::language::Lang;
 
@@ -131,6 +132,144 @@ const SYMBOLS_HTML: &str = r#"
 const SYMBOLS_CSS: &str = r#"
 (rule_set (selectors) @name) @symbol.rule
 "#;
+
+// ── Fold queries ──────────────────────────────────────────────────────────
+
+const FOLDS_RUST: &str = r#"
+(function_item body: (block) @fold)
+(impl_item body: (declaration_list) @fold)
+(struct_item body: (field_declaration_list) @fold)
+(enum_item body: (enum_variant_list) @fold)
+(trait_item body: (declaration_list) @fold)
+(mod_item body: (declaration_list) @fold)
+(match_expression body: (match_block) @fold)
+"#;
+
+const FOLDS_PYTHON: &str = r#"
+(function_definition body: (block) @fold)
+(class_definition body: (block) @fold)
+(if_statement consequence: (block) @fold)
+(for_statement body: (block) @fold)
+(while_statement body: (block) @fold)
+(try_statement body: (block) @fold)
+"#;
+
+const FOLDS_JAVASCRIPT: &str = r#"
+(function_declaration body: (statement_block) @fold)
+(method_definition body: (statement_block) @fold)
+(class_body) @fold
+(arrow_function body: (statement_block) @fold)
+"#;
+
+const FOLDS_TYPESCRIPT: &str = r#"
+(function_declaration body: (statement_block) @fold)
+(method_definition body: (statement_block) @fold)
+(class_body) @fold
+(interface_body) @fold
+(arrow_function body: (statement_block) @fold)
+"#;
+
+const FOLDS_TSX: &str = FOLDS_TYPESCRIPT;
+
+const FOLDS_JSON: &str = r#"
+(object) @fold
+(array) @fold
+"#;
+
+const FOLDS_MARKDOWN: &str = r#"
+(section) @fold
+(fenced_code_block) @fold
+"#;
+
+const FOLDS_BASH: &str = r#"
+(function_definition body: (compound_statement) @fold)
+(if_statement) @fold
+(for_statement) @fold
+(while_statement) @fold
+(case_statement) @fold
+"#;
+
+const FOLDS_CSHARP: &str = r#"
+(class_declaration body: (declaration_list) @fold)
+(interface_declaration body: (declaration_list) @fold)
+(struct_declaration body: (declaration_list) @fold)
+(method_declaration body: (block) @fold)
+(constructor_declaration body: (block) @fold)
+(namespace_declaration body: (declaration_list) @fold)
+"#;
+
+const FOLDS_JAVA: &str = r#"
+(class_declaration body: (class_body) @fold)
+(interface_declaration body: (interface_body) @fold)
+(enum_declaration body: (enum_body) @fold)
+(method_declaration body: (block) @fold)
+(constructor_declaration body: (constructor_body) @fold)
+"#;
+
+const FOLDS_GO: &str = r#"
+(function_declaration body: (block) @fold)
+(method_declaration body: (block) @fold)
+(if_statement consequence: (block) @fold)
+(for_statement body: (block) @fold)
+"#;
+
+const FOLDS_KOTLIN: &str = r#"
+(class_body) @fold
+(function_body) @fold
+(when_expression) @fold
+"#;
+
+const FOLDS_GROOVY: &str = r#"
+(class_body) @fold
+(closure) @fold
+"#;
+
+const FOLDS_YAML: &str = r#"
+(block_mapping) @fold
+(block_sequence) @fold
+"#;
+
+const FOLDS_TOML: &str = r#"
+(table) @fold
+(table_array_element) @fold
+(inline_table) @fold
+(array) @fold
+"#;
+
+const FOLDS_HTML: &str = r#"
+(element) @fold
+"#;
+
+const FOLDS_CSS: &str = r#"
+(rule_set) @fold
+(media_statement) @fold
+"#;
+
+/// Return the fold query for `lang`. Empty string means "no folds for this
+/// grammar"; `None` means the grammar isn't supported at all.
+pub fn folds_query_for(lang: Lang) -> Option<&'static str> {
+    Some(match lang {
+        Lang::Rust => FOLDS_RUST,
+        Lang::Python => FOLDS_PYTHON,
+        Lang::JavaScript => FOLDS_JAVASCRIPT,
+        Lang::TypeScript => FOLDS_TYPESCRIPT,
+        Lang::Tsx => FOLDS_TSX,
+        Lang::Json => FOLDS_JSON,
+        Lang::Markdown => FOLDS_MARKDOWN,
+        Lang::Sh => FOLDS_BASH,
+        Lang::CSharp => FOLDS_CSHARP,
+        Lang::Java => FOLDS_JAVA,
+        Lang::Go => FOLDS_GO,
+        Lang::Kotlin => FOLDS_KOTLIN,
+        Lang::Groovy => FOLDS_GROOVY,
+        Lang::Yaml => FOLDS_YAML,
+        Lang::Properties => "",
+        Lang::Toml => FOLDS_TOML,
+        Lang::Html => FOLDS_HTML,
+        Lang::Css => FOLDS_CSS,
+        Lang::Unknown => return None,
+    })
+}
 
 /// Return the symbols query for `lang`, or `None` if no query is defined.
 pub fn symbols_query_for(lang: Lang) -> Option<&'static str> {

--- a/src/syntax/queries.rs
+++ b/src/syntax/queries.rs
@@ -1,0 +1,158 @@
+//! Tree-sitter queries for cross-cutting features.
+//!
+//! Currently houses the **symbols-in-file** queries used by the
+//! `Ctrl+Shift+O` picker: each grammar's query captures a `@name` for every
+//! named definition (function, struct, class, etc.) and tags it with
+//! `@symbol.<kind>` so the runtime can render a kind glyph.
+//!
+//! Queries are kept inline as Rust string constants so the grammar list and
+//! the queries that exercise it sit in the same place. Each grammar gets a
+//! pragmatic best-effort query — the goal is "useful in 90% of files",
+//! not "perfect parse-tree coverage". Fold queries (driving the code-fold
+//! feature) live alongside these constants once that feature is added.
+
+use crate::syntax::language::Lang;
+
+// ── Symbol queries ────────────────────────────────────────────────────────
+
+const SYMBOLS_RUST: &str = r#"
+(function_item name: (identifier) @name) @symbol.fn
+(impl_item type: (type_identifier) @name) @symbol.impl
+(struct_item name: (type_identifier) @name) @symbol.struct
+(enum_item name: (type_identifier) @name) @symbol.enum
+(trait_item name: (type_identifier) @name) @symbol.trait
+(mod_item name: (identifier) @name) @symbol.mod
+(const_item name: (identifier) @name) @symbol.const
+(static_item name: (identifier) @name) @symbol.static
+(macro_definition name: (identifier) @name) @symbol.macro
+(type_item name: (type_identifier) @name) @symbol.type
+"#;
+
+const SYMBOLS_PYTHON: &str = r#"
+(function_definition name: (identifier) @name) @symbol.fn
+(class_definition name: (identifier) @name) @symbol.class
+(decorated_definition (function_definition name: (identifier) @name)) @symbol.fn
+(decorated_definition (class_definition name: (identifier) @name)) @symbol.class
+"#;
+
+const SYMBOLS_JAVASCRIPT: &str = r#"
+(function_declaration name: (identifier) @name) @symbol.fn
+(method_definition name: (property_identifier) @name) @symbol.fn
+(class_declaration name: (identifier) @name) @symbol.class
+(variable_declarator name: (identifier) @name value: (arrow_function)) @symbol.fn
+(variable_declarator name: (identifier) @name value: (function_expression)) @symbol.fn
+(generator_function_declaration name: (identifier) @name) @symbol.fn
+"#;
+
+const SYMBOLS_TYPESCRIPT: &str = r#"
+(function_declaration name: (identifier) @name) @symbol.fn
+(method_definition name: (property_identifier) @name) @symbol.fn
+(class_declaration name: (type_identifier) @name) @symbol.class
+(interface_declaration name: (type_identifier) @name) @symbol.interface
+(type_alias_declaration name: (type_identifier) @name) @symbol.type
+(enum_declaration name: (identifier) @name) @symbol.enum
+(variable_declarator name: (identifier) @name value: (arrow_function)) @symbol.fn
+"#;
+
+const SYMBOLS_TSX: &str = SYMBOLS_TYPESCRIPT;
+
+const SYMBOLS_JSON: &str = r#"
+(pair key: (string (string_content) @name)) @symbol.key
+"#;
+
+const SYMBOLS_MARKDOWN: &str = r#"
+(atx_heading (atx_h1_marker) heading_content: (_) @name) @symbol.h1
+(atx_heading (atx_h2_marker) heading_content: (_) @name) @symbol.h2
+(atx_heading (atx_h3_marker) heading_content: (_) @name) @symbol.h3
+(atx_heading (atx_h4_marker) heading_content: (_) @name) @symbol.h4
+"#;
+
+const SYMBOLS_BASH: &str = r#"
+(function_definition name: (word) @name) @symbol.fn
+"#;
+
+const SYMBOLS_CSHARP: &str = r#"
+(class_declaration name: (identifier) @name) @symbol.class
+(interface_declaration name: (identifier) @name) @symbol.interface
+(struct_declaration name: (identifier) @name) @symbol.struct
+(enum_declaration name: (identifier) @name) @symbol.enum
+(method_declaration name: (identifier) @name) @symbol.fn
+(constructor_declaration name: (identifier) @name) @symbol.fn
+(property_declaration name: (identifier) @name) @symbol.property
+(namespace_declaration name: (_) @name) @symbol.ns
+"#;
+
+const SYMBOLS_JAVA: &str = r#"
+(class_declaration name: (identifier) @name) @symbol.class
+(interface_declaration name: (identifier) @name) @symbol.interface
+(enum_declaration name: (identifier) @name) @symbol.enum
+(method_declaration name: (identifier) @name) @symbol.fn
+(constructor_declaration name: (identifier) @name) @symbol.fn
+"#;
+
+const SYMBOLS_GO: &str = r#"
+(function_declaration name: (identifier) @name) @symbol.fn
+(method_declaration name: (field_identifier) @name) @symbol.fn
+(type_declaration (type_spec name: (type_identifier) @name)) @symbol.type
+(const_declaration (const_spec name: (identifier) @name)) @symbol.const
+(var_declaration (var_spec name: (identifier) @name)) @symbol.var
+"#;
+
+const SYMBOLS_KOTLIN: &str = r#"
+(class_declaration (type_identifier) @name) @symbol.class
+(function_declaration (simple_identifier) @name) @symbol.fn
+(object_declaration (type_identifier) @name) @symbol.object
+(property_declaration (variable_declaration (simple_identifier) @name)) @symbol.property
+"#;
+
+const SYMBOLS_GROOVY: &str = r#"
+(class_declaration name: (identifier) @name) @symbol.class
+(function_definition name: (identifier) @name) @symbol.fn
+"#;
+
+const SYMBOLS_YAML: &str = r#"
+(block_mapping_pair key: (flow_node) @name) @symbol.key
+"#;
+
+const SYMBOLS_PROPERTIES: &str = r#"
+(property (key) @name) @symbol.key
+"#;
+
+const SYMBOLS_TOML: &str = r#"
+(table (bare_key) @name) @symbol.table
+(table_array_element (bare_key) @name) @symbol.table
+(pair (bare_key) @name) @symbol.key
+"#;
+
+const SYMBOLS_HTML: &str = r#"
+(element (start_tag (tag_name) @name)) @symbol.tag
+"#;
+
+const SYMBOLS_CSS: &str = r#"
+(rule_set (selectors) @name) @symbol.rule
+"#;
+
+/// Return the symbols query for `lang`, or `None` if no query is defined.
+pub fn symbols_query_for(lang: Lang) -> Option<&'static str> {
+    Some(match lang {
+        Lang::Rust => SYMBOLS_RUST,
+        Lang::Python => SYMBOLS_PYTHON,
+        Lang::JavaScript => SYMBOLS_JAVASCRIPT,
+        Lang::TypeScript => SYMBOLS_TYPESCRIPT,
+        Lang::Tsx => SYMBOLS_TSX,
+        Lang::Json => SYMBOLS_JSON,
+        Lang::Markdown => SYMBOLS_MARKDOWN,
+        Lang::Sh => SYMBOLS_BASH,
+        Lang::CSharp => SYMBOLS_CSHARP,
+        Lang::Java => SYMBOLS_JAVA,
+        Lang::Go => SYMBOLS_GO,
+        Lang::Kotlin => SYMBOLS_KOTLIN,
+        Lang::Groovy => SYMBOLS_GROOVY,
+        Lang::Yaml => SYMBOLS_YAML,
+        Lang::Properties => SYMBOLS_PROPERTIES,
+        Lang::Toml => SYMBOLS_TOML,
+        Lang::Html => SYMBOLS_HTML,
+        Lang::Css => SYMBOLS_CSS,
+        Lang::Unknown => return None,
+    })
+}

--- a/src/ui/command_palette.rs
+++ b/src/ui/command_palette.rs
@@ -62,6 +62,11 @@ pub static COMMANDS: &[CommandEntry] = &[
         action: || EditorAction::OpenFuzzyPicker,
     },
     CommandEntry {
+        name: "Go to Symbol in File",
+        key_hint: "Ctrl+Shift+O",
+        action: || EditorAction::OpenSymbolPicker,
+    },
+    CommandEntry {
         name: "Buffer Switcher",
         key_hint: "Ctrl+Shift+E",
         action: || EditorAction::OpenBufferSwitcher,

--- a/src/ui/command_palette.rs
+++ b/src/ui/command_palette.rs
@@ -82,6 +82,26 @@ pub static COMMANDS: &[CommandEntry] = &[
         action: || EditorAction::UnfoldAll,
     },
     CommandEntry {
+        name: "Set Mark…",
+        key_hint: "Ctrl+M",
+        action: || EditorAction::BeginSetMark,
+    },
+    CommandEntry {
+        name: "Jump to Mark…",
+        key_hint: "Ctrl+'",
+        action: || EditorAction::BeginJumpToMark,
+    },
+    CommandEntry {
+        name: "Jump-list Back",
+        key_hint: "Alt+Left",
+        action: || EditorAction::JumpListBack,
+    },
+    CommandEntry {
+        name: "Jump-list Forward",
+        key_hint: "Alt+Right",
+        action: || EditorAction::JumpListForward,
+    },
+    CommandEntry {
         name: "Buffer Switcher",
         key_hint: "Ctrl+Shift+E",
         action: || EditorAction::OpenBufferSwitcher,

--- a/src/ui/command_palette.rs
+++ b/src/ui/command_palette.rs
@@ -107,6 +107,16 @@ pub static COMMANDS: &[CommandEntry] = &[
         action: || EditorAction::ExpandSnippetAtCursor,
     },
     CommandEntry {
+        name: "Record / Stop Macro",
+        key_hint: "Ctrl+Shift+R",
+        action: || EditorAction::BeginRecordMacro,
+    },
+    CommandEntry {
+        name: "Replay Macro…",
+        key_hint: "Ctrl+Alt+R",
+        action: || EditorAction::BeginReplayMacro,
+    },
+    CommandEntry {
         name: "Buffer Switcher",
         key_hint: "Ctrl+Shift+E",
         action: || EditorAction::OpenBufferSwitcher,

--- a/src/ui/command_palette.rs
+++ b/src/ui/command_palette.rs
@@ -102,6 +102,11 @@ pub static COMMANDS: &[CommandEntry] = &[
         action: || EditorAction::JumpListForward,
     },
     CommandEntry {
+        name: "Expand Snippet at Cursor",
+        key_hint: "Tab",
+        action: || EditorAction::ExpandSnippetAtCursor,
+    },
+    CommandEntry {
         name: "Buffer Switcher",
         key_hint: "Ctrl+Shift+E",
         action: || EditorAction::OpenBufferSwitcher,

--- a/src/ui/command_palette.rs
+++ b/src/ui/command_palette.rs
@@ -67,6 +67,21 @@ pub static COMMANDS: &[CommandEntry] = &[
         action: || EditorAction::OpenSymbolPicker,
     },
     CommandEntry {
+        name: "Toggle Fold at Cursor",
+        key_hint: "Ctrl+Shift+[",
+        action: || EditorAction::ToggleFoldAtCursor,
+    },
+    CommandEntry {
+        name: "Fold All",
+        key_hint: "Alt+0",
+        action: || EditorAction::FoldAll,
+    },
+    CommandEntry {
+        name: "Unfold All",
+        key_hint: "Alt+Shift+0",
+        action: || EditorAction::UnfoldAll,
+    },
+    CommandEntry {
         name: "Buffer Switcher",
         key_hint: "Ctrl+Shift+E",
         action: || EditorAction::OpenBufferSwitcher,

--- a/src/ui/editor_view.rs
+++ b/src/ui/editor_view.rs
@@ -40,6 +40,8 @@ pub fn render(
     focused: bool,
     show_whitespace: bool,
     tab_size: usize,
+    indent_guides: bool,
+    rulers: &[usize],
     theme: &ThemeColors,
     area: Rect,
     buf: &mut TermBuffer,
@@ -367,6 +369,78 @@ pub fn render(
             buf.set_string(text_area.x, y, " ", cursor_style);
         }
     }
+
+    // ── Indent guides and column rulers (post-pass overlay) ───────────────
+    // Both are drawn *after* the main text pass and only on cells that still
+    // show a plain space — they never overwrite cursors, selections, or the
+    // first non-whitespace character of a line.
+    if (indent_guides && tab_size > 0) || !rulers.is_empty() {
+        let guide_style = Style::default().fg(Color::Rgb(70, 70, 95));
+        let max_x = text_area.x + text_area.width;
+        for (screen_row, vl) in visual_lines.iter().enumerate() {
+            let y = area.y + screen_row as u16;
+
+            // Compute first non-whitespace display column for this logical
+            // line (only meaningful on the first visual segment).
+            let first_non_ws = if indent_guides && vl.is_first_seg {
+                first_non_whitespace_display_col(&handle.buffer.line_str(vl.line_idx), tab_size)
+            } else {
+                0
+            };
+
+            if indent_guides && vl.is_first_seg && first_non_ws >= tab_size {
+                let mut col = tab_size;
+                while col < first_non_ws {
+                    let x = text_area.x + col as u16;
+                    if x >= max_x {
+                        break;
+                    }
+                    overlay_guide(buf, x, y, "│", guide_style);
+                    col += tab_size;
+                }
+            }
+
+            for &ruler in rulers {
+                if ruler == 0 || ruler >= text_area.width as usize {
+                    continue;
+                }
+                let x = text_area.x + ruler as u16;
+                if x < max_x {
+                    overlay_guide(buf, x, y, "│", guide_style);
+                }
+            }
+        }
+    }
+}
+
+/// Display column of the first non-whitespace character on `line`. If the line
+/// is entirely whitespace (or empty), returns the display width of all leading
+/// whitespace — i.e. "any indent guide column up to here is fine to draw".
+fn first_non_whitespace_display_col(line: &str, tab_size: usize) -> usize {
+    let mut col = 0usize;
+    for grapheme in line_str_graphemes(line) {
+        match grapheme {
+            " " => col += 1,
+            "\t" => col += tab_size.saturating_sub(col % tab_size).max(1),
+            _ => return col,
+        }
+    }
+    col
+}
+
+/// Overlay a guide glyph at `(x, y)` only when the underlying cell still
+/// shows a plain space and has the default background. Prevents indent/ruler
+/// guides from clobbering cursors, selections, or syntax highlights.
+fn overlay_guide(buf: &mut TermBuffer, x: u16, y: u16, glyph: &str, style: Style) {
+    use ratatui::layout::Position;
+    let pos = Position::new(x, y);
+    if let Some(cell) = buf.cell(pos) {
+        let symbol = cell.symbol();
+        let has_bg_style = cell.bg != Color::Reset;
+        if (symbol == " " || symbol.is_empty()) && !has_bg_style {
+            buf.set_string(x, y, glyph, style);
+        }
+    }
 }
 
 /// Choose the highlight style for a grapheme at `byte_offset`.
@@ -510,6 +584,33 @@ mod tests {
         assert_eq!(gutter_width(99), 2);
         assert_eq!(gutter_width(100), 3);
         assert_eq!(gutter_width(1000), 4);
+    }
+
+    #[test]
+    fn first_non_ws_display_col_blank_line_returns_indent_width() {
+        // 8 spaces, no content → returns 8 so guides span the whole indent.
+        assert_eq!(first_non_whitespace_display_col("        ", 4), 8);
+    }
+
+    #[test]
+    fn first_non_ws_display_col_spaces_then_text() {
+        assert_eq!(first_non_whitespace_display_col("    fn foo()", 4), 4);
+        assert_eq!(first_non_whitespace_display_col("        x", 4), 8);
+    }
+
+    #[test]
+    fn first_non_ws_display_col_tabs_round_to_tab_stop() {
+        // One tab at width 4 → column 4.
+        assert_eq!(first_non_whitespace_display_col("\tfoo", 4), 4);
+        // Two tabs → column 8.
+        assert_eq!(first_non_whitespace_display_col("\t\tfoo", 4), 8);
+        // Tab at width 8.
+        assert_eq!(first_non_whitespace_display_col("\tfoo", 8), 8);
+    }
+
+    #[test]
+    fn first_non_ws_display_col_no_indent_returns_zero() {
+        assert_eq!(first_non_whitespace_display_col("hello", 4), 0);
     }
 
     #[test]

--- a/src/ui/editor_view.rs
+++ b/src/ui/editor_view.rs
@@ -20,6 +20,8 @@ const GUTTER_PAD: u16 = 1;
 const GIT_GUTTER_W: u16 = 1;
 /// Width of the diagnostic gutter column (shown when diagnostics are present).
 const DIAG_GUTTER_W: u16 = 1;
+/// Width of the fold-chevron gutter column (shown when any fold candidates exist).
+const FOLD_GUTTER_W: u16 = 1;
 
 /// Render the text editing area into the ratatui terminal buffer.
 ///
@@ -55,8 +57,12 @@ pub fn render(
     let git_col_w: u16 = if has_git { GIT_GUTTER_W } else { 0 };
     let has_diag = !handle.lsp_state.diagnostics.is_empty();
     let diag_col_w: u16 = if has_diag { DIAG_GUTTER_W } else { 0 };
+    // Fold gutter is shown only when the buffer has at least one foldable
+    // candidate range — keeps the gutter tight for plaintext and short files.
+    let has_folds = (0..total_lines).any(|i| handle.folds.is_fold_start_candidate(i));
+    let fold_col_w: u16 = if has_folds { FOLD_GUTTER_W } else { 0 };
     let gw = gutter_width(total_lines);
-    let text_area = text_area(area, gw, git_col_w, diag_col_w);
+    let text_area = text_area(area, gw, git_col_w, diag_col_w, fold_col_w);
 
     // Build per-line diagnostic severity map (highest severity per line).
     let diag_line_severity = if has_diag {
@@ -149,11 +155,16 @@ pub fn render(
     }
 
     let height = area.height as usize;
+    // Walk extra lines so folds collapsing several screen rows don't leave
+    // empty space at the bottom of the editor. 4x is a generous upper bound
+    // for typical fold ratios.
+    let walk_lines = if has_folds { height * 4 } else { height };
     let visual_lines: Vec<VisualLine> = if handle.viewport.word_wrap && text_area.width > 0 {
-        let wrapped =
-            handle
-                .viewport
-                .visible_lines_wrapped(&handle.buffer, height, text_area.width as usize);
+        let wrapped = handle.viewport.visible_lines_wrapped(
+            &handle.buffer,
+            walk_lines,
+            text_area.width as usize,
+        );
         let mut last_line = usize::MAX;
         wrapped
             .into_iter()
@@ -167,11 +178,13 @@ pub fn render(
                     is_first_seg,
                 }
             })
+            .filter(|vl| !handle.folds.is_line_hidden(vl.line_idx))
+            .take(height)
             .collect()
     } else {
         handle
             .viewport
-            .visible_lines(&handle.buffer, height)
+            .visible_lines(&handle.buffer, walk_lines)
             .map(|(line_idx, display)| {
                 let seg_byte = scroll_col_byte_offset(
                     &handle.buffer.line_str(line_idx),
@@ -184,6 +197,8 @@ pub fn render(
                     is_first_seg: true,
                 }
             })
+            .filter(|vl| !handle.folds.is_line_hidden(vl.line_idx))
+            .take(height)
             .collect()
     };
 
@@ -215,8 +230,23 @@ pub fn render(
             buf.set_string(diag_x, y, diag_sym, diag_sty);
         }
 
+        // ── Fold gutter ──────────────────────────────────────────────────────
+        if has_folds && vl.is_first_seg {
+            let fold_x = area.x + git_col_w + diag_col_w;
+            let folded = handle.folds.is_fold_start_folded(line_idx);
+            let candidate = handle.folds.is_fold_start_candidate(line_idx);
+            let (sym, sty) = if folded {
+                ("▸", Style::default().fg(Color::Rgb(220, 180, 80)))
+            } else if candidate {
+                ("▾", Style::default().fg(Color::Rgb(90, 100, 120)))
+            } else {
+                (" ", Style::default())
+            };
+            buf.set_string(fold_x, y, sym, sty);
+        }
+
         // ── Gutter (line number) ─────────────────────────────────────────────
-        let gutter_x = area.x + git_col_w + diag_col_w;
+        let gutter_x = area.x + git_col_w + diag_col_w + fold_col_w;
         let is_current_line = line_idx == cursor.line;
         let num_style = if is_current_line {
             line_num_current_style
@@ -345,6 +375,20 @@ pub fn render(
             && screen_x < max_x
         {
             buf.set_string(screen_x, y, " ", cursor_style);
+        }
+
+        // Append "▸ N lines" marker on the start line of a folded range so
+        // the reader knows the content is hidden, not just blank.
+        if vl.is_first_seg
+            && let Some(end_line) = handle.folds.folded_end_line(line_idx)
+            && screen_x + 2 < max_x
+        {
+            let n = end_line - line_idx;
+            let label = format!("  ▸ {n} lines");
+            let fold_inline_style = Style::default().fg(Color::Rgb(180, 140, 40));
+            let avail = (max_x - screen_x) as usize;
+            let clipped: String = label.chars().take(avail).collect();
+            buf.set_string(screen_x, y, &clipped, fold_inline_style);
         }
         // Draw secondary cursors at end of line.
         if is_last_seg || !handle.viewport.word_wrap {
@@ -527,8 +571,8 @@ pub fn gutter_width(total_lines: usize) -> u16 {
 
 // ── Private helpers ───────────────────────────────────────────────────────────
 
-fn text_area(area: Rect, gutter_w: u16, git_col_w: u16, diag_col_w: u16) -> Rect {
-    let gutter_total = git_col_w + diag_col_w + gutter_w + GUTTER_PAD;
+fn text_area(area: Rect, gutter_w: u16, git_col_w: u16, diag_col_w: u16, fold_col_w: u16) -> Rect {
+    let gutter_total = git_col_w + diag_col_w + fold_col_w + gutter_w + GUTTER_PAD;
     if area.width <= gutter_total {
         return Rect::new(area.x + area.width, area.y, 0, area.height);
     }
@@ -616,7 +660,7 @@ mod tests {
     #[test]
     fn text_area_layout_no_git() {
         let area = Rect::new(0, 0, 80, 24);
-        let ta = text_area(area, 3, 0, 0);
+        let ta = text_area(area, 3, 0, 0, 0);
         assert_eq!(ta.x, 4);
         assert_eq!(ta.width, 76);
     }
@@ -624,7 +668,7 @@ mod tests {
     #[test]
     fn text_area_layout_with_git_gutter() {
         let area = Rect::new(0, 0, 80, 24);
-        let ta = text_area(area, 3, GIT_GUTTER_W, 0);
+        let ta = text_area(area, 3, GIT_GUTTER_W, 0, 0);
         // git(1) + line_num(3) + pad(1) = 5
         assert_eq!(ta.x, 5);
         assert_eq!(ta.width, 75);
@@ -633,17 +677,26 @@ mod tests {
     #[test]
     fn text_area_too_narrow() {
         let area = Rect::new(0, 0, 3, 24);
-        let ta = text_area(area, 3, 0, 0);
+        let ta = text_area(area, 3, 0, 0, 0);
         assert_eq!(ta.width, 0);
     }
 
     #[test]
     fn text_area_layout_with_diagnostics() {
         let area = Rect::new(0, 0, 80, 24);
-        let ta = text_area(area, 3, GIT_GUTTER_W, DIAG_GUTTER_W);
+        let ta = text_area(area, 3, GIT_GUTTER_W, DIAG_GUTTER_W, 0);
         // git(1) + diag(1) + line_num(3) + pad(1) = 6
         assert_eq!(ta.x, 6);
         assert_eq!(ta.width, 74);
+    }
+
+    #[test]
+    fn text_area_layout_with_fold_gutter() {
+        let area = Rect::new(0, 0, 80, 24);
+        let ta = text_area(area, 3, GIT_GUTTER_W, DIAG_GUTTER_W, FOLD_GUTTER_W);
+        // git(1) + diag(1) + fold(1) + line_num(3) + pad(1) = 7
+        assert_eq!(ta.x, 7);
+        assert_eq!(ta.width, 73);
     }
 
     #[test]

--- a/src/ui/help_overlay.rs
+++ b/src/ui/help_overlay.rs
@@ -305,6 +305,14 @@ const TEMPLATE: &[HelpEntry] = &[
         desc: "Expand snippet at cursor (Tab; see ~/.config/txt/snippets/)",
     },
     HelpEntry::Binding {
+        actions: &["record_macro"],
+        desc: "Record/stop keyboard macro (a–z slot)",
+    },
+    HelpEntry::Binding {
+        actions: &["replay_macro"],
+        desc: "Replay keyboard macro (a–z slot)",
+    },
+    HelpEntry::Binding {
         actions: &["open_recent_files"],
         desc: "Recent files",
     },

--- a/src/ui/help_overlay.rs
+++ b/src/ui/help_overlay.rs
@@ -301,6 +301,10 @@ const TEMPLATE: &[HelpEntry] = &[
         desc: "Jump-list forward",
     },
     HelpEntry::Binding {
+        actions: &["expand_snippet"],
+        desc: "Expand snippet at cursor (Tab; see ~/.config/txt/snippets/)",
+    },
+    HelpEntry::Binding {
         actions: &["open_recent_files"],
         desc: "Recent files",
     },

--- a/src/ui/help_overlay.rs
+++ b/src/ui/help_overlay.rs
@@ -285,6 +285,22 @@ const TEMPLATE: &[HelpEntry] = &[
         desc: "Unfold all (Alt+Shift+0)",
     },
     HelpEntry::Binding {
+        actions: &["set_mark"],
+        desc: "Set named mark (Ctrl+M then a–z)",
+    },
+    HelpEntry::Binding {
+        actions: &["jump_to_mark"],
+        desc: "Jump to named mark (Ctrl+' then a–z)",
+    },
+    HelpEntry::Binding {
+        actions: &["jump_list_back"],
+        desc: "Jump-list back",
+    },
+    HelpEntry::Binding {
+        actions: &["jump_list_forward"],
+        desc: "Jump-list forward",
+    },
+    HelpEntry::Binding {
         actions: &["open_recent_files"],
         desc: "Recent files",
     },

--- a/src/ui/help_overlay.rs
+++ b/src/ui/help_overlay.rs
@@ -273,6 +273,18 @@ const TEMPLATE: &[HelpEntry] = &[
         desc: "Symbols in file picker",
     },
     HelpEntry::Binding {
+        actions: &["toggle_fold_at_cursor"],
+        desc: "Toggle fold at cursor",
+    },
+    HelpEntry::Binding {
+        actions: &["fold_all"],
+        desc: "Fold all (Alt+0)",
+    },
+    HelpEntry::Binding {
+        actions: &["unfold_all"],
+        desc: "Unfold all (Alt+Shift+0)",
+    },
+    HelpEntry::Binding {
         actions: &["open_recent_files"],
         desc: "Recent files",
     },

--- a/src/ui/help_overlay.rs
+++ b/src/ui/help_overlay.rs
@@ -269,6 +269,10 @@ const TEMPLATE: &[HelpEntry] = &[
         desc: "Fuzzy file picker",
     },
     HelpEntry::Binding {
+        actions: &["open_symbol_picker"],
+        desc: "Symbols in file picker",
+    },
+    HelpEntry::Binding {
         actions: &["open_recent_files"],
         desc: "Recent files",
     },

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -185,6 +185,8 @@ pub fn render(state: &mut AppState, frame: &mut Frame) {
         editor_focused,
         state.config.show_whitespace,
         state.config.tab_size,
+        state.config.indent_guides,
+        &state.config.rulers,
         &theme,
         editor_area,
         buf,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -16,6 +16,7 @@ pub mod settings_overlay;
 pub mod sidebar;
 pub mod status_bar;
 pub mod sticky_header;
+pub mod symbol_picker;
 pub mod tab_bar;
 pub mod welcome_overlay;
 
@@ -172,6 +173,7 @@ pub fn render(state: &mut AppState, frame: &mut Frame) {
 
     let editor_focused = !state.sidebar_focused
         && state.fuzzy_picker.is_none()
+        && state.symbol_picker.is_none()
         && state.command_palette.is_none()
         && !state.show_help
         && !state.show_settings
@@ -271,6 +273,11 @@ pub fn render(state: &mut AppState, frame: &mut Frame) {
     // ── Fuzzy picker floating overlay ─────────────────────────────────────────
     if let Some(picker) = &state.fuzzy_picker {
         fuzzy_picker::render(picker, &theme, area, buf);
+    }
+
+    // ── Symbols-in-file picker overlay ────────────────────────────────────────
+    if let Some(picker) = &state.symbol_picker {
+        symbol_picker::render(picker, &theme, area, buf);
     }
 
     // ── Command palette overlay ───────────────────────────────────────────────

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -15,6 +15,7 @@ pub mod search_bar;
 pub mod settings_overlay;
 pub mod sidebar;
 pub mod status_bar;
+pub mod sticky_header;
 pub mod tab_bar;
 pub mod welcome_overlay;
 
@@ -177,6 +178,30 @@ pub fn render(state: &mut AppState, frame: &mut Frame) {
         && !state.show_welcome
         && !state.show_changelog;
 
+    // Compute the sticky header path for the active buffer's cursor and, when
+    // it's non-empty and there's room, reserve the first row of the editor
+    // pane for it.
+    let sticky_path = if state.config.sticky_header && editor_area.height >= 3 {
+        let cursor_byte = handle.buffer.cursors.primary().byte_offset;
+        handle
+            .syntax
+            .enclosing_named_path(handle.buffer.rope(), cursor_byte)
+    } else {
+        Vec::new()
+    };
+    let (header_area, editor_area) = if !sticky_path.is_empty() {
+        let header = Rect::new(editor_area.x, editor_area.y, editor_area.width, 1);
+        let body = Rect::new(
+            editor_area.x,
+            editor_area.y + 1,
+            editor_area.width,
+            editor_area.height.saturating_sub(1),
+        );
+        (Some(header), body)
+    } else {
+        (None, editor_area)
+    };
+
     editor_view::render(
         handle,
         state.search_state.as_ref(),
@@ -191,6 +216,10 @@ pub fn render(state: &mut AppState, frame: &mut Frame) {
         editor_area,
         buf,
     );
+
+    if let Some(ha) = header_area {
+        sticky_header::render(&sticky_path, ha, buf);
+    }
 
     if let Some(sa) = search_area_opt
         && let Some(ss) = &state.search_state

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -181,14 +181,23 @@ pub fn render(state: &mut AppState, frame: &mut Frame) {
         && !state.show_welcome
         && !state.show_changelog;
 
-    // Compute the sticky header path for the active buffer's cursor and, when
-    // it's non-empty and there's room, reserve the first row of the editor
-    // pane for it.
+    // Compute the sticky header path from the *top visible line* of the
+    // editor pane (not the cursor) so that scrolling through a class
+    // updates the header even when the cursor stays put. The cursor's
+    // position is a poor signal here: a user reading code by scrolling
+    // would otherwise see the header stuck on whichever function the
+    // cursor happens to be inside.
     let sticky_path = if state.config.sticky_header && editor_area.height >= 3 {
-        let cursor_byte = handle.buffer.cursors.primary().byte_offset;
-        handle
-            .syntax
-            .enclosing_named_path(handle.buffer.rope(), cursor_byte)
+        let rope = handle.buffer.rope();
+        let scroll_row = handle.viewport.scroll_row;
+        let total_lines = rope.len_lines();
+        let top_line = scroll_row.min(total_lines.saturating_sub(1));
+        let top_byte = if top_line >= total_lines {
+            rope.len_bytes()
+        } else {
+            rope.line_to_byte(top_line)
+        };
+        handle.syntax.enclosing_named_path(rope, top_byte)
     } else {
         Vec::new()
     };

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -119,10 +119,15 @@ pub fn render(state: &AppState, theme: &ThemeColors, area: Rect, buf: &mut TermB
         .unwrap_or_default();
 
     let indent_str = format!(" {}", state.indent_label());
+    let rec_str = state
+        .macros
+        .recording_slot()
+        .map(|c| format!(" REC {c}"))
+        .unwrap_or_default();
 
-    // Right side: branch + word-wrap flag + LSP/TS mode + diagnostics + language + indent + position + memory + encoding
+    // Right side: branch + word-wrap flag + LSP/TS mode + diagnostics + language + indent + REC + position + memory + encoding
     let right = format!(
-        "{}{}{}{}{}{}  {}{}{}",
+        "{}{}{}{}{}{}{}  {}{}{}",
         branch_str,
         wrap_flag,
         lsp_flag,
@@ -133,6 +138,7 @@ pub fn render(state: &AppState, theme: &ThemeColors, area: Rect, buf: &mut TermB
             String::new()
         },
         indent_str,
+        rec_str,
         pos,
         mem_str,
         enc
@@ -242,6 +248,8 @@ fn modal_prompt(mode: &InputMode) -> Option<String> {
         InputMode::AlignChar(s) => Some(format!(" Align lines on character: {}_", s)),
         InputMode::SetMarkChar => Some(" Mark: ".to_string()),
         InputMode::JumpToMarkChar => Some(" Jump to mark: ".to_string()),
+        InputMode::RecordMacroChar => Some(" Record macro into slot: ".to_string()),
+        InputMode::ReplayMacroChar => Some(" Replay macro from slot: ".to_string()),
     }
 }
 

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -164,13 +164,16 @@ pub fn render(state: &AppState, theme: &ThemeColors, area: Rect, buf: &mut TermB
     }
 
     // Language name after modified flag
-    if !modified_str.is_empty() {
+    let after_lang_x = if !modified_str.is_empty() {
         let lang_x = modified_x + modified_str.len().min(modified_available) as u16;
         let lang_available = (right_x as usize).saturating_sub(lang_x as usize);
         if lang_available > 2 && lang != "plain" {
             let lang_label = format!("  {}", lang);
             let l = truncate_str(&lang_label, lang_available);
             buf.set_string(lang_x, area.y, &l, lang_style);
+            lang_x + l.len() as u16
+        } else {
+            lang_x
         }
     } else if lang != "plain" {
         let lang_x = modified_x;
@@ -179,6 +182,30 @@ pub fn render(state: &AppState, theme: &ThemeColors, area: Rect, buf: &mut TermB
             let lang_label = format!("  {}", lang);
             let l = truncate_str(&lang_label, lang_available);
             buf.set_string(lang_x, area.y, &l, lang_style);
+            lang_x + l.len() as u16
+        } else {
+            lang_x
+        }
+    } else {
+        modified_x
+    };
+
+    // Breadcrumbs: enclosing function / class / module of the cursor.
+    if state.config.sticky_header {
+        let cursor_byte = handle.buffer.cursors.primary().byte_offset;
+        let path = handle
+            .syntax
+            .enclosing_named_path(handle.buffer.rope(), cursor_byte);
+        if !path.is_empty() {
+            let crumb_avail = (right_x as usize).saturating_sub(after_lang_x as usize + 3);
+            if crumb_avail > 4 {
+                let label = format!("  › {}", crate::ui::sticky_header::format_path(&path));
+                let trimmed = truncate_str(&label, crumb_avail);
+                let crumb_style = Style::default()
+                    .bg(theme.statusbar_bg)
+                    .fg(Color::Rgb(140, 160, 200));
+                buf.set_string(after_lang_x, area.y, &trimmed, crumb_style);
+            }
         }
     }
 }

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -240,6 +240,8 @@ fn modal_prompt(mode: &InputMode) -> Option<String> {
         InputMode::GitStashMessage(s) => Some(format!(" Stash message (optional): {}_", s)),
         InputMode::ShellFilter(s) => Some(format!(" Shell filter (selection): {}_", s)),
         InputMode::AlignChar(s) => Some(format!(" Align lines on character: {}_", s)),
+        InputMode::SetMarkChar => Some(" Mark: ".to_string()),
+        InputMode::JumpToMarkChar => Some(" Jump to mark: ".to_string()),
     }
 }
 

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -118,9 +118,11 @@ pub fn render(state: &AppState, theme: &ThemeColors, area: Rect, buf: &mut TermB
         .map(|b| format!(" ⎇ {}", b))
         .unwrap_or_default();
 
-    // Right side: branch + word-wrap flag + LSP/TS mode + diagnostics + language + position + memory + encoding
+    let indent_str = format!(" {}", state.indent_label());
+
+    // Right side: branch + word-wrap flag + LSP/TS mode + diagnostics + language + indent + position + memory + encoding
     let right = format!(
-        "{}{}{}{}{}  {}{}{}",
+        "{}{}{}{}{}{}  {}{}{}",
         branch_str,
         wrap_flag,
         lsp_flag,
@@ -130,6 +132,7 @@ pub fn render(state: &AppState, theme: &ThemeColors, area: Rect, buf: &mut TermB
         } else {
             String::new()
         },
+        indent_str,
         pos,
         mem_str,
         enc

--- a/src/ui/sticky_header.rs
+++ b/src/ui/sticky_header.rs
@@ -1,0 +1,134 @@
+//! Sticky header row at the top of the editor pane.
+//!
+//! Displays the enclosing function/class/module of the cursor's position,
+//! computed from the tree-sitter parse tree via
+//! [`crate::syntax::SyntaxHost::enclosing_named_path`]. Renders nothing when
+//! the path is empty so no row is reserved unnecessarily.
+
+use ratatui::{
+    buffer::Buffer as TermBuffer,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+};
+
+use crate::syntax::EnclosingSymbol;
+
+/// Format the breadcrumb path as `kind name › kind name › …`. Returns an
+/// empty string for an empty path.
+pub fn format_path(path: &[EnclosingSymbol]) -> String {
+    let mut out = String::new();
+    for (i, sym) in path.iter().enumerate() {
+        if i > 0 {
+            out.push_str(" › ");
+        }
+        out.push_str(sym.kind);
+        out.push(' ');
+        out.push_str(&sym.name);
+    }
+    out
+}
+
+/// Render one row showing the enclosing-symbol breadcrumb. The caller is
+/// responsible for shrinking the editor area by 1 row when this is drawn.
+pub fn render(path: &[EnclosingSymbol], area: Rect, buf: &mut TermBuffer) {
+    if area.width == 0 || area.height == 0 || path.is_empty() {
+        return;
+    }
+    let bg = Color::Rgb(22, 26, 40);
+    let fg = Color::Rgb(180, 190, 220);
+    let dim = Color::Rgb(110, 130, 170);
+    let bar_style = Style::default().bg(bg).fg(fg);
+
+    // Background fill for the header row.
+    for x in area.x..area.x + area.width {
+        buf.set_string(x, area.y, " ", bar_style);
+    }
+
+    let label = format_path(path);
+    let max = (area.width as usize).saturating_sub(2);
+    let truncated = truncate_left_keep_right(&label, max);
+    let prefix_style = bar_style.add_modifier(Modifier::ITALIC).fg(dim);
+    buf.set_string(area.x, area.y, " ", prefix_style);
+    buf.set_string(
+        area.x + 1,
+        area.y,
+        &truncated,
+        bar_style.add_modifier(Modifier::BOLD),
+    );
+}
+
+/// Truncate `s` to fit in `max_chars` columns, keeping the rightmost
+/// (innermost) part of the breadcrumb. Falls back to a left truncate if the
+/// string already fits.
+fn truncate_left_keep_right(s: &str, max_chars: usize) -> String {
+    let len = s.chars().count();
+    if len <= max_chars || max_chars == 0 {
+        return s.chars().take(max_chars).collect();
+    }
+    let want = max_chars.saturating_sub(1);
+    let skip = len - want;
+    let tail: String = s.chars().skip(skip).collect();
+    let mut out = String::with_capacity(tail.len() + 1);
+    out.push('…');
+    out.push_str(&tail);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sym(kind: &'static str, name: &str) -> EnclosingSymbol {
+        EnclosingSymbol {
+            kind,
+            name: name.into(),
+        }
+    }
+
+    #[test]
+    fn format_path_joins_with_chevron() {
+        let path = vec![sym("impl", "Bar"), sym("fn", "baz")];
+        assert_eq!(format_path(&path), "impl Bar › fn baz");
+    }
+
+    #[test]
+    fn format_path_empty_yields_empty_string() {
+        assert_eq!(format_path(&[]), "");
+    }
+
+    #[test]
+    fn truncate_left_keep_right_preserves_innermost() {
+        let s = "very long path › fn baz";
+        let out = truncate_left_keep_right(s, 10);
+        assert!(out.starts_with('…'), "out={out:?}");
+        assert!(out.ends_with("fn baz"), "out={out:?}");
+    }
+
+    #[test]
+    fn truncate_left_no_op_when_fits() {
+        assert_eq!(truncate_left_keep_right("fn baz", 20), "fn baz");
+    }
+
+    #[test]
+    fn render_skips_empty_path() {
+        let area = Rect::new(0, 0, 40, 1);
+        let mut buf = TermBuffer::empty(area);
+        let initial = buf.cell((0, 0)).unwrap().symbol().to_string();
+        render(&[], area, &mut buf);
+        // No writes for an empty path — the cell content is unchanged.
+        assert_eq!(buf.cell((0, 0)).unwrap().symbol(), initial);
+    }
+
+    #[test]
+    fn render_writes_path_when_non_empty() {
+        let area = Rect::new(0, 0, 40, 1);
+        let mut buf = TermBuffer::empty(area);
+        render(&[sym("fn", "main")], area, &mut buf);
+        // The full breadcrumb starts at column 1 (after the leading space pad).
+        let mut text = String::new();
+        for x in 0..40 {
+            text.push_str(buf.cell((x, 0)).unwrap().symbol());
+        }
+        assert!(text.contains("fn main"), "rendered text was {text:?}");
+    }
+}

--- a/src/ui/symbol_picker.rs
+++ b/src/ui/symbol_picker.rs
@@ -1,0 +1,198 @@
+//! Render the symbols-in-file picker (Ctrl+Shift+O).
+//!
+//! Same overall layout as [`super::fuzzy_picker`] — centered float with a
+//! query line and a scrollable result list — but each row shows a kind glyph
+//! (`fn`, `struct`, `class`, …) before the symbol name.
+
+use ratatui::{
+    buffer::Buffer as TermBuffer,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+};
+
+use crate::app::SymbolPickerState;
+use crate::theme::ThemeColors;
+
+pub fn render(picker: &SymbolPickerState, theme: &ThemeColors, area: Rect, buf: &mut TermBuffer) {
+    let overlay_w = (area.width * 2 / 3).max(40).min(area.width);
+    let overlay_h = (area.height * 2 / 3).max(8).min(area.height);
+    let overlay_x = area.x + (area.width.saturating_sub(overlay_w)) / 2;
+    let overlay_y = area.y + area.height / 6;
+    let overlay = Rect::new(overlay_x, overlay_y, overlay_w, overlay_h);
+
+    let bg_style = Style::default().bg(theme.picker_bg).fg(Color::White);
+    let border_style = Style::default()
+        .bg(theme.picker_bg)
+        .fg(Color::Rgb(80, 80, 140));
+    let header_style = Style::default()
+        .bg(theme.picker_bg)
+        .fg(Color::Rgb(180, 180, 220))
+        .add_modifier(Modifier::BOLD);
+    let query_style = Style::default().bg(theme.picker_bg).fg(Color::White);
+    let selected_style = Style::default().bg(theme.picker_sel_bg).fg(Color::White);
+    let kind_style = Style::default()
+        .bg(theme.picker_bg)
+        .fg(Color::Rgb(150, 180, 210));
+    let kind_sel_style = Style::default()
+        .bg(theme.picker_sel_bg)
+        .fg(Color::Rgb(200, 220, 240))
+        .add_modifier(Modifier::BOLD);
+    let item_style = bg_style;
+
+    for y in overlay.y..overlay.y + overlay.height {
+        for x in overlay.x..overlay.x + overlay.width {
+            buf.set_string(x, y, " ", bg_style);
+        }
+    }
+
+    // Border (top, sides, bottom).
+    buf.set_string(overlay.x, overlay.y, "┌", border_style);
+    for x in overlay.x + 1..overlay.x + overlay.width.saturating_sub(1) {
+        buf.set_string(x, overlay.y, "─", border_style);
+    }
+    if overlay.width >= 2 {
+        buf.set_string(overlay.x + overlay.width - 1, overlay.y, "┐", border_style);
+    }
+    let bot_y = overlay.y + overlay.height.saturating_sub(1);
+    buf.set_string(overlay.x, bot_y, "└", border_style);
+    for x in overlay.x + 1..overlay.x + overlay.width.saturating_sub(1) {
+        buf.set_string(x, bot_y, "─", border_style);
+    }
+    if overlay.width >= 2 {
+        buf.set_string(overlay.x + overlay.width - 1, bot_y, "┘", border_style);
+    }
+    for y in overlay.y + 1..bot_y {
+        buf.set_string(overlay.x, y, "│", border_style);
+        if overlay.width >= 2 {
+            buf.set_string(overlay.x + overlay.width - 1, y, "│", border_style);
+        }
+    }
+
+    if overlay.height < 3 || overlay.width < 4 {
+        return;
+    }
+
+    let inner_x = overlay.x + 1;
+    let inner_w = overlay.width.saturating_sub(2);
+    let mut current_y = overlay.y + 1;
+
+    let header = " Go to symbol";
+    let header_line = format!("{:<width$}", header, width = inner_w as usize);
+    buf.set_string(inner_x, current_y, &header_line, header_style);
+    current_y += 1;
+
+    if current_y >= bot_y {
+        return;
+    }
+    let query_prompt = format!(" > {}_", picker.query);
+    let query_line = format!("{:<width$}", query_prompt, width = inner_w as usize);
+    buf.set_string(inner_x, current_y, &query_line, query_style);
+    current_y += 1;
+
+    if current_y < bot_y {
+        for x in inner_x..inner_x + inner_w {
+            buf.set_string(x, current_y, "─", border_style);
+        }
+        current_y += 1;
+    }
+
+    let list_rows = bot_y.saturating_sub(current_y) as usize;
+    let scroll = if picker.selected >= list_rows && list_rows > 0 {
+        picker.selected - list_rows + 1
+    } else {
+        0
+    };
+
+    let kind_col_w: usize = 9;
+    for (screen_row, (_, sym_idx)) in picker
+        .filtered
+        .iter()
+        .skip(scroll)
+        .take(list_rows)
+        .enumerate()
+    {
+        let y = current_y + screen_row as u16;
+        let global_idx = scroll + screen_row;
+        let is_selected = global_idx == picker.selected;
+        let row_style = if is_selected {
+            selected_style
+        } else {
+            item_style
+        };
+        let kind_st = if is_selected {
+            kind_sel_style
+        } else {
+            kind_style
+        };
+
+        let Some(sym) = picker.all_symbols.get(*sym_idx) else {
+            continue;
+        };
+
+        // Fill row background.
+        let blank = format!("{:<width$}", "", width = inner_w as usize);
+        buf.set_string(inner_x, y, &blank, row_style);
+
+        let kind_label = format!(" {:<width$}", sym.kind, width = kind_col_w - 1);
+        let kind_display = if kind_label.len() > kind_col_w {
+            kind_label[..kind_col_w].to_string()
+        } else {
+            kind_label
+        };
+        buf.set_string(inner_x, y, &kind_display, kind_st);
+
+        let name_x = inner_x + kind_col_w as u16;
+        let name_avail = (inner_w as usize).saturating_sub(kind_col_w);
+        let name = if sym.name.len() > name_avail {
+            &sym.name[..name_avail]
+        } else {
+            &sym.name
+        };
+        buf.set_string(name_x, y, name, row_style);
+    }
+
+    if picker.filtered.is_empty() && list_rows > 0 {
+        let msg = " No matching symbols";
+        buf.set_string(
+            inner_x,
+            current_y,
+            format!("{:<width$}", msg, width = inner_w as usize),
+            Style::default()
+                .bg(Color::Rgb(25, 25, 40))
+                .fg(Color::DarkGray),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::buffer::cursor::ByteRange;
+    use crate::syntax::Symbol;
+
+    fn make_state(symbols: Vec<Symbol>) -> SymbolPickerState {
+        SymbolPickerState::new(symbols)
+    }
+
+    #[test]
+    fn render_does_not_panic_on_empty_picker() {
+        let area = Rect::new(0, 0, 80, 24);
+        let mut buf = TermBuffer::empty(area);
+        let theme = ThemeColors::for_theme(&crate::config::Theme::Default);
+        let state = make_state(Vec::new());
+        render(&state, &theme, area, &mut buf);
+    }
+
+    #[test]
+    fn render_does_not_panic_with_symbols() {
+        let area = Rect::new(0, 0, 80, 24);
+        let mut buf = TermBuffer::empty(area);
+        let theme = ThemeColors::for_theme(&crate::config::Theme::Default);
+        let state = make_state(vec![Symbol {
+            name: "foo".into(),
+            kind: "fn",
+            byte_range: ByteRange::new(0, 10),
+        }]);
+        render(&state, &theme, area, &mut buf);
+    }
+}


### PR DESCRIPTION
Add a small parser/resolver for .editorconfig and apply the resolved
overrides to per-buffer indent style and width, line-ending style on
save, insert_final_newline, and trim_trailing_whitespace. Walks parent
directories from the file path stopping at root = true. Status bar gains
a "spaces:N" / "tabs:N" segment showing the resolved indent.