### PR TITLE
Add tab bar click handling for tab switching

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -786,6 +786,10 @@ pub struct AppState {
     /// frame. Used by mouse-event routing to translate `(col, row)` into either
     /// an entry hit, a separator hit, or a fall-through to the editor.
     pub sidebar_area: Option<Rect>,
+    /// Tab-bar rect from the most recent frame, or `None` when the strip is
+    /// not shown (single tab). Used by mouse-event routing to hit-test tab
+    /// labels.
+    pub tab_bar_area: Option<Rect>,
     /// Active separator-drag, if any.
     pub sidebar_drag: Option<SidebarDrag>,
     /// Active Alt+drag box-select anchor, in (line, display_col).
@@ -904,6 +908,7 @@ impl AppState {
             sidebar_focused: false,
             sidebar_width: DEFAULT_SIDEBAR_WIDTH,
             sidebar_area: None,
+            tab_bar_area: None,
             sidebar_drag: None,
             box_drag_anchor: None,
             saved_sidebar: None,
@@ -1402,7 +1407,10 @@ impl AppState {
 
             // ── Mouse ─────────────────────────────────────────────────
             EditorAction::MouseClick { col, row } => {
-                if self.point_on_separator(col, row) {
+                if let Some(idx) = self.tab_bar_tab_at(col, row) {
+                    self.editor.go_to_tab(idx);
+                    self.sidebar_focused = false;
+                } else if self.point_on_separator(col, row) {
                     // Begin a sidebar resize drag.
                     self.sidebar_drag = Some(SidebarDrag {
                         start_col: col,
@@ -4853,6 +4861,13 @@ impl AppState {
                 .slice(start..end)
                 .to_string(),
         )
+    }
+
+    /// Hit-test the tab strip. Returns the tab index when `(col, row)`
+    /// lands on a rendered tab label.
+    fn tab_bar_tab_at(&self, col: u16, row: u16) -> Option<usize> {
+        let area = self.tab_bar_area?;
+        crate::ui::tab_bar::tab_at(&self.editor, area, col, row)
     }
 
     /// Returns true if the given screen point is inside the sidebar's

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -97,6 +97,7 @@ pub fn render(state: &mut AppState, frame: &mut Frame) {
     // Store the rendered sidebar rect (or `None`) so mouse-event handlers in
     // the next `update()` call can hit-test against it.
     state.sidebar_area = sidebar_area;
+    state.tab_bar_area = tab_area;
 
     // ── Compute syntax highlights for visible range ───────────────────────────
     // Prefer LSP semantic tokens when available; fall back to tree-sitter.

--- a/src/ui/tab_bar.rs
+++ b/src/ui/tab_bar.rs
@@ -28,30 +28,159 @@ pub fn render(editor: &Editor, area: Rect, buf: &mut TermBuffer) {
         buf.set_string(x, area.y, " ", inactive_style);
     }
 
-    let mut x = area.x;
-    for (i, tab) in editor.tabs.iter().enumerate() {
-        if x >= area.x + area.width {
-            break;
-        }
-        let is_active = i == editor.active_idx;
+    for layout in tab_layouts(editor, area) {
+        let is_active = layout.index == editor.active_idx;
         let style = if is_active {
             active_style
         } else {
             inactive_style
         };
+        let tab = &editor.tabs[layout.index];
         let dot = if tab.buffer.modified { "•" } else { " " };
         let name = tab.display_name();
         let label = format!(" {}{} ", dot, name);
+        let visible = &label[..layout.label_byte_len];
+        buf.set_string(layout.start_x, area.y, visible, style);
 
-        let max_w = (area.x + area.width).saturating_sub(x) as usize;
-        let label_w = label.len().min(max_w);
-        buf.set_string(x, area.y, &label[..label_w], style);
-        x += label_w as u16;
-
-        // Separator between tabs (not after the last one).
-        if i + 1 < editor.tabs.len() && x < area.x + area.width {
-            buf.set_string(x, area.y, "│", sep_style);
-            x += 1;
+        if layout.has_separator {
+            let sep_x = layout.start_x + layout.width;
+            buf.set_string(sep_x, area.y, "│", sep_style);
         }
+    }
+}
+
+/// Geometry of one rendered tab inside the tab strip.
+struct TabLayout {
+    /// Index of the tab in `editor.tabs`.
+    index: usize,
+    /// Absolute terminal column where the tab label starts.
+    start_x: u16,
+    /// Number of terminal columns consumed by the label (excluding the
+    /// trailing separator).
+    width: u16,
+    /// Byte length of the rendered slice of the label string.
+    label_byte_len: usize,
+    /// `true` if a separator column follows this tab.
+    has_separator: bool,
+}
+
+/// Lay out the tab strip and yield one `TabLayout` per visible tab.
+///
+/// Mirrors the iteration in [`render`] so hit-testing stays in sync with
+/// what was actually drawn. Tabs that don't fit inside `area` are not
+/// included in the result.
+fn tab_layouts(editor: &Editor, area: Rect) -> Vec<TabLayout> {
+    let mut out = Vec::with_capacity(editor.tabs.len());
+    let mut x = area.x;
+    let limit = area.x + area.width;
+    for (i, tab) in editor.tabs.iter().enumerate() {
+        if x >= limit {
+            break;
+        }
+        let dot = if tab.buffer.modified { "•" } else { " " };
+        let name = tab.display_name();
+        let label = format!(" {}{} ", dot, name);
+        let max_w = limit.saturating_sub(x) as usize;
+        let label_byte_len = label.len().min(max_w);
+        let width = label_byte_len as u16;
+        let next_x = x + width;
+        let has_separator = i + 1 < editor.tabs.len() && next_x < limit;
+        out.push(TabLayout {
+            index: i,
+            start_x: x,
+            width,
+            label_byte_len,
+            has_separator,
+        });
+        x = next_x + if has_separator { 1 } else { 0 };
+    }
+    out
+}
+
+/// Return the tab index at the given screen position, or `None` if the
+/// point is not on a rendered tab label. Separator columns and empty
+/// space past the last tab are treated as misses.
+pub fn tab_at(editor: &Editor, area: Rect, col: u16, row: u16) -> Option<usize> {
+    if area.height == 0 || row != area.y {
+        return None;
+    }
+    if col < area.x || col >= area.x + area.width {
+        return None;
+    }
+    tab_layouts(editor, area)
+        .into_iter()
+        .find(|t| col >= t.start_x && col < t.start_x + t.width)
+        .map(|t| t.index)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::editor::Editor;
+    use crate::editor::tab::BufferHandle;
+    use std::path::PathBuf;
+
+    fn editor_with_names(names: &[&str]) -> Editor {
+        let mut editor = Editor::new();
+        editor.tabs.clear();
+        for (i, name) in names.iter().enumerate() {
+            let mut handle = BufferHandle::new_empty(i);
+            handle.path = Some(PathBuf::from(name));
+            editor.tabs.push(handle);
+        }
+        editor.active_idx = 0;
+        editor
+    }
+
+    #[test]
+    fn tab_at_returns_clicked_index() {
+        let editor = editor_with_names(&["a.rs", "bb.rs", "ccc.rs"]);
+        let area = Rect::new(0, 0, 80, 1);
+
+        // Labels are formatted as " {dot}{name} ": for an unmodified file
+        // that's two leading spaces plus the name plus a trailing space.
+        // Tab 0 "  a.rs " spans cols 0..7, separator at col 7.
+        assert_eq!(tab_at(&editor, area, 0, 0), Some(0));
+        assert_eq!(tab_at(&editor, area, 6, 0), Some(0));
+        assert_eq!(tab_at(&editor, area, 7, 0), None);
+        // Tab 1 "  bb.rs " spans cols 8..16, separator at col 16.
+        assert_eq!(tab_at(&editor, area, 8, 0), Some(1));
+        assert_eq!(tab_at(&editor, area, 15, 0), Some(1));
+        assert_eq!(tab_at(&editor, area, 16, 0), None);
+        // Tab 2 "  ccc.rs " spans cols 17..26 (last tab, no trailing sep).
+        assert_eq!(tab_at(&editor, area, 17, 0), Some(2));
+        assert_eq!(tab_at(&editor, area, 25, 0), Some(2));
+        // Past the last tab: empty space, no hit.
+        assert_eq!(tab_at(&editor, area, 30, 0), None);
+    }
+
+    #[test]
+    fn tab_at_ignores_wrong_row() {
+        let editor = editor_with_names(&["a.rs", "b.rs"]);
+        let area = Rect::new(0, 0, 80, 1);
+        assert_eq!(tab_at(&editor, area, 0, 1), None);
+    }
+
+    #[test]
+    fn tab_at_respects_area_offset() {
+        let editor = editor_with_names(&["a.rs", "b.rs"]);
+        let area = Rect::new(10, 3, 80, 1);
+        // Outside on the left.
+        assert_eq!(tab_at(&editor, area, 9, 3), None);
+        // First tab starts at col 10.
+        assert_eq!(tab_at(&editor, area, 10, 3), Some(0));
+        // Wrong row.
+        assert_eq!(tab_at(&editor, area, 10, 2), None);
+    }
+
+    #[test]
+    fn tab_at_truncated_when_area_too_narrow() {
+        let editor = editor_with_names(&["a.rs", "b.rs", "c.rs"]);
+        // Only enough room for the first label "  a.rs " (7 cols).
+        let area = Rect::new(0, 0, 7, 1);
+        assert_eq!(tab_at(&editor, area, 0, 0), Some(0));
+        assert_eq!(tab_at(&editor, area, 6, 0), Some(0));
+        // Column 7 is outside the area.
+        assert_eq!(tab_at(&editor, area, 7, 0), None);
     }
 }


### PR DESCRIPTION
## Summary
This PR adds mouse click support to the tab bar, allowing users to switch between tabs by clicking on them. The implementation includes hit-testing logic to determine which tab was clicked and proper handling of tab separators and truncated labels.

## Key Changes
- **Refactored tab rendering logic**: Extracted tab layout calculations into a new `tab_layouts()` function that computes the geometry (position, width, separator presence) for each visible tab. This ensures hit-testing stays synchronized with what's actually rendered.
- **Added `tab_at()` function**: New public function that performs hit-testing on the tab bar, returning the tab index when a screen position lands on a rendered tab label. Properly handles edge cases like separators, area boundaries, and truncated tabs.
- **Integrated mouse click handling**: Modified `AppState` to store the tab bar area from the most recent frame and route mouse clicks to tab switching via the new `tab_bar_tab_at()` method.
- **Added comprehensive tests**: Included unit tests covering:
  - Basic tab clicking at various positions within a tab
  - Separator column exclusion from hit-testing
  - Row validation (clicks on wrong rows return None)
  - Area offset handling
  - Truncation behavior when the tab bar is too narrow

## Implementation Details
- The `TabLayout` struct encapsulates all geometry information needed for rendering and hit-testing, eliminating the need to recalculate positions.
- Tab labels are formatted as ` {dot}{name} ` where the dot indicates modification status.
- The last tab in the strip has no trailing separator, which is correctly reflected in hit-testing.
- The implementation properly handles tabs that don't fit within the available width by truncating them and excluding them from further layout calculations.

https://claude.ai/code/session_013rxXVphrfx2gJ5D2n1n6Vn