### PR TITLE
Switch Kotlin LSP server from kotlin-language-server to kotlin-lsp

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -814,12 +814,7 @@ pub const LSP_SERVER_OPTIONS: &[(&str, &str, &str, &[&str])] = &[
     ("C/C++", "clangd", "clangd", &[]),
     ("Go", "gopls", "gopls", &["serve"]),
     ("Java", "jdtls", "jdtls", &[]),
-    (
-        "Kotlin",
-        "kotlin-language-server",
-        "kotlin-language-server",
-        &[],
-    ),
+    ("Kotlin", "kotlin-lsp", "kotlin-lsp", &[]),
     ("Lua", "lua-language-server", "lua-language-server", &[]),
     ("Python", "pyright", "pyright-langserver", &["--stdio"]),
     ("Rust", "rust-analyzer", "rust-analyzer", &[]),

--- a/web/index.md
+++ b/web/index.md
@@ -139,7 +139,7 @@ The picker ships with presets for the following servers — click through to the
 - **Rust** — [rust-analyzer](https://rust-analyzer.github.io/)
 - **Go** — [gopls](https://github.com/golang/tools/tree/master/gopls)
 - **TypeScript / JavaScript** — [typescript-language-server](https://github.com/typescript-language-server/typescript-language-server)
-- **Kotlin** — [kotlin-language-server](https://github.com/fwcd/kotlin-language-server)
+- **Kotlin** — [kotlin-lsp](https://github.com/Kotlin/kotlin-lsp)
 - **Java** — [Eclipse JDT Language Server (jdtls)](https://github.com/eclipse-jdtls/eclipse.jdt.ls)
 - **C#** — [OmniSharp](https://github.com/OmniSharp/omnisharp-roslyn)
 


### PR DESCRIPTION
## Summary
This PR updates the Kotlin language server configuration to use the official `kotlin-lsp` package instead of the community-maintained `kotlin-language-server`.

## Changes
- Updated LSP server configuration in `src/app.rs` to use `kotlin-lsp` as both the package name and executable
- Updated documentation in `web/index.md` to reference the new official Kotlin LSP repository

## Details
The change switches from the community fork (fwcd/kotlin-language-server) to the official Kotlin LSP implementation (Kotlin/kotlin-lsp). This aligns with the Kotlin ecosystem's official language server tooling.

https://claude.ai/code/session_017mbQmqVAAM5EEW4GYgyhc2