### PR TITLE
Expand and reformat the LSP server picker dialog

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -802,19 +802,29 @@ pub struct PendingLspApproval {
 }
 
 /// Built-in LSP server definitions the user can choose from.
-pub const LSP_SERVER_OPTIONS: &[(&str, &str, &[&str])] = &[
-    // (display name / key, command, args)
-    ("rust-analyzer", "rust-analyzer", &[]),
-    ("pyright", "pyright-langserver", &["--stdio"]),
+/// Sorted alphabetically by language display name.
+pub const LSP_SERVER_OPTIONS: &[(&str, &str, &str, &[&str])] = &[
+    // (language display, server key written to lsp.toml, command, args)
+    ("C#", "omnisharp", "omnisharp", &["-lsp"]),
+    ("C/C++", "clangd", "clangd", &[]),
+    ("Go", "gopls", "gopls", &["serve"]),
+    ("Java", "jdtls", "jdtls", &[]),
     (
+        "Kotlin",
+        "kotlin-language-server",
+        "kotlin-language-server",
+        &[],
+    ),
+    ("Lua", "lua-language-server", "lua-language-server", &[]),
+    ("Python", "pyright", "pyright-langserver", &["--stdio"]),
+    ("Rust", "rust-analyzer", "rust-analyzer", &[]),
+    (
+        "TypeScript",
         "typescript-language-server",
         "typescript-language-server",
         &["--stdio"],
     ),
-    ("clangd", "clangd", &[]),
-    ("gopls", "gopls", &["serve"]),
-    ("lua-language-server", "lua-language-server", &[]),
-    ("zls", "zls", &[]),
+    ("Zig", "zls", "zls", &[]),
 ];
 
 /// State for the LSP configuration picker overlay.
@@ -835,7 +845,7 @@ impl LspPickerState {
                 .and_then(|key| {
                     LSP_SERVER_OPTIONS
                         .iter()
-                        .position(|(name, _, _)| *name == key)
+                        .position(|(_, name, _, _)| *name == key)
                         .map(|i| i + 1)
                 })
                 .unwrap_or(0)
@@ -3239,7 +3249,7 @@ impl AppState {
             // Disabled
             WorkspaceLspConfig::default()
         } else {
-            let (name, command, args) = LSP_SERVER_OPTIONS[selected - 1];
+            let (_language, name, command, args) = LSP_SERVER_OPTIONS[selected - 1];
             let mut servers = HashMap::new();
             servers.insert(
                 name.to_string(),

--- a/src/ui/lsp_picker.rs
+++ b/src/ui/lsp_picker.rs
@@ -9,8 +9,8 @@ use crate::app::{LSP_SERVER_OPTIONS, LspPickerState};
 // ── Layout constants ─────────────────────────────────────────────────────────
 
 const OVERLAY_W: u16 = 50;
-// Rows: border-top + header + separator + (1 Disabled + N servers) + separator + hint + border-bot
-const CHROME_ROWS: u16 = 6; // top border + header + sep + sep + hint + bottom border
+// Rows: border-top + header + separator + (1 Disabled + N servers) + separator + 2 notice rows + hint + border-bot
+const CHROME_ROWS: u16 = 8; // top border + header + sep + sep + notice×2 + hint + bottom border
 
 /// Render the LSP configuration picker overlay centered in `area`.
 pub fn render(picker: &LspPickerState, area: Rect, buf: &mut TermBuffer) {
@@ -43,6 +43,7 @@ pub fn render(picker: &LspPickerState, area: Rect, buf: &mut TermBuffer) {
         .fg(Color::Rgb(120, 220, 120))
         .add_modifier(Modifier::BOLD);
     let hint_style = Style::default().bg(bg).fg(Color::Rgb(100, 110, 150));
+    let notice_style = Style::default().bg(bg).fg(Color::Rgb(255, 200, 80));
 
     // ── Background fill ──────────────────────────────────────────────────────
     for y in overlay.y..overlay.y + overlay.height {
@@ -88,13 +89,9 @@ pub fn render(picker: &LspPickerState, area: Rect, buf: &mut TermBuffer) {
             let display: String = label.chars().take(inner_w.saturating_sub(2)).collect();
             buf.set_string(cx, row_y, &display, style);
         } else {
-            // Server option
-            let (name, command, _) = LSP_SERVER_OPTIONS[i - 1];
-            let label = if name == command {
-                name.to_string()
-            } else {
-                format!("{} ({})", name, command)
-            };
+            // Server option: "Language (command)"
+            let (language, _name, command, _) = LSP_SERVER_OPTIONS[i - 1];
+            let label = format!("{} ({})", language, command);
             let style = server_style.bg(row_bg);
             let display: String = label.chars().take(inner_w.saturating_sub(6)).collect();
             buf.set_string(cx, row_y, &display, style);
@@ -114,9 +111,24 @@ pub fn render(picker: &LspPickerState, area: Rect, buf: &mut TermBuffer) {
         draw_h_separator(buf, overlay, sep_y, border_style);
     }
 
+    // ── Notice rows ──────────────────────────────────────────────────────────
+    let notices = [
+        "Install LSP server externally before enabling.",
+        "Edit .txt/lsp.toml for advanced configuration.",
+    ];
+    for (i, line) in notices.iter().enumerate() {
+        let row_y = sep_y + 1 + i as u16;
+        if row_y >= overlay.y + overlay.height {
+            break;
+        }
+        let row_x = overlay.x + overlay.width.saturating_sub(line.len() as u16 + 2) / 2 + 1;
+        let truncated: String = line.chars().take(inner_w).collect();
+        buf.set_string(row_x, row_y, &truncated, notice_style);
+    }
+
     // ── Hint row ─────────────────────────────────────────────────────────────
     let hint = "Enter: select  ·  Esc: cancel";
-    let hint_y = sep_y + 1;
+    let hint_y = sep_y + 1 + notices.len() as u16;
     if hint_y < overlay.y + overlay.height {
         let hint_x = overlay.x + overlay.width.saturating_sub(hint.len() as u16 + 2) / 2 + 1;
         let truncated: String = hint.chars().take(inner_w).collect();


### PR DESCRIPTION
## Summary

- Add Kotlin (`kotlin-language-server`), C# (`omnisharp -lsp`), and Java (`jdtls`) to the built-in LSP server list. Go was already present as `gopls`.
- Reformat picker labels to `Language (command)` so entries read like `Java (jdtls)` instead of just the server name.
- Sort entries alphabetically by language display name.
- Add a two-line amber notice above the hint row warning that the LSP server must be installed externally before enabling, and pointing at `.txt/lsp.toml` for advanced configuration.

## Test plan

- [ ] `./scripts/check.sh` passes (fmt, build, clippy, test).
- [ ] Open the picker with Ctrl+L and confirm the new sort order: C#, C/C++, Go, Java, Kotlin, Lua, Python, Rust, TypeScript, Zig.
- [ ] Confirm every row reads `Language (command)`.
- [ ] Confirm the two amber notice lines render above the gray `Enter: select · Esc: cancel` hint.
- [ ] Pick a new entry (e.g. Java) and verify `<workspace>/.txt/lsp.toml` is written with `server = "jdtls"` and `[servers.jdtls]`.
- [ ] Reopen the picker and confirm the previously selected row is pre-highlighted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)