### PR TITLE
Add configurable filters to hide .git and dot-prefixed directories

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -96,14 +96,14 @@ pub struct FuzzyPickerState {
 
 impl FuzzyPickerState {
     /// Build by walking the current directory with `ignore` (respects .gitignore).
-    pub fn new() -> Self {
+    /// `hide_git` skips the `.git` directory; `hide_dot` skips every dot-prefixed
+    /// directory (and implies `hide_git`).
+    pub fn new(hide_git: bool, hide_dot: bool) -> Self {
         let mut all_files = Vec::new();
-        for entry in ignore::WalkBuilder::new(".")
-            .hidden(false)
-            .git_ignore(true)
-            .build()
-            .flatten()
-        {
+        let mut builder = ignore::WalkBuilder::new(".");
+        builder.hidden(false).git_ignore(true);
+        crate::search::apply_hidden_dir_filters(&mut builder, hide_git, hide_dot);
+        for entry in builder.build().flatten() {
             if entry.file_type().map(|ft| ft.is_file()).unwrap_or(false) {
                 // Strip the leading "./" for display clarity.
                 let p = entry.into_path();
@@ -1673,7 +1673,10 @@ impl AppState {
                 self.input_mode = InputMode::JumpToLine(String::new());
             }
             EditorAction::OpenFuzzyPicker => {
-                self.fuzzy_picker = Some(FuzzyPickerState::new());
+                self.fuzzy_picker = Some(FuzzyPickerState::new(
+                    self.config.hide_git_folder,
+                    self.config.hide_dot_folders,
+                ));
             }
             EditorAction::ToggleSidebar => {
                 if self.sidebar.is_none() {
@@ -2300,8 +2303,14 @@ impl AppState {
             Some(ps) => (ps.query.clone(), ps.is_regex, ps.case_sensitive),
             None => return,
         };
-        let results =
-            crate::search::project::run(&self.workspace, &query, is_regex, case_sensitive);
+        let results = crate::search::project::run(
+            &self.workspace,
+            &query,
+            is_regex,
+            case_sensitive,
+            self.config.hide_git_folder,
+            self.config.hide_dot_folders,
+        );
         if let Some(ps) = &mut self.project_search {
             ps.results = results;
             ps.selected = 0;
@@ -2762,7 +2771,7 @@ impl AppState {
     /// Handle input while the settings overlay is open.
     /// Returns `true` if the action was consumed, `false` to let it fall through.
     fn handle_settings(&mut self, action: &EditorAction) -> bool {
-        const NUM_ROWS: usize = 5;
+        const NUM_ROWS: usize = crate::ui::settings_overlay::NUM_SETTINGS;
         match action {
             EditorAction::MoveCursor(Direction::Up) => {
                 self.settings_cursor = self.settings_cursor.saturating_sub(1);
@@ -2806,7 +2815,9 @@ impl AppState {
             0 => self.config.confirm_exit = !self.config.confirm_exit,
             1 => self.config.auto_save = !self.config.auto_save,
             2 => self.config.show_whitespace = !self.config.show_whitespace,
-            3 => {
+            3 => self.config.hide_git_folder = !self.config.hide_git_folder,
+            4 => self.config.hide_dot_folders = !self.config.hide_dot_folders,
+            5 => {
                 let all = Theme::ALL;
                 let idx = all
                     .iter()
@@ -2819,7 +2830,7 @@ impl AppState {
                 };
                 self.config.theme = all[next].clone();
             }
-            4 => {
+            6 => {
                 let all = KeymapPreset::ALL;
                 let idx = all
                     .iter()

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -91,8 +91,8 @@ pub struct Config {
     #[serde(default)]
     pub disable_shell_filter: bool,
     /// Exclude the `.git` directory from go-to-file and project search.
-    /// Implied when `hide_dot_folders` is true.
-    #[serde(default)]
+    /// Implied when `hide_dot_folders` is true. Defaults to `true`.
+    #[serde(default = "default_hide_git_folder")]
     pub hide_git_folder: bool,
     /// Exclude every dot-prefixed directory from go-to-file and project search.
     #[serde(default)]
@@ -101,6 +101,10 @@ pub struct Config {
 
 fn default_tab_size() -> usize {
     4
+}
+
+fn default_hide_git_folder() -> bool {
+    true
 }
 
 impl Default for Config {
@@ -116,7 +120,7 @@ impl Default for Config {
             last_seen_version: None,
             formatting: FormattingConfig::default(),
             disable_shell_filter: false,
-            hide_git_folder: false,
+            hide_git_folder: true,
             hide_dot_folders: false,
         }
     }
@@ -318,17 +322,25 @@ mod tests {
     }
 
     #[test]
-    fn hide_folder_defaults_false() {
+    fn hide_folder_defaults() {
         let cfg = Config::default();
-        assert!(!cfg.hide_git_folder);
+        assert!(cfg.hide_git_folder);
         assert!(!cfg.hide_dot_folders);
     }
 
     #[test]
-    fn hide_folder_round_trips() {
-        let toml_text = "hide_git_folder = true\nhide_dot_folders = true\n";
-        let cfg: Config = toml::from_str(toml_text).unwrap();
+    fn hide_git_folder_default_applies_to_partial_toml() {
+        // Missing hide_git_folder must deserialise to true (matching Default),
+        // not to bool's intrinsic false.
+        let cfg: Config = toml::from_str("tab_size = 2\n").unwrap();
         assert!(cfg.hide_git_folder);
+    }
+
+    #[test]
+    fn hide_folder_round_trips() {
+        let toml_text = "hide_git_folder = false\nhide_dot_folders = true\n";
+        let cfg: Config = toml::from_str(toml_text).unwrap();
+        assert!(!cfg.hide_git_folder);
         assert!(cfg.hide_dot_folders);
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -90,6 +90,13 @@ pub struct Config {
     /// undesirable; default `false`.
     #[serde(default)]
     pub disable_shell_filter: bool,
+    /// Exclude the `.git` directory from go-to-file and project search.
+    /// Implied when `hide_dot_folders` is true.
+    #[serde(default)]
+    pub hide_git_folder: bool,
+    /// Exclude every dot-prefixed directory from go-to-file and project search.
+    #[serde(default)]
+    pub hide_dot_folders: bool,
 }
 
 fn default_tab_size() -> usize {
@@ -109,6 +116,8 @@ impl Default for Config {
             last_seen_version: None,
             formatting: FormattingConfig::default(),
             disable_shell_filter: false,
+            hide_git_folder: false,
+            hide_dot_folders: false,
         }
     }
 }
@@ -287,6 +296,8 @@ mod tests {
             last_seen_version: Some("0.3.0".to_string()),
             formatting: FormattingConfig::default(),
             disable_shell_filter: false,
+            hide_git_folder: true,
+            hide_dot_folders: true,
         };
         let serialized = toml::to_string(&original).unwrap();
         let deserialized: Config = toml::from_str(&serialized).unwrap();
@@ -304,6 +315,21 @@ mod tests {
         let toml_text = "disable_shell_filter = true\n";
         let cfg: Config = toml::from_str(toml_text).unwrap();
         assert!(cfg.disable_shell_filter);
+    }
+
+    #[test]
+    fn hide_folder_defaults_false() {
+        let cfg = Config::default();
+        assert!(!cfg.hide_git_folder);
+        assert!(!cfg.hide_dot_folders);
+    }
+
+    #[test]
+    fn hide_folder_round_trips() {
+        let toml_text = "hide_git_folder = true\nhide_dot_folders = true\n";
+        let cfg: Config = toml::from_str(toml_text).unwrap();
+        assert!(cfg.hide_git_folder);
+        assert!(cfg.hide_dot_folders);
     }
 
     #[test]

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -1,8 +1,35 @@
 pub mod project;
 
+use ignore::WalkBuilder;
 use regex::Regex;
 
 use crate::buffer::cursor::ByteRange;
+
+/// Apply the user's "hide .git" / "hide dot folders" filters to an
+/// `ignore::WalkBuilder`. The filter rejects directories whose names match the
+/// configured criteria; their contents are pruned from the walk. The root
+/// entry (depth 0) is always retained.
+pub fn apply_hidden_dir_filters(builder: &mut WalkBuilder, hide_git: bool, hide_dot: bool) {
+    if !hide_git && !hide_dot {
+        return;
+    }
+    builder.filter_entry(move |entry| {
+        if entry.depth() == 0 {
+            return true;
+        }
+        let is_dir = entry.file_type().is_some_and(|ft| ft.is_dir());
+        if !is_dir {
+            return true;
+        }
+        let Some(name) = entry.file_name().to_str() else {
+            return true;
+        };
+        if hide_dot {
+            return !name.starts_with('.');
+        }
+        name != ".git"
+    });
+}
 
 /// Cap on the number of matches stored at once. Protects the editor against
 /// pathological queries (e.g. `e` in a megabyte file) that would otherwise

--- a/src/search/project.rs
+++ b/src/search/project.rs
@@ -50,8 +50,16 @@ pub struct ProjectSearchResults {
 }
 
 /// Walk `root` and collect matches for `query`. Honours `.gitignore` and skips
-/// binary / oversized files.
-pub fn run(root: &Path, query: &str, is_regex: bool, case_sensitive: bool) -> ProjectSearchResults {
+/// binary / oversized files. `hide_git` and `hide_dot` prune `.git` / all
+/// dot-prefixed directories respectively.
+pub fn run(
+    root: &Path,
+    query: &str,
+    is_regex: bool,
+    case_sensitive: bool,
+    hide_git: bool,
+    hide_dot: bool,
+) -> ProjectSearchResults {
     let mut out = ProjectSearchResults::default();
     if query.is_empty() {
         return out;
@@ -62,12 +70,10 @@ pub fn run(root: &Path, query: &str, is_regex: bool, case_sensitive: bool) -> Pr
         Err(_) => return out,
     };
 
-    'walk: for entry in WalkBuilder::new(root)
-        .hidden(false)
-        .git_ignore(true)
-        .build()
-        .flatten()
-    {
+    let mut builder = WalkBuilder::new(root);
+    builder.hidden(false).git_ignore(true);
+    super::apply_hidden_dir_filters(&mut builder, hide_git, hide_dot);
+    'walk: for entry in builder.build().flatten() {
         if !entry.file_type().map(|ft| ft.is_file()).unwrap_or(false) {
             continue;
         }
@@ -214,7 +220,7 @@ mod tests {
         fs::write(dir.join("b.txt"), "no match here\n").unwrap();
         fs::write(dir.join("c.txt"), "another hello\n").unwrap();
 
-        let r = run(&dir, "hello", false, true);
+        let r = run(&dir, "hello", false, true, false, false);
         assert!(!r.truncated);
         assert_eq!(r.matches.len(), 3);
         assert!(
@@ -239,7 +245,7 @@ mod tests {
             .unwrap();
         fs::write(dir.join("text.txt"), "hello text\n").unwrap();
 
-        let r = run(&dir, "hello", false, true);
+        let r = run(&dir, "hello", false, true, false, false);
         assert_eq!(r.matches.len(), 1);
         assert_eq!(r.matches[0].path.file_name().unwrap(), "text.txt");
 
@@ -259,7 +265,7 @@ mod tests {
             .current_dir(&dir)
             .output();
 
-        let r = run(&dir, "hello", false, true);
+        let r = run(&dir, "hello", false, true, false, false);
         // Either the env has git or it doesn't; assert that kept.txt is found
         // and that if any match comes from ignored.txt, the test environment
         // didn't have git available — both are acceptable.
@@ -273,7 +279,7 @@ mod tests {
         let dir = tempdir();
         fs::write(dir.join("a.txt"), "Hello WORLD\nhello there\n").unwrap();
 
-        let r = run(&dir, "hello", false, false);
+        let r = run(&dir, "hello", false, false, false, false);
         assert_eq!(r.matches.len(), 2);
 
         let _ = fs::remove_dir_all(&dir);
@@ -284,8 +290,58 @@ mod tests {
         let dir = tempdir();
         fs::write(dir.join("a.txt"), "abc 123 def 456\n").unwrap();
 
-        let r = run(&dir, r"\d+", true, true);
+        let r = run(&dir, r"\d+", true, true, false, false);
         assert_eq!(r.matches.len(), 2);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn hide_git_folder_skips_git_dir() {
+        let dir = tempdir();
+        fs::create_dir_all(dir.join(".git")).unwrap();
+        fs::create_dir_all(dir.join(".cache")).unwrap();
+        fs::write(dir.join(".git").join("config"), "hello git\n").unwrap();
+        fs::write(dir.join(".cache").join("data.txt"), "hello cache\n").unwrap();
+        fs::write(dir.join("kept.txt"), "hello kept\n").unwrap();
+
+        let r = run(&dir, "hello", false, true, true, false);
+        assert!(r.matches.iter().any(|m| m.path.ends_with("kept.txt")));
+        assert!(
+            r.matches
+                .iter()
+                .any(|m| m.path.components().any(|c| c.as_os_str() == ".cache"))
+        );
+        assert!(
+            !r.matches
+                .iter()
+                .any(|m| m.path.components().any(|c| c.as_os_str() == ".git"))
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn hide_dot_folders_skips_all_dot_dirs() {
+        let dir = tempdir();
+        fs::create_dir_all(dir.join(".git")).unwrap();
+        fs::create_dir_all(dir.join(".cache")).unwrap();
+        fs::write(dir.join(".git").join("config"), "hello git\n").unwrap();
+        fs::write(dir.join(".cache").join("data.txt"), "hello cache\n").unwrap();
+        fs::write(dir.join("kept.txt"), "hello kept\n").unwrap();
+
+        let r = run(&dir, "hello", false, true, false, true);
+        assert!(r.matches.iter().any(|m| m.path.ends_with("kept.txt")));
+        assert!(
+            !r.matches
+                .iter()
+                .any(|m| m.path.components().any(|c| c.as_os_str() == ".git"))
+        );
+        assert!(
+            !r.matches
+                .iter()
+                .any(|m| m.path.components().any(|c| c.as_os_str() == ".cache"))
+        );
 
         let _ = fs::remove_dir_all(&dir);
     }

--- a/src/ui/settings_overlay.rs
+++ b/src/ui/settings_overlay.rs
@@ -10,9 +10,9 @@ use crate::config::Config;
 // ── Layout constants ──────────────────────────────────────────────────────────
 
 const OVERLAY_W: u16 = 50;
-// Rows: top border + header + separator + 4 settings + separator + hint + bottom border = 10
-const NUM_SETTINGS: usize = 5;
-const OVERLAY_H: u16 = 3 + NUM_SETTINGS as u16 + 3; // 10
+// Rows: top border + header + separator + N settings + separator + hint + bottom border
+pub(crate) const NUM_SETTINGS: usize = 7;
+const OVERLAY_H: u16 = 3 + NUM_SETTINGS as u16 + 3;
 
 /// Render the settings overlay centered in `area`.
 pub fn render(state: &AppState, area: Rect, buf: &mut TermBuffer) {
@@ -101,6 +101,14 @@ pub fn render(state: &AppState, area: Rect, buf: &mut TermBuffer) {
         (
             "Show whitespace",
             SettingValue::Bool(state.config.show_whitespace),
+        ),
+        (
+            "Hide .git folder",
+            SettingValue::Bool(state.config.hide_git_folder),
+        ),
+        (
+            "Hide dot folders",
+            SettingValue::Bool(state.config.hide_dot_folders),
         ),
         (
             "Color theme",


### PR DESCRIPTION
## Summary
This PR adds user-configurable options to exclude the `.git` directory and all dot-prefixed directories from file search and navigation features. These settings are exposed in the configuration file and the settings overlay UI.

## Key Changes

- **New config options**: Added `hide_git_folder` (defaults to `true`) and `hide_dot_folders` (defaults to `false`) to the `Config` struct
- **Centralized filter logic**: Introduced `apply_hidden_dir_filters()` in `src/search/mod.rs` to apply directory filtering consistently across the codebase
- **Project search integration**: Updated `search::project::run()` to accept `hide_git` and `hide_dot` parameters and apply filters via the new utility function
- **Fuzzy picker integration**: Updated `FuzzyPickerState::new()` to accept and apply the same filter parameters
- **Settings UI**: Added two new boolean toggles to the settings overlay for controlling these filters
- **Test coverage**: Added comprehensive tests for both filter behaviors and config serialization/deserialization

## Implementation Details

- The filter function operates on `ignore::WalkBuilder` and prunes directories at the entry level, preventing traversal into filtered directories
- The root directory (depth 0) is always retained to allow searching from the current working directory
- When `hide_dot_folders` is enabled, it implicitly hides `.git` as well (since `.git` starts with a dot)
- All existing tests were updated to pass the new boolean parameters with `false, false` defaults to maintain current behavior
- The settings overlay now displays 7 settings instead of 5, with proper layout adjustments

https://claude.ai/code/session_01EobrX4w1G9w2re9yyTxwAJ