### PR TITLE
Replace initial empty tab when opening first file

### DIFF
--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -56,6 +56,9 @@ impl Editor {
 
     /// Open `path` in a new tab. If the path is already open, switch to it.
     /// Returns `Err` only if the file cannot be read.
+    ///
+    /// If the editor currently has a single empty, unsaved tab, that tab is
+    /// replaced by the newly opened file rather than opening alongside it.
     pub fn open_tab(&mut self, path: PathBuf) -> anyhow::Result<()> {
         // Switch to an existing tab if the file is already open.
         if let Some(idx) = self
@@ -69,8 +72,13 @@ impl Editor {
         let id = self.next_id;
         self.next_id += 1;
         let handle = BufferHandle::from_path(id, path)?;
-        self.tabs.push(handle);
-        self.active_idx = self.tabs.len() - 1;
+        if self.tabs.len() == 1 && is_empty_unsaved(&self.tabs[0]) {
+            self.tabs[0] = handle;
+            self.active_idx = 0;
+        } else {
+            self.tabs.push(handle);
+            self.active_idx = self.tabs.len() - 1;
+        }
         Ok(())
     }
 
@@ -139,5 +147,117 @@ impl Editor {
 impl Default for Editor {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// A tab is "empty and unsaved" when it has no associated file, no edits, and
+/// no content — the state of the placeholder tab created on startup or after
+/// closing the last tab.
+fn is_empty_unsaved(handle: &BufferHandle) -> bool {
+    handle.path.is_none() && !handle.buffer.modified && handle.buffer.rope().len_bytes() == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_temp(name: &str, contents: &str) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(name);
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(contents.as_bytes()).unwrap();
+        dir
+    }
+
+    #[test]
+    fn open_tab_replaces_initial_empty_tab() {
+        let dir = write_temp("a.txt", "hello");
+        let path = dir.path().join("a.txt");
+
+        let mut editor = Editor::new();
+        assert_eq!(editor.tab_count(), 1);
+        assert!(editor.active().path.is_none());
+
+        editor.open_tab(path.clone()).unwrap();
+
+        assert_eq!(
+            editor.tab_count(),
+            1,
+            "empty placeholder should be replaced"
+        );
+        assert_eq!(editor.active_idx, 0);
+        assert_eq!(editor.active().path.as_deref(), Some(path.as_path()));
+    }
+
+    #[test]
+    fn open_tab_keeps_modified_empty_tab() {
+        let dir = write_temp("a.txt", "hello");
+        let path = dir.path().join("a.txt");
+
+        let mut editor = Editor::new();
+        // Mark the placeholder as modified — user typed and erased, e.g.
+        editor.active_mut().buffer.modified = true;
+
+        editor.open_tab(path).unwrap();
+
+        assert_eq!(
+            editor.tab_count(),
+            2,
+            "modified placeholder must not be discarded"
+        );
+        assert_eq!(editor.active_idx, 1);
+    }
+
+    #[test]
+    fn open_tab_keeps_non_empty_placeholder() {
+        let dir = write_temp("a.txt", "hello");
+        let path = dir.path().join("a.txt");
+
+        let mut editor = Editor::new();
+        // Placeholder has content even though `modified` is somehow false.
+        editor.active_mut().buffer = crate::buffer::Buffer::from_str("typed text");
+
+        editor.open_tab(path).unwrap();
+
+        assert_eq!(editor.tab_count(), 2);
+    }
+
+    #[test]
+    fn open_tab_adds_alongside_when_multiple_tabs_open() {
+        let dir = write_temp("a.txt", "hello");
+        let dir2 = write_temp("b.txt", "world");
+        let a = dir.path().join("a.txt");
+        let b = dir2.path().join("b.txt");
+
+        let mut editor = Editor::new();
+        editor.open_tab(a).unwrap();
+        // Now one tab with `a.txt`. Add an explicit empty tab so we have 2.
+        editor.new_tab();
+        assert_eq!(editor.tab_count(), 2);
+
+        editor.open_tab(b).unwrap();
+
+        assert_eq!(editor.tab_count(), 3, "additional tabs left untouched");
+    }
+
+    #[test]
+    fn open_tab_switches_to_existing_without_replacing_placeholder() {
+        let dir = write_temp("a.txt", "hello");
+        let path = dir.path().join("a.txt");
+
+        let mut editor = Editor::new();
+        editor.open_tab(path.clone()).unwrap();
+        // Add a fresh empty tab and make it active.
+        editor.new_tab();
+        assert_eq!(editor.tab_count(), 2);
+        assert_eq!(editor.active_idx, 1);
+
+        // Re-opening an already-open file should switch to it, leaving the
+        // empty tab in place.
+        editor.open_tab(path).unwrap();
+
+        assert_eq!(editor.tab_count(), 2);
+        assert_eq!(editor.active_idx, 0);
     }
 }


### PR DESCRIPTION
## Summary
Improved the tab management experience by replacing the initial empty placeholder tab when opening the first file, rather than creating a second tab. This provides a more intuitive workflow where users don't accumulate empty tabs.

## Key Changes
- Modified `open_tab()` to detect when the editor has a single empty, unsaved tab and replace it with the newly opened file instead of adding a new tab
- Added `is_empty_unsaved()` helper function to identify placeholder tabs (no path, no modifications, no content)
- Updated the `open_tab()` documentation to describe this new behavior
- Added comprehensive test coverage for the new behavior:
  - Verifies replacement of initial empty tab
  - Ensures modified empty tabs are preserved
  - Ensures non-empty placeholder tabs are preserved
  - Confirms normal append behavior with multiple existing tabs
  - Validates that switching to existing files doesn't trigger replacement

## Implementation Details
The replacement logic only applies when:
1. The editor has exactly one tab
2. That tab is empty, unmodified, and has no associated file path

This preserves the existing behavior for all other cases (multiple tabs, modified content, or switching to already-open files).

https://claude.ai/code/session_017UynRCxU4vA52dYcNozDCC