### PR TITLE
Add double-click word selection in editor

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -42,6 +42,11 @@ pub const MIN_SIDEBAR_WIDTH: u16 = 12;
 /// to half the terminal width so the editor stays usable.
 pub const MAX_SIDEBAR_WIDTH: u16 = 80;
 
+/// Maximum delay between two left-clicks at the same screen cell for the
+/// second click to register as a double-click (which selects the word under
+/// the cursor).
+const DOUBLE_CLICK_INTERVAL: Duration = Duration::from_millis(500);
+
 // ── Modal input mode ─────────────────────────────────────────────────────────
 
 /// Modes that capture keyboard input for a status-bar prompt.
@@ -890,6 +895,11 @@ pub struct AppState {
     /// Active Alt+drag box-select anchor, in (line, display_col).
     /// Set on `BoxDragStart`, used by `BoxDragUpdate`, cleared on `BoxDragEnd`.
     pub box_drag_anchor: Option<(usize, usize)>,
+    /// Time and screen position of the most recent left-click in the editor
+    /// area. A subsequent click at the same `(col, row)` within
+    /// `DOUBLE_CLICK_INTERVAL` is treated as a double-click and selects the
+    /// word at the click position.
+    last_click: Option<(Instant, u16, u16)>,
     saved_sidebar: Option<SidebarState>,
     pub sidebar_clipboard: Option<SidebarClipboard>,
     pub search_state: Option<SearchState>,
@@ -1011,6 +1021,7 @@ impl AppState {
             tab_bar_area: None,
             sidebar_drag: None,
             box_drag_anchor: None,
+            last_click: None,
             saved_sidebar: None,
             sidebar_clipboard: None,
             search_state: None,
@@ -1536,12 +1547,14 @@ impl AppState {
                 if let Some(idx) = self.tab_bar_tab_at(col, row) {
                     self.editor.go_to_tab(idx);
                     self.sidebar_focused = false;
+                    self.last_click = None;
                 } else if self.point_on_separator(col, row) {
                     // Begin a sidebar resize drag.
                     self.sidebar_drag = Some(SidebarDrag {
                         start_col: col,
                         start_width: self.sidebar_width,
                     });
+                    self.last_click = None;
                 } else if self.point_in_sidebar(col, row) {
                     if let Some(idx) = self.sidebar_entry_at(row) {
                         self.sidebar_focused = true;
@@ -1568,15 +1581,38 @@ impl AppState {
                             }
                         }
                     }
+                    self.last_click = None;
                 } else {
                     // Click in the editor area: defocus the sidebar (if focused)
-                    // and move the cursor to the click target.
+                    // and move the cursor to the click target. A second click
+                    // at the same cell within DOUBLE_CLICK_INTERVAL selects the
+                    // word under the cursor instead of just moving.
                     self.sidebar_focused = false;
                     if let Some(offset) = self.screen_to_byte(col, row) {
-                        self.editor
-                            .active_mut()
-                            .buffer
-                            .move_cursor_to(offset, false);
+                        let is_double_click = self.last_click.is_some_and(|(t, c, r)| {
+                            c == col && r == row && t.elapsed() <= DOUBLE_CLICK_INTERVAL
+                        });
+                        if is_double_click {
+                            let span = crate::buffer::cursor::word_span_at(
+                                self.editor.active().buffer.rope(),
+                                offset,
+                            );
+                            let buf = &mut self.editor.active_mut().buffer;
+                            if let Some((start, end)) = span {
+                                buf.move_cursor_to(start, false);
+                                buf.move_cursor_to(end, true);
+                            } else {
+                                buf.move_cursor_to(offset, false);
+                            }
+                            // Reset so a third click starts a fresh single-click sequence.
+                            self.last_click = None;
+                        } else {
+                            self.editor
+                                .active_mut()
+                                .buffer
+                                .move_cursor_to(offset, false);
+                            self.last_click = Some((Instant::now(), col, row));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
Implement double-click detection in the editor to select words. When a user clicks twice at the same screen position within 500ms, the word at that position is selected instead of just moving the cursor.

## Key Changes
- Added `DOUBLE_CLICK_INTERVAL` constant (500ms) to define the time window for double-click detection
- Added `last_click` field to `AppState` to track the timestamp and screen position of the most recent left-click in the editor area
- Implemented double-click detection logic in the left-click handler that:
  - Compares the current click position and timing against the last recorded click
  - Calls `word_span_at()` to find word boundaries when a double-click is detected
  - Selects the word by moving the cursor to the start and then to the end with selection enabled
  - Resets the click tracker after a double-click to prevent triple-clicks from being treated as another double-click
- Updated all other click handlers (tab bar, sidebar resize, sidebar entries) to reset `last_click` to `None` since they don't support double-click selection

## Implementation Details
- Double-click detection only applies to clicks in the editor area, not to UI elements like tabs or sidebar
- The click tracker is reset after handling a double-click or when clicking on non-editor UI elements
- Single clicks in the editor area now record their position and time for future double-click comparison

https://claude.ai/code/session_0156fqW2AKiYprBJQbaHDa23