### PR TITLE
Tier 3 features for txt

### DIFF
--- a/feature_proposals.md
+++ b/feature_proposals.md
@@ -151,19 +151,22 @@ A natural extension is a workspace‑wide symbol index built on file open and re
 
 ### Tier 3 — power features that round out the editor
 
-#### 3.1 Persistent sessions per workspace
+All seven Tier 3 features have been implemented on branch
+`claude/tier-3-features-tests-fNbG8` (one commit per feature).
+
+#### 3.1 Persistent sessions per workspace ✅ implemented
 
 Save open tabs, cursor positions, fold state, marks, and sidebar expansion to `<workspace>/.txt/session.json` and restore on `txt .` in the same directory. Opt‑in via config to keep "starts instantly" honest.
 
-#### 3.2 Persistent undo
+#### 3.2 Persistent undo ✅ implemented
 
 `Buffer::history` already serialises cleanly. Writing it to `<workspace>/.txt/undo/<file-hash>.bin` on save, and reloading on open, gives Vim‑style cross‑session undo. Bounded by the existing 1000‑entry cap so disk use stays predictable.
 
-#### 3.3 Clipboard ring (registers without modal pain)
+#### 3.3 Clipboard ring (registers without modal pain) ✅ implemented
 
 A bounded ring of the last *N* yanks/cuts. `Ctrl+Shift+V` opens a small picker showing each entry's first line; `Enter` pastes. The system clipboard remains the default target — the ring is purely additive and lives only in memory.
 
-#### 3.4 Surround / change‑pair
+#### 3.4 Surround / change‑pair ✅ implemented
 
 A non‑modal version of vim‑surround:
 - `Ctrl+'` followed by a delimiter wraps the current selection in `''`, `""`, `()`, `[]`, `{}`, `<>`, or HTML tags.
@@ -171,18 +174,18 @@ A non‑modal version of vim‑surround:
 
 Bracket auto‑close on insertion (`(`→`()`) with smart skip on the matching close is the obvious companion. Both are toggle‑able in config because half the audience hates auto‑pairs.
 
-#### 3.5 Diff‑aware navigation and partial revert
+#### 3.5 Diff‑aware navigation and partial revert ✅ implemented
 
 The git gutter already classifies each line. Add:
 - `Alt+]` / `Alt+[` — jump to next / previous changed hunk.
 - `Ctrl+Shift+U` — revert the hunk at the cursor (replace with `HEAD` content). Exists in `git_dialog.rs` philosophy already.
 - Inline diff peek: `Ctrl+Shift+D` opens a small float showing the `HEAD` version of the surrounding lines.
 
-#### 3.6 Trailing whitespace, mixed indentation, tabs visualisation
+#### 3.6 Trailing whitespace, mixed indentation, tabs visualisation ✅ implemented
 
 Already half‑there via `show_whitespace`. Add a subtle red highlight for trailing whitespace at end of line, and a one‑line warning in the status bar when a file mixes tabs and spaces. `format_on_save = false` config keeps it opt‑in.
 
-#### 3.7 Quickfix / location list
+#### 3.7 Quickfix / location list ✅ implemented (LSP-diagnostics source; project-search and external-command sources deferred)
 
 A general "list of file:line:col entries with messages" pane reusable for:
 - LSP diagnostics across the workspace.
@@ -212,7 +215,7 @@ A pragmatic 5‑release roadmap that keeps each release shippable on its own:
 | v0.6 | "Multi‑cursor upgrade" | 1.2 add‑next ✅, 1.3 box selection ✅, 3.3 clipboard ring |
 | v0.7 | "Navigate" ✅ shipped | 2.3 marks + jump list ✅, 2.8 file symbols ✅, 3.5 diff navigation |
 | v0.8 | "Rhythm" ✅ shipped | 2.2 macros ✅, 2.1 snippets ✅, 3.4 surround/auto‑pairs |
-| v0.9 | "Polish" ✅ shipped | 2.4 folding ✅, 2.5 sticky header ✅, 2.6 indent guides + rulers ✅, 2.7 EditorConfig ✅, 3.1 sessions, 3.2 persistent undo |
+| v0.9 | "Polish" ✅ shipped | 2.4 folding ✅, 2.5 sticky header ✅, 2.6 indent guides + rulers ✅, 2.7 EditorConfig ✅, 3.1 sessions ✅, 3.2 persistent undo ✅ |
 
 ## 5. Constraints to respect
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -3303,7 +3303,8 @@ impl AppState {
             2 => self.config.show_whitespace = !self.config.show_whitespace,
             3 => self.config.hide_git_folder = !self.config.hide_git_folder,
             4 => self.config.hide_dot_folders = !self.config.hide_dot_folders,
-            5 => {
+            5 => self.config.restore_session = !self.config.restore_session,
+            6 => {
                 let all = Theme::ALL;
                 let idx = all
                     .iter()
@@ -3316,7 +3317,7 @@ impl AppState {
                 };
                 self.config.theme = all[next].clone();
             }
-            6 => {
+            7 => {
                 let all = KeymapPreset::ALL;
                 let idx = all
                     .iter()

--- a/src/app.rs
+++ b/src/app.rs
@@ -4334,6 +4334,16 @@ impl AppState {
             self.lsp_dirty_since = None;
             self.lsp_change_sent = false;
             self.notify_lsp_did_save();
+            // Persist undo history (opt-in) so Ctrl+Z still works after a
+            // restart. Silent on I/O failure.
+            if self.config.persistent_undo {
+                let tab = self.editor.active();
+                if let Some(path) = &tab.path {
+                    let content = tab.buffer.to_string();
+                    let snap = tab.buffer.history_snapshot();
+                    crate::buffer::persistent_undo::save(&self.workspace, path, &content, &snap);
+                }
+            }
         } else {
             self.input_mode = InputMode::SaveAsPath(String::new());
         }
@@ -4736,10 +4746,34 @@ impl AppState {
 
     /// Called after a file is opened or saved — updates recent files, git gutter,
     /// installs a file watcher, and notifies the LSP server.
+    /// Attempt to load persistent undo history for the active tab. No-op
+    /// when the feature is disabled, the buffer has no path, or the
+    /// on-disk hash doesn't match the buffer content.
+    pub fn try_load_persistent_undo_for_active(&mut self) {
+        if !self.config.persistent_undo {
+            return;
+        }
+        let path = match self.editor.active().path.clone() {
+            Some(p) => p,
+            None => return,
+        };
+        let content = self.editor.active().buffer.to_string();
+        if let Some(snap) = crate::buffer::persistent_undo::load(&self.workspace, &path, &content) {
+            self.editor.active_mut().buffer.restore_history(snap);
+        }
+    }
+
     fn after_file_open_or_save(&mut self) {
         if let Some(path) = self.editor.active().path.clone() {
             add_to_recent_files(&path, &self.workspace.clone());
             self.file_watcher = FileWatcher::new(&path);
+        }
+        // Persistent undo: a freshly opened buffer has an empty history, so
+        // we use that as the cue that this is an `open` event (not a
+        // `save`). This avoids the load clobbering the in-memory history
+        // that we are about to persist on save.
+        if !self.editor.active().buffer.can_undo() {
+            self.try_load_persistent_undo_for_active();
         }
         self.refresh_git_gutter();
         // Notify LSP server that a file was opened.
@@ -6163,6 +6197,16 @@ impl App {
             state.restore_from_session(session);
             state.refresh_git_gutter();
         }
+        // Load persistent undo for every tab that was opened during
+        // startup (either via the positional CLI arg or session restore).
+        // Walk by index so we can borrow `state` mutably across iterations;
+        // restore the original active index when done.
+        let saved_active = state.editor.active_idx;
+        for i in 0..state.editor.tabs.len() {
+            state.editor.active_idx = i;
+            state.try_load_persistent_undo_for_active();
+        }
+        state.editor.active_idx = saved_active.min(state.editor.tabs.len().saturating_sub(1));
 
         // Only re-anchor the viewport on the cursor when something actually
         // moved the cursor (or the layout changed); pure scroll actions leave

--- a/src/app.rs
+++ b/src/app.rs
@@ -4489,6 +4489,63 @@ impl AppState {
         });
     }
 
+    /// Build a `Session` snapshot of the current editor state and write it
+    /// to `<workspace>/.txt/session.json`. Called once on clean shutdown
+    /// when `restore_session = true`. Buffers without a saved path are
+    /// skipped — they have nothing to reopen on the next launch.
+    fn save_session(&self) {
+        use crate::session::{Session, TabState};
+        let mut tabs = Vec::new();
+        let mut active_in_session = 0usize;
+        let active_idx = self.editor.active_idx;
+        for (i, tab) in self.editor.tabs.iter().enumerate() {
+            let Some(path) = &tab.path else {
+                continue;
+            };
+            if i <= active_idx {
+                active_in_session = tabs.len();
+            }
+            tabs.push(TabState {
+                path: path.clone(),
+                cursor_byte: tab.buffer.cursors.primary().byte_offset,
+                viewport_top: tab.viewport.scroll_row,
+            });
+        }
+        let session = Session {
+            tabs,
+            active: active_in_session,
+            sidebar_open: self.sidebar.is_some(),
+        };
+        session.save(&self.workspace);
+    }
+
+    /// Open every tab listed in `session` and restore cursor positions /
+    /// viewport tops. Files that no longer exist on disk are skipped.
+    /// Returns `true` when at least one tab was restored.
+    pub fn restore_from_session(&mut self, session: crate::session::Session) -> bool {
+        let mut restored_any = false;
+        for tab in &session.tabs {
+            if !tab.path.exists() {
+                continue;
+            }
+            if self.editor.open_tab(tab.path.clone()).is_ok() {
+                let buf = &mut self.editor.active_mut().buffer;
+                let bound = tab.cursor_byte.min(buf.rope().len_bytes());
+                *buf.cursors.primary_mut() =
+                    crate::buffer::cursor::Cursor::from_byte_offset(buf.rope(), bound);
+                self.editor.active_mut().viewport.scroll_row = tab.viewport_top;
+                restored_any = true;
+            }
+        }
+        if restored_any && session.active < self.editor.tabs.len() {
+            self.editor.active_idx = session.active;
+        }
+        if session.sidebar_open && self.sidebar.is_none() {
+            self.sidebar = Some(SidebarState::new());
+        }
+        restored_any
+    }
+
     fn refresh_git_gutter(&mut self) {
         let path = self.editor.active().path.clone();
         if let Some(path) = path {
@@ -6092,11 +6149,19 @@ impl App {
         editor: Editor,
         open_sidebar: bool,
         workspace: PathBuf,
+        pending_session: Option<crate::session::Session>,
     ) -> Result<()> {
         let mut state = AppState::new(editor, workspace);
         if open_sidebar {
             state.sidebar = Some(SidebarState::new());
             state.sidebar_focused = true;
+        }
+        // Honour `restore_session = true`: re-open the previously saved
+        // tabs before painting the first frame. Skips silently when no
+        // session is pending.
+        if let Some(session) = pending_session {
+            state.restore_from_session(session);
+            state.refresh_git_gutter();
         }
 
         // Only re-anchor the viewport on the cursor when something actually
@@ -6180,6 +6245,12 @@ impl App {
             if state.should_quit {
                 break;
             }
+        }
+
+        // Persist the session for the next launch when the user has opted
+        // in. Silent on I/O failures.
+        if state.config.restore_session {
+            state.save_session();
         }
 
         Ok(())

--- a/src/app.rs
+++ b/src/app.rs
@@ -87,6 +87,9 @@ pub enum InputMode {
     RecordMacroChar,
     /// "Replay macro from slot: " — next char names the slot a–z.
     ReplayMacroChar,
+    /// Alt+': "Surround with: " — wraps the current selection in a chosen
+    /// delimiter pair on the next typed character.
+    SurroundChar,
 }
 
 impl InputMode {
@@ -1302,14 +1305,26 @@ impl AppState {
 
             // ── Text insertion ────────────────────────────────────────
             EditorAction::InsertChar(c) => {
-                let (indent, rules) = self.indent_for_active();
-                if self.editor.active().buffer.cursors.is_multi() {
-                    self.editor.active_mut().buffer.multi_insert_char(c);
-                } else {
-                    self.editor
-                        .active_mut()
-                        .buffer
-                        .insert_char_with_indent(c, &indent, rules);
+                // Auto-pair: when the user types one of the configured open
+                // delimiters with no active selection, also insert the
+                // matching close delimiter and step the cursor back one byte
+                // so they keep typing inside the pair. Skip-on-close: when
+                // the user types a close delimiter and the next char already
+                // is that close, just advance the cursor instead of
+                // inserting a duplicate.
+                let auto_paired = self.config.auto_pair
+                    && !self.editor.active().buffer.cursors.is_multi()
+                    && self.try_auto_pair(c);
+                if !auto_paired {
+                    let (indent, rules) = self.indent_for_active();
+                    if self.editor.active().buffer.cursors.is_multi() {
+                        self.editor.active_mut().buffer.multi_insert_char(c);
+                    } else {
+                        self.editor
+                            .active_mut()
+                            .buffer
+                            .insert_char_with_indent(c, &indent, rules);
+                    }
                 }
             }
             EditorAction::InsertNewline => {
@@ -1946,6 +1961,9 @@ impl AppState {
             EditorAction::BeginReplayMacro => {
                 self.input_mode = InputMode::ReplayMacroChar;
             }
+            EditorAction::BeginSurround => {
+                self.input_mode = InputMode::SurroundChar;
+            }
             EditorAction::ToggleSidebar => {
                 if self.sidebar.is_none() {
                     // Restore saved state or create fresh, then expand to current file.
@@ -2324,6 +2342,11 @@ impl AppState {
                     self.replay_macro_slot(c);
                     return;
                 }
+                InputMode::SurroundChar => {
+                    self.input_mode = InputMode::Normal;
+                    self.apply_surround(c);
+                    return;
+                }
                 _ => {}
             }
         }
@@ -2369,7 +2392,8 @@ impl AppState {
                     | InputMode::SetMarkChar
                     | InputMode::JumpToMarkChar
                     | InputMode::RecordMacroChar
-                    | InputMode::ReplayMacroChar => {}
+                    | InputMode::ReplayMacroChar
+                    | InputMode::SurroundChar => {}
                 }
                 return;
             }
@@ -2484,7 +2508,8 @@ impl AppState {
                     | InputMode::SetMarkChar
                     | InputMode::JumpToMarkChar
                     | InputMode::RecordMacroChar
-                    | InputMode::ReplayMacroChar => {}
+                    | InputMode::ReplayMacroChar
+                    | InputMode::SurroundChar => {}
                 }
             }
             EditorAction::Quit | EditorAction::Unhandled => {
@@ -5507,6 +5532,112 @@ impl AppState {
     }
 
     // ── Coordinate helpers ───────────────────────────────────────────────────
+
+    /// Try to handle `c` as a bracket-pair insertion or skip-on-close.
+    /// Returns `true` when this method consumed the keystroke; the caller
+    /// must skip the normal insert path. Caller already ensured the buffer
+    /// is single-cursor and `config.auto_pair` is on.
+    fn try_auto_pair(&mut self, c: char) -> bool {
+        // Pair table — opener → closer. Symmetric pairs (`"` etc.) close
+        // with the same character.
+        let pair_for = |ch: char| -> Option<char> {
+            match ch {
+                '(' => Some(')'),
+                '[' => Some(']'),
+                '{' => Some('}'),
+                '"' => Some('"'),
+                '\'' => Some('\''),
+                '`' => Some('`'),
+                _ => None,
+            }
+        };
+        let close_for = |ch: char| -> bool { matches!(ch, ')' | ']' | '}' | '"' | '\'' | '`') };
+
+        let buf = &mut self.editor.active_mut().buffer;
+        let cursor = buf.cursors.primary();
+        if cursor.has_selection() {
+            return false;
+        }
+        let at = cursor.byte_offset;
+        let rope = buf.rope();
+        let next_char = if at < rope.len_bytes() {
+            let ch_idx = rope.byte_to_char(at);
+            rope.chars_at(ch_idx).next()
+        } else {
+            None
+        };
+        let prev_char = if at > 0 {
+            let ch_idx = rope.byte_to_char(at);
+            // Walk one char back.
+            let mut iter = rope.chars_at(ch_idx);
+            iter.prev()
+        } else {
+            None
+        };
+
+        // Skip-on-close: typing `)` over an existing `)` just advances.
+        if close_for(c) && next_char == Some(c) {
+            let new_off = at + c.len_utf8();
+            buf.move_cursor_to(new_off, false);
+            return true;
+        }
+
+        // Auto-open: insert `(` `)` and step back. Symmetric pairs need extra
+        // care to avoid pairing a closing quote with itself when the cursor
+        // is right after a word character (e.g. `let's` → don't pair the
+        // apostrophe).
+        if let Some(close) = pair_for(c) {
+            let is_symmetric = c == close;
+            if is_symmetric {
+                // Don't auto-pair quotes when adjacent to a word char on
+                // either side (prevents the `let's` case and contractions).
+                let is_word = |ch: Option<char>| match ch {
+                    Some(c) => c.is_alphanumeric() || c == '_',
+                    None => false,
+                };
+                if is_word(prev_char) || is_word(next_char) {
+                    return false;
+                }
+            }
+            let mut pair = String::with_capacity(c.len_utf8() + close.len_utf8());
+            pair.push(c);
+            pair.push(close);
+            buf.insert_str(&pair);
+            // Step the cursor back one char so the user types inside the pair.
+            let after = buf.cursors.primary().byte_offset;
+            let target = after.saturating_sub(close.len_utf8());
+            buf.move_cursor_to(target, false);
+            return true;
+        }
+        false
+    }
+
+    /// Wrap the active selection (or word at the cursor) in the delimiter
+    /// pair chosen by `ch`. Symmetric punctuation (e.g. `"`, `'`) uses the
+    /// same character on both sides.
+    fn apply_surround(&mut self, ch: char) {
+        let pair: Option<(String, String)> = match ch {
+            '(' | ')' => Some(("(".into(), ")".into())),
+            '[' | ']' => Some(("[".into(), "]".into())),
+            '{' | '}' => Some(("{".into(), "}".into())),
+            '<' | '>' => Some(("<".into(), ">".into())),
+            '"' | '\'' | '`' => Some((ch.to_string(), ch.to_string())),
+            c if c.is_ascii_punctuation() => Some((c.to_string(), c.to_string())),
+            _ => None,
+        };
+        let Some((open, close)) = pair else {
+            self.status_error = Some(format!("No surround pair for '{ch}'"));
+            return;
+        };
+        let ok = self
+            .editor
+            .active_mut()
+            .buffer
+            .surround_selection(&open, &close);
+        if !ok {
+            self.status_error = Some("No selection or word to surround".into());
+        }
+    }
 
     fn selected_text(&self) -> Option<String> {
         let cursor = self.editor.active().buffer.cursors.primary();

--- a/src/app.rs
+++ b/src/app.rs
@@ -3301,10 +3301,17 @@ impl AppState {
             0 => self.config.confirm_exit = !self.config.confirm_exit,
             1 => self.config.auto_save = !self.config.auto_save,
             2 => self.config.show_whitespace = !self.config.show_whitespace,
-            3 => self.config.hide_git_folder = !self.config.hide_git_folder,
-            4 => self.config.hide_dot_folders = !self.config.hide_dot_folders,
-            5 => self.config.restore_session = !self.config.restore_session,
-            6 => {
+            3 => {
+                self.config.highlight_trailing_whitespace =
+                    !self.config.highlight_trailing_whitespace;
+            }
+            4 => self.config.warn_mixed_indent = !self.config.warn_mixed_indent,
+            5 => self.config.auto_pair = !self.config.auto_pair,
+            6 => self.config.hide_git_folder = !self.config.hide_git_folder,
+            7 => self.config.hide_dot_folders = !self.config.hide_dot_folders,
+            8 => self.config.restore_session = !self.config.restore_session,
+            9 => self.config.persistent_undo = !self.config.persistent_undo,
+            10 => {
                 let all = Theme::ALL;
                 let idx = all
                     .iter()
@@ -3317,7 +3324,7 @@ impl AppState {
                 };
                 self.config.theme = all[next].clone();
             }
-            7 => {
+            11 => {
                 let all = KeymapPreset::ALL;
                 let idx = all
                     .iter()

--- a/src/app.rs
+++ b/src/app.rs
@@ -959,6 +959,8 @@ pub struct AppState {
     pub clipboard_ring: Option<ClipboardRingState>,
     /// `Alt+H` float showing HEAD content for the hunk at the cursor.
     pub diff_peek: Option<DiffPeekState>,
+    /// `Alt+1` overlay listing every LSP diagnostic across the workspace.
+    pub quickfix: Option<crate::quickfix::QuickfixState>,
     pub git_gutter: Option<GitGutter>,
     pub git_dialog: Option<GitDialogState>,
     pub config: Config,
@@ -1078,6 +1080,7 @@ impl AppState {
             references_list: None,
             clipboard_ring: None,
             diff_peek: None,
+            quickfix: None,
             git_gutter: None,
             git_dialog: None,
             config,
@@ -1241,6 +1244,11 @@ impl AppState {
 
         // Clipboard ring picker — captured input
         if self.clipboard_ring.is_some() && self.handle_clipboard_ring(&action) {
+            return;
+        }
+
+        // Quickfix list — captured input
+        if self.quickfix.is_some() && self.handle_quickfix_input(&action) {
             return;
         }
 
@@ -2045,6 +2053,20 @@ impl AppState {
             }
             EditorAction::PeekHeadAtCursor => {
                 self.toggle_diff_peek();
+            }
+            EditorAction::OpenQuickfix => {
+                let entries = crate::quickfix::collect_lsp_diagnostics(&self.editor);
+                if entries.is_empty() {
+                    self.status_error = Some("No diagnostics".into());
+                } else {
+                    self.quickfix = Some(crate::quickfix::QuickfixState::new(entries));
+                }
+            }
+            EditorAction::QuickfixNext => {
+                self.quickfix_step(1);
+            }
+            EditorAction::QuickfixPrev => {
+                self.quickfix_step(-1);
             }
             EditorAction::TriggerCompletion => {
                 self.trigger_completion();
@@ -5283,6 +5305,79 @@ impl AppState {
             })
             .collect();
         self.references_list = Some(ReferencesListState { items, selected: 0 });
+    }
+
+    /// Walk to the next/previous quickfix entry and jump to it. Does not
+    /// open the overlay — just navigates the list when it is already
+    /// populated. Builds a fresh list from current diagnostics if the
+    /// overlay state is empty.
+    fn quickfix_step(&mut self, step: i32) {
+        if self.quickfix.is_none() {
+            let entries = crate::quickfix::collect_lsp_diagnostics(&self.editor);
+            if entries.is_empty() {
+                self.status_error = Some("No diagnostics".into());
+                return;
+            }
+            self.quickfix = Some(crate::quickfix::QuickfixState::new(entries));
+        }
+        let entry_opt = {
+            let qf = self.quickfix.as_mut().unwrap();
+            let n = qf.entries.len();
+            if n == 0 {
+                None
+            } else {
+                let i = if step > 0 {
+                    (qf.selected + 1) % n
+                } else {
+                    (qf.selected + n - 1) % n
+                };
+                qf.selected = i;
+                Some(qf.entries[i].clone())
+            }
+        };
+        if let Some(e) = entry_opt {
+            self.jump_to_location(&(e.path, e.line, e.col));
+        }
+    }
+
+    /// Handle input while the quickfix list overlay is open.
+    fn handle_quickfix_input(&mut self, action: &EditorAction) -> bool {
+        let n = self.quickfix.as_ref().map(|q| q.entries.len()).unwrap_or(0);
+        match action {
+            EditorAction::MoveCursor(Direction::Up) => {
+                if let Some(q) = &mut self.quickfix {
+                    q.selected = q.selected.saturating_sub(1);
+                }
+                true
+            }
+            EditorAction::MoveCursor(Direction::Down) => {
+                if let Some(q) = &mut self.quickfix {
+                    q.selected = (q.selected + 1).min(n.saturating_sub(1));
+                }
+                true
+            }
+            EditorAction::InsertNewline => {
+                let target = self.quickfix.as_ref().and_then(|q| {
+                    q.entries
+                        .get(q.selected)
+                        .map(|e| (e.path.clone(), e.line, e.col))
+                });
+                self.quickfix = None;
+                if let Some(loc) = target {
+                    self.jump_to_location(&loc);
+                }
+                true
+            }
+            EditorAction::CloseSearch => {
+                self.quickfix = None;
+                true
+            }
+            EditorAction::Quit | EditorAction::ForceQuit => {
+                self.quickfix = None;
+                false
+            }
+            _ => false,
+        }
     }
 
     /// Handle input while the clipboard-ring picker is open. Returns `true`

--- a/src/app.rs
+++ b/src/app.rs
@@ -773,6 +773,16 @@ pub struct ReferencesListState {
     pub selected: usize,
 }
 
+/// State for the inline diff-peek float (`Alt+H`). Lists the HEAD lines for
+/// the hunk under the cursor.
+pub struct DiffPeekState {
+    pub head_lines: Vec<String>,
+    /// Cursor line at the time the peek was opened — used to anchor the float
+    /// near the cursor.
+    #[allow(dead_code)]
+    pub anchor_line: usize,
+}
+
 /// State for the clipboard-ring picker overlay (`Ctrl+Shift+V`).
 pub struct ClipboardRingState {
     /// Snapshot of the ring at the time the overlay was opened. Most recent
@@ -947,6 +957,8 @@ pub struct AppState {
     pub references_list: Option<ReferencesListState>,
     /// `Ctrl+Shift+V` overlay listing the last N clipboard entries.
     pub clipboard_ring: Option<ClipboardRingState>,
+    /// `Alt+H` float showing HEAD content for the hunk at the cursor.
+    pub diff_peek: Option<DiffPeekState>,
     pub git_gutter: Option<GitGutter>,
     pub git_dialog: Option<GitDialogState>,
     pub config: Config,
@@ -1065,6 +1077,7 @@ impl AppState {
             hover: None,
             references_list: None,
             clipboard_ring: None,
+            diff_peek: None,
             git_gutter: None,
             git_dialog: None,
             config,
@@ -2020,6 +2033,18 @@ impl AppState {
                         selected: 0,
                     });
                 }
+            }
+            EditorAction::NextHunk => {
+                self.jump_to_relative_hunk(1);
+            }
+            EditorAction::PrevHunk => {
+                self.jump_to_relative_hunk(-1);
+            }
+            EditorAction::RevertHunkAtCursor => {
+                self.revert_hunk_at_cursor();
+            }
+            EditorAction::PeekHeadAtCursor => {
+                self.toggle_diff_peek();
             }
             EditorAction::TriggerCompletion => {
                 self.trigger_completion();
@@ -4293,6 +4318,155 @@ impl AppState {
     }
 
     /// Recompute the git gutter for the currently active buffer (if it has a path).
+    /// Move the cursor to the start of the next (`step == 1`) or previous
+    /// (`step == -1`) git hunk. No-op when there are no hunks or git is off.
+    fn jump_to_relative_hunk(&mut self, step: i32) {
+        let Some(gutter) = self.git_gutter.as_ref() else {
+            return;
+        };
+        let hunks = gutter.hunks();
+        if hunks.is_empty() {
+            self.status_error = Some("No git hunks in this buffer".into());
+            return;
+        }
+        let cur_line = self.editor.active().buffer.cursors.primary().line;
+        let target = if step > 0 {
+            hunks
+                .iter()
+                .find(|h| h.start_line > cur_line)
+                .copied()
+                .unwrap_or(hunks[0])
+        } else {
+            hunks
+                .iter()
+                .rev()
+                .find(|h| h.end_line < cur_line)
+                .copied()
+                .unwrap_or(*hunks.last().unwrap())
+        };
+        self.push_current_to_jump_list();
+        let rope = self.editor.active().buffer.rope().clone();
+        let line = target.start_line.min(rope.len_lines().saturating_sub(1));
+        let cursor = crate::buffer::cursor::Cursor::from_line_col(&rope, line, 0);
+        *self.editor.active_mut().buffer.cursors.primary_mut() = cursor;
+    }
+
+    /// Replace the hunk containing the cursor with its HEAD content.
+    fn revert_hunk_at_cursor(&mut self) {
+        let Some(gutter) = self.git_gutter.as_ref() else {
+            self.status_error = Some("No git gutter available".into());
+            return;
+        };
+        let cur_line = self.editor.active().buffer.cursors.primary().line;
+        let hunk_opt = gutter
+            .hunks()
+            .into_iter()
+            .find(|h| cur_line >= h.start_line && cur_line <= h.end_line);
+        let Some(hunk) = hunk_opt else {
+            self.status_error = Some("Cursor is not inside a hunk".into());
+            return;
+        };
+        let Some(path) = self.editor.active().path.clone() else {
+            self.status_error = Some("Save the file before reverting a hunk".into());
+            return;
+        };
+        let head_content = match crate::git::fetch_head_content(&path) {
+            Some(c) => c,
+            None => {
+                self.status_error = Some("File is not tracked in HEAD".into());
+                return;
+            }
+        };
+        // Recompute the hunk's HEAD-side line span by re-running the same
+        // diff that produced the gutter. We need to find the HEAD lines that
+        // map to this hunk's [start_line, end_line] range in the current
+        // buffer.
+        let current_full = self.editor.active().buffer.to_string();
+        let head_lines: Vec<&str> = head_content.lines().collect();
+        let current_lines: Vec<&str> = current_full.lines().collect();
+        let (head_start, head_end) = crate::git::head_range_for_hunk(
+            &head_lines,
+            &current_lines,
+            hunk.start_line,
+            hunk.end_line,
+        );
+
+        // Replace the buffer slice [hunk.start_line, hunk.end_line] with the
+        // HEAD content slice [head_start, head_end].
+        let replacement = if head_start <= head_end && head_end < head_lines.len() {
+            let mut s = head_lines[head_start..=head_end].join("\n");
+            // Keep the trailing newline so we don't merge the next line into
+            // the hunk's last line.
+            s.push('\n');
+            s
+        } else {
+            // Pure deletion in HEAD — replacement is empty (matches: hunk
+            // exists in current but has no HEAD counterpart).
+            String::new()
+        };
+
+        let buf = &mut self.editor.active_mut().buffer;
+        let start_byte = buf.line_start_byte(hunk.start_line);
+        let end_line = (hunk.end_line + 1).min(buf.len_lines());
+        let end_byte = buf.line_start_byte(end_line);
+        buf.begin_batch();
+        buf.delete_range(start_byte, end_byte);
+        if !replacement.is_empty() {
+            buf.cursors.primary_mut().byte_offset = start_byte;
+            buf.insert_str(&replacement);
+        }
+        buf.commit_batch();
+        self.refresh_git_gutter();
+    }
+
+    /// Toggle the inline diff-peek float for the hunk under the cursor.
+    fn toggle_diff_peek(&mut self) {
+        if self.diff_peek.is_some() {
+            self.diff_peek = None;
+            return;
+        }
+        let Some(gutter) = self.git_gutter.as_ref() else {
+            return;
+        };
+        let cur_line = self.editor.active().buffer.cursors.primary().line;
+        let Some(hunk) = gutter
+            .hunks()
+            .into_iter()
+            .find(|h| cur_line >= h.start_line && cur_line <= h.end_line)
+        else {
+            self.status_error = Some("Cursor is not inside a hunk".into());
+            return;
+        };
+        let Some(path) = self.editor.active().path.clone() else {
+            return;
+        };
+        let Some(head_content) = crate::git::fetch_head_content(&path) else {
+            self.status_error = Some("File is not tracked in HEAD".into());
+            return;
+        };
+        let current_full = self.editor.active().buffer.to_string();
+        let head_lines: Vec<&str> = head_content.lines().collect();
+        let current_lines: Vec<&str> = current_full.lines().collect();
+        let (head_start, head_end) = crate::git::head_range_for_hunk(
+            &head_lines,
+            &current_lines,
+            hunk.start_line,
+            hunk.end_line,
+        );
+        let lines: Vec<String> = if head_start <= head_end && head_end < head_lines.len() {
+            head_lines[head_start..=head_end]
+                .iter()
+                .map(|s| s.to_string())
+                .collect()
+        } else {
+            vec!["(no HEAD content for this hunk)".into()]
+        };
+        self.diff_peek = Some(DiffPeekState {
+            head_lines: lines,
+            anchor_line: cur_line,
+        });
+    }
+
     fn refresh_git_gutter(&mut self) {
         let path = self.editor.active().path.clone();
         if let Some(path) = path {

--- a/src/app.rs
+++ b/src/app.rs
@@ -770,6 +770,15 @@ pub struct ReferencesListState {
     pub selected: usize,
 }
 
+/// State for the clipboard-ring picker overlay (`Ctrl+Shift+V`).
+pub struct ClipboardRingState {
+    /// Snapshot of the ring at the time the overlay was opened. Most recent
+    /// entry first. Mutated only via `selected`; the underlying
+    /// `ClipboardManager` is not touched until the user confirms a pick.
+    pub entries: Vec<String>,
+    pub selected: usize,
+}
+
 /// A single reference location.
 pub struct ReferenceItem {
     pub path: PathBuf,
@@ -933,6 +942,8 @@ pub struct AppState {
     pub completion: Option<CompletionState>,
     pub hover: Option<HoverState>,
     pub references_list: Option<ReferencesListState>,
+    /// `Ctrl+Shift+V` overlay listing the last N clipboard entries.
+    pub clipboard_ring: Option<ClipboardRingState>,
     pub git_gutter: Option<GitGutter>,
     pub git_dialog: Option<GitDialogState>,
     pub config: Config,
@@ -1050,6 +1061,7 @@ impl AppState {
             completion: None,
             hover: None,
             references_list: None,
+            clipboard_ring: None,
             git_gutter: None,
             git_dialog: None,
             config,
@@ -1208,6 +1220,11 @@ impl AppState {
 
         // References list — captured input
         if self.references_list.is_some() && self.handle_references_input(&action) {
+            return;
+        }
+
+        // Clipboard ring picker — captured input
+        if self.clipboard_ring.is_some() && self.handle_clipboard_ring(&action) {
             return;
         }
 
@@ -1976,6 +1993,15 @@ impl AppState {
             }
             EditorAction::OpenGitDialog => {
                 self.open_git_dialog();
+            }
+            EditorAction::OpenClipboardRing => {
+                let entries = self.clipboard.ring_entries();
+                if !entries.is_empty() {
+                    self.clipboard_ring = Some(ClipboardRingState {
+                        entries,
+                        selected: 0,
+                    });
+                }
             }
             EditorAction::TriggerCompletion => {
                 self.trigger_completion();
@@ -5058,6 +5084,51 @@ impl AppState {
             })
             .collect();
         self.references_list = Some(ReferencesListState { items, selected: 0 });
+    }
+
+    /// Handle input while the clipboard-ring picker is open. Returns `true`
+    /// when the action was consumed, `false` to allow global routing.
+    fn handle_clipboard_ring(&mut self, action: &EditorAction) -> bool {
+        let num_items = self
+            .clipboard_ring
+            .as_ref()
+            .map(|r| r.entries.len())
+            .unwrap_or(0);
+        match action {
+            EditorAction::MoveCursor(Direction::Up) => {
+                if let Some(r) = &mut self.clipboard_ring {
+                    r.selected = r.selected.saturating_sub(1);
+                }
+                true
+            }
+            EditorAction::MoveCursor(Direction::Down) => {
+                if let Some(r) = &mut self.clipboard_ring {
+                    r.selected = (r.selected + 1).min(num_items.saturating_sub(1));
+                }
+                true
+            }
+            EditorAction::InsertNewline => {
+                if let Some(r) = &self.clipboard_ring {
+                    let idx = r.selected;
+                    if let Some(text) = self.clipboard.pick(idx) {
+                        // Reuse the buffer's insert_str — it already handles
+                        // replacing the active selection, exactly like Paste.
+                        self.editor.active_mut().buffer.insert_str(&text);
+                    }
+                }
+                self.clipboard_ring = None;
+                true
+            }
+            EditorAction::CloseSearch => {
+                self.clipboard_ring = None;
+                true
+            }
+            EditorAction::Quit | EditorAction::ForceQuit => {
+                self.clipboard_ring = None;
+                false
+            }
+            _ => false,
+        }
     }
 
     fn handle_references_input(&mut self, action: &EditorAction) -> bool {

--- a/src/buffer/history.rs
+++ b/src/buffer/history.rs
@@ -4,8 +4,10 @@
 //! knows how to undo itself. A `BatchGuard` groups multiple commands into one
 //! logical undo step (e.g., Replace All).
 
+use serde::{Deserialize, Serialize};
+
 /// A single undoable/redoable text edit.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum EditCommand {
     /// Inserted `text` at byte offset `at`.
     Insert { at: usize, text: String },
@@ -52,8 +54,8 @@ impl EditCommand {
 
 /// One entry on the undo stack. Either a single command or a batch of commands
 /// that are undone/redone together.
-#[derive(Debug, Clone)]
-enum UndoEntry {
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum UndoEntry {
     Single(EditCommand),
     Batch(Vec<EditCommand>),
 }
@@ -176,6 +178,31 @@ impl UndoStack {
     pub fn redo_depth(&self) -> usize {
         self.redo_stack.len()
     }
+
+    /// Build a serializable snapshot of the current undo/redo stacks. Used
+    /// by `crate::buffer::persistent_undo` to write the history to disk.
+    pub fn snapshot(&self) -> UndoStackSnapshot {
+        UndoStackSnapshot {
+            undo: self.undo_stack.clone(),
+            redo: self.redo_stack.clone(),
+        }
+    }
+
+    /// Replace the in-memory stacks with `snap`. Any open batch is dropped.
+    pub fn restore(&mut self, snap: UndoStackSnapshot) {
+        self.current_batch = None;
+        self.undo_stack = snap.undo;
+        self.redo_stack = snap.redo;
+        self.trim_to_capacity();
+    }
+}
+
+/// Serializable view of an `UndoStack`. The on-disk format is JSON via
+/// `serde_json` to match the other workspace-local files.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct UndoStackSnapshot {
+    pub undo: Vec<UndoEntry>,
+    pub redo: Vec<UndoEntry>,
 }
 
 impl Default for UndoStack {

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -102,6 +102,31 @@ impl Buffer {
         s.trim_end_matches(['\r', '\n']).to_string()
     }
 
+    /// Whether the buffer contains both tab-indented and space-indented lines.
+    /// Only leading whitespace is examined; lines whose first non-whitespace
+    /// character is at column 0, or which are entirely whitespace, are ignored.
+    pub fn has_mixed_indent(&self) -> bool {
+        let mut saw_tabs = false;
+        let mut saw_spaces = false;
+        let total = self.rope.len_lines();
+        // Scan up to 5000 lines — enough for every realistic source file but
+        // bounded so a 1 GiB buffer doesn't stall the status bar.
+        let cap = total.min(5000);
+        for i in 0..cap {
+            let line = self.rope.line(i);
+            let first = line.chars().next();
+            match first {
+                Some('\t') => saw_tabs = true,
+                Some(' ') => saw_spaces = true,
+                _ => {}
+            }
+            if saw_tabs && saw_spaces {
+                return true;
+            }
+        }
+        false
+    }
+
     // ------------------------------------------------------------------ //
     // Undo / redo
     // ------------------------------------------------------------------ //
@@ -2057,6 +2082,35 @@ mod tests {
         buf.insert_str("hello");
         assert_eq!(buf.to_string(), "hello");
         assert!(buf.modified);
+    }
+
+    #[test]
+    fn has_mixed_indent_detects_mixed() {
+        let mut buf = Buffer::new();
+        buf.insert_str("\tfoo\n  bar\n");
+        assert!(buf.has_mixed_indent());
+    }
+
+    #[test]
+    fn has_mixed_indent_pure_tabs() {
+        let mut buf = Buffer::new();
+        buf.insert_str("\tfoo\n\tbar\n");
+        assert!(!buf.has_mixed_indent());
+    }
+
+    #[test]
+    fn has_mixed_indent_pure_spaces() {
+        let mut buf = Buffer::new();
+        buf.insert_str("  foo\n    bar\n");
+        assert!(!buf.has_mixed_indent());
+    }
+
+    #[test]
+    fn has_mixed_indent_ignores_unindented_lines() {
+        let mut buf = Buffer::new();
+        // Top-level lines (column 0 content) don't count either way.
+        buf.insert_str("foo\nbar\n");
+        assert!(!buf.has_mixed_indent());
     }
 
     #[test]

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -535,6 +535,79 @@ impl Buffer {
         self.history.commit_batch();
     }
 
+    /// Wrap the current selection with `open` and `close`. When no selection
+    /// is active, the word boundaries around the cursor are used. Both
+    /// inserts go in a single undo batch.
+    ///
+    /// Returns `true` when an edit was performed; `false` when there was no
+    /// selectable target (empty buffer / cursor on a non-word character with
+    /// no selection).
+    pub fn surround_selection(&mut self, open: &str, close: &str) -> bool {
+        let (start, end) = {
+            let cursor = self.cursors.primary();
+            if cursor.has_selection() {
+                let range = cursor.selection_bytes();
+                (range.start, range.end)
+            } else {
+                let at = cursor.byte_offset;
+                let s = rope_edit::prev_word_boundary(&self.rope, at);
+                // Scan forward from `at` while we keep seeing word characters;
+                // unlike `next_word_boundary`, this does not consume trailing
+                // whitespace so "(hello)" is wrapped, not "(hello )".
+                let char_at = self.rope.byte_to_char(at);
+                let mut e = at;
+                for ch in self.rope.chars_at(char_at) {
+                    let is_word = ch.is_alphanumeric() || ch == '_';
+                    if !is_word {
+                        break;
+                    }
+                    e += ch.len_utf8();
+                }
+                if s == e {
+                    return false;
+                }
+                (s, e)
+            }
+        };
+        let open_bytes = open.len();
+        let close_bytes = close.len();
+
+        self.history.begin_batch();
+        // Insert close first so the open-insert offset doesn't shift.
+        rope_edit::insert(&mut self.rope, end, close);
+        record(
+            &mut self.history,
+            &mut self.pending_edits,
+            EditCommand::Insert {
+                at: end,
+                text: close.to_string(),
+            },
+        );
+        rope_edit::insert(&mut self.rope, start, open);
+        record(
+            &mut self.history,
+            &mut self.pending_edits,
+            EditCommand::Insert {
+                at: start,
+                text: open.to_string(),
+            },
+        );
+        self.history.commit_batch();
+
+        // Update primary cursor + selection to wrap the new inner range
+        // (after the inserted open delimiter, before the inserted close).
+        let inner_start = start + open_bytes;
+        let inner_end = end + open_bytes; // shifted only by the open insert
+        let _ = close_bytes;
+        *self.cursors.primary_mut() = Cursor::from_byte_offset(&self.rope, inner_end);
+        self.cursors.primary_mut().selection = Some(crate::buffer::cursor::Selection::new(
+            inner_start,
+            inner_end,
+        ));
+        self.modified = true;
+        true
+    }
+
     /// Duplicate the current line (or selection).
     pub fn duplicate_line(&mut self) {
         let cursor = self.cursors.primary();
@@ -2111,6 +2184,41 @@ mod tests {
         // Top-level lines (column 0 content) don't count either way.
         buf.insert_str("foo\nbar\n");
         assert!(!buf.has_mixed_indent());
+    }
+
+    #[test]
+    fn surround_selection_wraps_quotes() {
+        let mut buf = Buffer::new();
+        buf.insert_str("foo bar");
+        // Select "bar" (bytes 4..7).
+        let primary = buf.cursors.primary_mut();
+        primary.byte_offset = 7;
+        primary.selection = Some(crate::buffer::cursor::Selection::new(4, 7));
+        assert!(buf.surround_selection("\"", "\""));
+        assert_eq!(buf.to_string(), "foo \"bar\"");
+    }
+
+    #[test]
+    fn surround_selection_wraps_brackets_around_word_under_cursor() {
+        let mut buf = Buffer::new();
+        buf.insert_str("hello world");
+        // Place cursor inside "hello" (byte 2). No selection.
+        buf.cursors.primary_mut().byte_offset = 2;
+        assert!(buf.surround_selection("(", ")"));
+        assert_eq!(buf.to_string(), "(hello) world");
+    }
+
+    #[test]
+    fn surround_selection_undo_restores_original() {
+        let mut buf = Buffer::new();
+        buf.insert_str("foo");
+        buf.cursors.primary_mut().byte_offset = 0;
+        buf.cursors.primary_mut().selection = Some(crate::buffer::cursor::Selection::new(0, 3));
+        assert!(buf.surround_selection("[", "]"));
+        assert_eq!(buf.to_string(), "[foo]");
+        // Surround inserts go in a single undo batch — one undo reverts both.
+        buf.undo();
+        assert_eq!(buf.to_string(), "foo");
     }
 
     #[test]

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -2,6 +2,7 @@ pub mod cursor;
 pub mod edit;
 pub mod folds;
 pub mod history;
+pub mod persistent_undo;
 
 use ropey::Rope;
 
@@ -139,6 +140,19 @@ impl Buffer {
     #[allow(dead_code)]
     pub fn can_redo(&self) -> bool {
         self.history.can_redo()
+    }
+
+    /// Take a serializable snapshot of the undo/redo stacks. Used by
+    /// persistent undo to write history to disk on save.
+    pub fn history_snapshot(&self) -> history::UndoStackSnapshot {
+        self.history.snapshot()
+    }
+
+    /// Restore the undo/redo stacks from `snap` (overwriting whatever is
+    /// currently held). Called once when the buffer is opened and a
+    /// persistent undo record was loaded.
+    pub fn restore_history(&mut self, snap: history::UndoStackSnapshot) {
+        self.history.restore(snap);
     }
 
     /// Number of undo entries currently on the stack. Changes whenever the buffer

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -1917,7 +1917,7 @@ impl Buffer {
     // Helpers
     // ------------------------------------------------------------------ //
 
-    fn line_start_byte(&self, line: usize) -> usize {
+    pub fn line_start_byte(&self, line: usize) -> usize {
         self.rope.char_to_byte(self.rope.line_to_char(line))
     }
 

--- a/src/buffer/persistent_undo.rs
+++ b/src/buffer/persistent_undo.rs
@@ -1,0 +1,131 @@
+//! Persist per-file undo history under `<workspace>/.txt/undo/`.
+//!
+//! Each persisted file is keyed by a stable digest of the canonical file
+//! path so it survives moves of the workspace itself but is per-absolute-
+//! file. The on-disk format is JSON via `serde_json` for consistency with
+//! the rest of `.txt/`.
+//!
+//! Loading is gated by a content-hash check: if the file's bytes on disk
+//! differ from the hash recorded at save time, the saved history is
+//! discarded silently. This prevents stale undo from being applied to a
+//! buffer that was edited externally between sessions.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::buffer::history::UndoStackSnapshot;
+
+/// On-disk record. Holds the snapshot plus the content hash at save time.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct OnDisk {
+    /// Hex-encoded BLAKE3-or-FNV (we use FNV-1a 64-bit to avoid a new
+    /// dependency) of the file's content at save time.
+    file_hash: String,
+    snapshot: UndoStackSnapshot,
+}
+
+/// Compute the on-disk filename for `file_path` inside `workspace`.
+fn record_path(workspace: &Path, file_path: &Path) -> PathBuf {
+    let canonical = file_path
+        .canonicalize()
+        .unwrap_or_else(|_| file_path.to_path_buf());
+    let key = fnv1a_64(canonical.to_string_lossy().as_bytes());
+    workspace
+        .join(".txt")
+        .join("undo")
+        .join(format!("{key:016x}.json"))
+}
+
+/// Persist `snapshot` to disk. Silent on I/O failure.
+pub fn save(workspace: &Path, file_path: &Path, file_content: &str, snapshot: &UndoStackSnapshot) {
+    let p = record_path(workspace, file_path);
+    if let Some(parent) = p.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let payload = OnDisk {
+        file_hash: format!("{:016x}", fnv1a_64(file_content.as_bytes())),
+        snapshot: snapshot.clone(),
+    };
+    if let Ok(text) = serde_json::to_string(&payload) {
+        let _ = std::fs::write(&p, text);
+    }
+}
+
+/// Load a saved snapshot for `file_path` from `workspace`. Returns `None` if
+/// the record is missing, unparseable, or its file hash no longer matches
+/// `current_content`.
+pub fn load(
+    workspace: &Path,
+    file_path: &Path,
+    current_content: &str,
+) -> Option<UndoStackSnapshot> {
+    let p = record_path(workspace, file_path);
+    let text = std::fs::read_to_string(&p).ok()?;
+    let parsed: OnDisk = serde_json::from_str(&text).ok()?;
+    let expected = format!("{:016x}", fnv1a_64(current_content.as_bytes()));
+    if parsed.file_hash != expected {
+        return None;
+    }
+    Some(parsed.snapshot)
+}
+
+/// 64-bit FNV-1a hash. Sufficient for content-change detection — we are not
+/// using this for security.
+fn fnv1a_64(bytes: &[u8]) -> u64 {
+    const OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+    let mut h = OFFSET;
+    for &b in bytes {
+        h ^= b as u64;
+        h = h.wrapping_mul(PRIME);
+    }
+    h
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::buffer::history::{EditCommand, UndoEntry};
+
+    fn sample_snapshot() -> UndoStackSnapshot {
+        UndoStackSnapshot {
+            undo: vec![UndoEntry::Single(EditCommand::Insert {
+                at: 3,
+                text: "hi".into(),
+            })],
+            redo: vec![],
+        }
+    }
+
+    #[test]
+    fn save_and_load_round_trip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("foo.txt");
+        std::fs::write(&file, "content").unwrap();
+        let snap = sample_snapshot();
+        save(tmp.path(), &file, "content", &snap);
+        let loaded = load(tmp.path(), &file, "content").expect("load");
+        assert_eq!(loaded.undo.len(), 1);
+    }
+
+    #[test]
+    fn load_returns_none_on_hash_mismatch() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("bar.txt");
+        std::fs::write(&file, "before").unwrap();
+        let snap = sample_snapshot();
+        save(tmp.path(), &file, "before", &snap);
+        // Pretend the file was changed externally.
+        let loaded = load(tmp.path(), &file, "after");
+        assert!(loaded.is_none(), "stale undo must not be loaded");
+    }
+
+    #[test]
+    fn missing_file_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("never-saved.txt");
+        std::fs::write(&file, "x").unwrap();
+        assert!(load(tmp.path(), &file, "x").is_none());
+    }
+}

--- a/src/clipboard/mod.rs
+++ b/src/clipboard/mod.rs
@@ -10,15 +10,27 @@
 ///   after the process exits, but reads/writes within the same session are fine.
 /// - If arboard returns an error at any point, we silently fall back to the
 ///   internal string and log nothing (to avoid polluting the TUI).
+///
+/// A bounded clipboard ring (last [`RING_CAP`] non-empty `set()` values) is
+/// kept in memory for the lifetime of the process. The system clipboard
+/// remains the default sink/source; the ring is additive and surfaced through
+/// the `Ctrl+Shift+V` overlay.
 pub struct ClipboardManager {
     /// In-process clipboard used as fallback when arboard is unavailable.
     internal: String,
+    /// Bounded ring of recent `set()` values, most-recent first. Adjacent
+    /// duplicates are coalesced.
+    ring: std::collections::VecDeque<String>,
 }
+
+/// Maximum number of distinct entries kept in the clipboard ring.
+pub const RING_CAP: usize = 32;
 
 impl ClipboardManager {
     pub fn new() -> Self {
         Self {
             internal: String::new(),
+            ring: std::collections::VecDeque::new(),
         }
     }
 
@@ -27,7 +39,8 @@ impl ClipboardManager {
         if let Ok(mut clip) = arboard::Clipboard::new() {
             let _ = clip.set_text(&text);
         }
-        self.internal = text;
+        self.internal = text.clone();
+        self.push_ring(text);
     }
 
     /// Read from the system clipboard. Falls back to internal storage on error.
@@ -40,6 +53,40 @@ impl ClipboardManager {
             return text;
         }
         self.internal.clone()
+    }
+
+    /// Returns a snapshot of the clipboard ring, most-recent first.
+    pub fn ring_entries(&self) -> Vec<String> {
+        self.ring.iter().cloned().collect()
+    }
+
+    /// Return the entry at `index` from the ring (0 = most recent) and promote
+    /// it to the front. `None` when out of bounds. Does NOT touch the system
+    /// clipboard so the user's external paste target stays unchanged.
+    pub fn pick(&mut self, index: usize) -> Option<String> {
+        let entry = self.ring.remove(index)?;
+        self.ring.push_front(entry.clone());
+        Some(entry)
+    }
+
+    fn push_ring(&mut self, text: String) {
+        if text.is_empty() {
+            return;
+        }
+        // Coalesce with the most recent entry to avoid spamming the ring when
+        // the same selection is yanked twice in a row.
+        if self.ring.front().is_some_and(|t| t == &text) {
+            return;
+        }
+        // De-dupe: if `text` already exists later in the ring, remove the old
+        // occurrence before unshifting the new one.
+        if let Some(pos) = self.ring.iter().position(|t| t == &text) {
+            self.ring.remove(pos);
+        }
+        self.ring.push_front(text);
+        while self.ring.len() > RING_CAP {
+            self.ring.pop_back();
+        }
     }
 
     /// Returns a reference to the internal (in-process) clipboard contents without
@@ -93,5 +140,78 @@ mod tests {
         cm.set("first".to_string());
         cm.set("second".to_string());
         assert_eq!(cm.internal(), "second");
+    }
+
+    #[test]
+    fn ring_records_unique_entries_newest_first() {
+        let mut cm = ClipboardManager::new();
+        cm.set("alpha".into());
+        cm.set("beta".into());
+        cm.set("gamma".into());
+        let ring = cm.ring_entries();
+        assert_eq!(
+            ring,
+            vec!["gamma".to_string(), "beta".into(), "alpha".into()]
+        );
+    }
+
+    #[test]
+    fn ring_coalesces_immediate_duplicates() {
+        let mut cm = ClipboardManager::new();
+        cm.set("x".into());
+        cm.set("x".into());
+        cm.set("x".into());
+        assert_eq!(cm.ring_entries(), vec!["x".to_string()]);
+    }
+
+    #[test]
+    fn ring_dedupes_older_occurrence() {
+        let mut cm = ClipboardManager::new();
+        cm.set("a".into());
+        cm.set("b".into());
+        cm.set("a".into());
+        // After the second `a`, only one `a` remains and it's at the front.
+        assert_eq!(cm.ring_entries(), vec!["a".to_string(), "b".into()]);
+    }
+
+    #[test]
+    fn ring_caps_at_ring_cap() {
+        let mut cm = ClipboardManager::new();
+        for i in 0..(RING_CAP + 5) {
+            cm.set(format!("entry-{i}"));
+        }
+        assert_eq!(cm.ring_entries().len(), RING_CAP);
+        // The oldest 5 should have fallen off.
+        assert_eq!(cm.ring_entries().last().unwrap(), &format!("entry-{}", 5));
+    }
+
+    #[test]
+    fn pick_promotes_entry_to_front() {
+        let mut cm = ClipboardManager::new();
+        cm.set("a".into());
+        cm.set("b".into());
+        cm.set("c".into());
+        // Pick index 2 (= "a") → ring becomes [a, c, b].
+        let picked = cm.pick(2);
+        assert_eq!(picked.as_deref(), Some("a"));
+        assert_eq!(
+            cm.ring_entries(),
+            vec!["a".to_string(), "c".into(), "b".into()]
+        );
+    }
+
+    #[test]
+    fn pick_out_of_bounds_returns_none() {
+        let mut cm = ClipboardManager::new();
+        cm.set("only".into());
+        assert!(cm.pick(5).is_none());
+    }
+
+    #[test]
+    fn empty_set_does_not_pollute_ring() {
+        let mut cm = ClipboardManager::new();
+        cm.set(String::new());
+        cm.set("real".into());
+        assert_eq!(cm.ring_entries(), vec!["real".to_string()]);
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -109,6 +109,26 @@ pub struct Config {
     /// Exclude every dot-prefixed directory from go-to-file and project search.
     #[serde(default)]
     pub hide_dot_folders: bool,
+    /// Highlight trailing whitespace at the end of edited lines.
+    #[serde(default = "default_highlight_trailing_whitespace")]
+    pub highlight_trailing_whitespace: bool,
+    /// Show a "mixed indent" status-bar segment when a buffer contains both
+    /// tab-leading and space-leading lines.
+    #[serde(default = "default_warn_mixed_indent")]
+    pub warn_mixed_indent: bool,
+    /// Automatically insert a matching closing delimiter when typing `(`,
+    /// `[`, `{`, `"`, `'`, or `` ` ``. Disable with `auto_pair = false`.
+    #[serde(default = "default_auto_pair")]
+    pub auto_pair: bool,
+    /// Restore the previous session (open tabs, cursor positions, sidebar
+    /// state) from `<workspace>/.txt/session.json` when `txt` is invoked
+    /// without a positional file argument.
+    #[serde(default)]
+    pub restore_session: bool,
+    /// Persist per-file undo history to `<workspace>/.txt/undo/` so that
+    /// `Ctrl+Z` keeps working across editor restarts.
+    #[serde(default)]
+    pub persistent_undo: bool,
 }
 
 fn default_tab_size() -> usize {
@@ -124,6 +144,18 @@ fn default_sticky_header() -> bool {
 }
 
 fn default_hide_git_folder() -> bool {
+    true
+}
+
+fn default_highlight_trailing_whitespace() -> bool {
+    true
+}
+
+fn default_warn_mixed_indent() -> bool {
+    true
+}
+
+fn default_auto_pair() -> bool {
     true
 }
 
@@ -145,6 +177,11 @@ impl Default for Config {
             sticky_header: default_sticky_header(),
             hide_git_folder: true,
             hide_dot_folders: false,
+            highlight_trailing_whitespace: default_highlight_trailing_whitespace(),
+            warn_mixed_indent: default_warn_mixed_indent(),
+            auto_pair: default_auto_pair(),
+            restore_session: false,
+            persistent_undo: false,
         }
     }
 }
@@ -341,6 +378,11 @@ mod tests {
             sticky_header: false,
             hide_git_folder: true,
             hide_dot_folders: true,
+            highlight_trailing_whitespace: false,
+            warn_mixed_indent: false,
+            auto_pair: false,
+            restore_session: true,
+            persistent_undo: true,
         };
         let serialized = toml::to_string(&original).unwrap();
         let deserialized: Config = toml::from_str(&serialized).unwrap();
@@ -511,6 +553,30 @@ mod tests {
         assert_eq!(super::parse_minor_version(""), None);
         assert_eq!(super::parse_minor_version("foo"), None);
         assert_eq!(super::parse_minor_version("1"), None);
+    }
+
+    #[test]
+    fn tier3_defaults_match_proposal() {
+        let cfg = Config::default();
+        // 3.6 — passive features default on
+        assert!(cfg.highlight_trailing_whitespace);
+        assert!(cfg.warn_mixed_indent);
+        // 3.4 — auto-pair default on (confirmed by user)
+        assert!(cfg.auto_pair);
+        // 3.1/3.2 — disk-touching features default off ("starts instantly")
+        assert!(!cfg.restore_session);
+        assert!(!cfg.persistent_undo);
+    }
+
+    #[test]
+    fn tier3_keys_round_trip() {
+        let text = "highlight_trailing_whitespace = false\nwarn_mixed_indent = false\nauto_pair = false\nrestore_session = true\npersistent_undo = true\n";
+        let cfg: Config = toml::from_str(text).unwrap();
+        assert!(!cfg.highlight_trailing_whitespace);
+        assert!(!cfg.warn_mixed_indent);
+        assert!(!cfg.auto_pair);
+        assert!(cfg.restore_session);
+        assert!(cfg.persistent_undo);
     }
 
     #[test]

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -24,6 +24,35 @@ impl GitGutter {
     pub fn get(&self, line: usize) -> Option<GutterMark> {
         self.marks.get(&line).copied()
     }
+
+    /// Group the per-line marks into contiguous hunks of non-`Unchanged`
+    /// lines, sorted ascending by start line. A `Deleted` mark joins the
+    /// hunk of the line it sits on (or starts a new one if isolated).
+    pub fn hunks(&self) -> Vec<Hunk> {
+        let mut lines: Vec<usize> = self.marks.keys().copied().collect();
+        lines.sort_unstable();
+        let mut out: Vec<Hunk> = Vec::new();
+        for line in lines {
+            match out.last_mut() {
+                Some(last) if line == last.end_line + 1 || line == last.end_line => {
+                    last.end_line = line;
+                }
+                _ => out.push(Hunk {
+                    start_line: line,
+                    end_line: line,
+                }),
+            }
+        }
+        out
+    }
+}
+
+/// A contiguous run of changed lines (`Added` / `Modified` / `Deleted`).
+/// Both `start_line` and `end_line` are 0-based and inclusive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Hunk {
+    pub start_line: usize,
+    pub end_line: usize,
 }
 
 // ── Pure diff ────────────────────────────────────────────────────────────────
@@ -121,6 +150,91 @@ fn diff_ops<'a>(original: &[&'a str], current: &[&'a str], dp: &[Vec<usize>]) ->
     }
     ops.reverse();
     ops
+}
+
+/// Given the HEAD and current line vectors, plus a hunk's [start, end] range
+/// in the current buffer, return the corresponding inclusive [head_start,
+/// head_end] line range in HEAD. When the hunk is purely additive in the
+/// current buffer (no HEAD counterpart), returns `(head_pos, head_pos - 1)`
+/// — a malformed range the caller can detect with `head_start > head_end`.
+pub fn head_range_for_hunk(
+    head_lines: &[&str],
+    current_lines: &[&str],
+    hunk_start: usize,
+    hunk_end: usize,
+) -> (usize, usize) {
+    let lcs = lcs_length(head_lines, current_lines);
+    let ops = diff_ops(head_lines, current_lines, &lcs);
+
+    let mut head_i = 0usize;
+    let mut cur_i = 0usize;
+    let mut head_start: Option<usize> = None;
+    let mut head_end: usize = 0;
+    let mut found_any = false;
+
+    for op in &ops {
+        let in_hunk = cur_i >= hunk_start && cur_i <= hunk_end;
+        match op {
+            DiffOp::Equal => {
+                head_i += 1;
+                cur_i += 1;
+            }
+            DiffOp::Insert => {
+                // line only exists in current; no head contribution
+                cur_i += 1;
+            }
+            DiffOp::Delete => {
+                if in_hunk {
+                    if head_start.is_none() {
+                        head_start = Some(head_i);
+                    }
+                    head_end = head_i;
+                    found_any = true;
+                }
+                head_i += 1;
+            }
+        }
+    }
+    // Also catch the case where the hunk is Modified — a modified line is
+    // recorded as Insert+Delete in `ops`; if the insert came before the
+    // delete we may have advanced past the hunk by the time we see the
+    // delete. Walk again recording deletes whose preceding head_i sits at
+    // the same effective position as the hunk's first current line.
+    if !found_any {
+        // Try a coarse fallback: map each current line to its head index via
+        // the LCS alignment, returning the contiguous head range covered by
+        // the hunk's body.
+        let mut head_i = 0usize;
+        let mut cur_i = 0usize;
+        let mut span: Option<(usize, usize)> = None;
+        for op in &ops {
+            let in_hunk = cur_i >= hunk_start && cur_i <= hunk_end;
+            match op {
+                DiffOp::Equal => {
+                    head_i += 1;
+                    cur_i += 1;
+                }
+                DiffOp::Insert => {
+                    if in_hunk {
+                        span = Some(match span {
+                            Some((s, _)) => (s, head_i.saturating_sub(1)),
+                            None => (head_i, head_i.saturating_sub(1)),
+                        });
+                    }
+                    cur_i += 1;
+                }
+                DiffOp::Delete => {
+                    head_i += 1;
+                }
+            }
+        }
+        if let Some((s, e)) = span {
+            return (s, e);
+        }
+        return (head_i, head_i.saturating_sub(1));
+    }
+
+    (head_start.unwrap_or(0), head_end)
 }
 
 // ── Git I/O ──────────────────────────────────────────────────────────────────
@@ -264,5 +378,34 @@ mod tests {
         let m = GutterMark::Added;
         let m2 = m;
         assert_eq!(m, m2);
+    }
+
+    #[test]
+    fn hunks_groups_adjacent_marks() {
+        let mut marks = HashMap::new();
+        marks.insert(2, GutterMark::Modified);
+        marks.insert(3, GutterMark::Added);
+        marks.insert(7, GutterMark::Modified);
+        let gutter = GitGutter { marks };
+        let hunks = gutter.hunks();
+        assert_eq!(
+            hunks,
+            vec![
+                Hunk {
+                    start_line: 2,
+                    end_line: 3
+                },
+                Hunk {
+                    start_line: 7,
+                    end_line: 7
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn hunks_for_empty_gutter() {
+        let gutter = GitGutter::default();
+        assert!(gutter.hunks().is_empty());
     }
 }

--- a/src/input/action.rs
+++ b/src/input/action.rs
@@ -270,6 +270,8 @@ pub enum EditorAction {
     OpenLspConfig,
     /// Open the git operations dialog (Ctrl+Shift+G).
     OpenGitDialog,
+    /// Open the clipboard-ring picker overlay (Ctrl+Shift+V).
+    OpenClipboardRing,
 
     // ── LSP features ─────────────────────────────────────────────────
     /// Trigger code completion (Ctrl+Space).
@@ -450,6 +452,7 @@ pub fn action_to_name(action: &EditorAction) -> Option<&'static str> {
         EditorAction::OpenBufferSwitcher => "open_buffer_switcher",
         EditorAction::OpenLspConfig => "open_lsp_config",
         EditorAction::OpenGitDialog => "open_git_dialog",
+        EditorAction::OpenClipboardRing => "open_clipboard_ring",
         // LSP features
         EditorAction::TriggerCompletion => "trigger_completion",
         EditorAction::ShowHover => "show_hover",
@@ -604,6 +607,7 @@ pub fn action_from_name(name: &str) -> Option<EditorAction> {
         "open_buffer_switcher" => EditorAction::OpenBufferSwitcher,
         "open_lsp_config" => EditorAction::OpenLspConfig,
         "open_git_dialog" => EditorAction::OpenGitDialog,
+        "open_clipboard_ring" => EditorAction::OpenClipboardRing,
         // LSP features
         "trigger_completion" => EditorAction::TriggerCompletion,
         "show_hover" => EditorAction::ShowHover,

--- a/src/input/action.rs
+++ b/src/input/action.rs
@@ -247,6 +247,13 @@ pub enum EditorAction {
     /// Open a small float showing the HEAD content for the hunk under the
     /// cursor (Alt+H).
     PeekHeadAtCursor,
+    /// Open the quickfix / location list overlay (Alt+1). Lists every LSP
+    /// diagnostic across the workspace.
+    OpenQuickfix,
+    /// Step to the next quickfix entry and jump to it (F8).
+    QuickfixNext,
+    /// Step to the previous quickfix entry and jump to it (Shift+F8).
+    QuickfixPrev,
     /// Toggle the file tree sidebar visibility (Ctrl+Shift+B).
     ToggleSidebar,
     /// Focus-jump between the editor and the sidebar (Ctrl+B).
@@ -453,6 +460,9 @@ pub fn action_to_name(action: &EditorAction) -> Option<&'static str> {
         EditorAction::PrevHunk => "prev_hunk",
         EditorAction::RevertHunkAtCursor => "revert_hunk",
         EditorAction::PeekHeadAtCursor => "peek_head",
+        EditorAction::OpenQuickfix => "open_quickfix",
+        EditorAction::QuickfixNext => "quickfix_next",
+        EditorAction::QuickfixPrev => "quickfix_prev",
         EditorAction::ToggleSidebar => "toggle_sidebar",
         EditorAction::FocusSidebar => "focus_sidebar",
         // View / UI toggles
@@ -613,6 +623,9 @@ pub fn action_from_name(name: &str) -> Option<EditorAction> {
         "prev_hunk" => EditorAction::PrevHunk,
         "revert_hunk" => EditorAction::RevertHunkAtCursor,
         "peek_head" => EditorAction::PeekHeadAtCursor,
+        "open_quickfix" => EditorAction::OpenQuickfix,
+        "quickfix_next" => EditorAction::QuickfixNext,
+        "quickfix_prev" => EditorAction::QuickfixPrev,
         "toggle_sidebar" => EditorAction::ToggleSidebar,
         "focus_sidebar" => EditorAction::FocusSidebar,
         // View / UI toggles

--- a/src/input/action.rs
+++ b/src/input/action.rs
@@ -238,6 +238,15 @@ pub enum EditorAction {
     /// and wraps the current selection (or word under cursor when no
     /// selection is active). Bound to Alt+' by default.
     BeginSurround,
+    /// Jump the cursor to the next git diff hunk (Alt+]).
+    NextHunk,
+    /// Jump the cursor to the previous git diff hunk (Alt+[).
+    PrevHunk,
+    /// Revert the hunk under the cursor to its HEAD content (Ctrl+Shift+U).
+    RevertHunkAtCursor,
+    /// Open a small float showing the HEAD content for the hunk under the
+    /// cursor (Alt+H).
+    PeekHeadAtCursor,
     /// Toggle the file tree sidebar visibility (Ctrl+Shift+B).
     ToggleSidebar,
     /// Focus-jump between the editor and the sidebar (Ctrl+B).
@@ -440,6 +449,10 @@ pub fn action_to_name(action: &EditorAction) -> Option<&'static str> {
         EditorAction::StopRecordMacro => "stop_recording_macro",
         EditorAction::BeginReplayMacro => "replay_macro",
         EditorAction::BeginSurround => "surround",
+        EditorAction::NextHunk => "next_hunk",
+        EditorAction::PrevHunk => "prev_hunk",
+        EditorAction::RevertHunkAtCursor => "revert_hunk",
+        EditorAction::PeekHeadAtCursor => "peek_head",
         EditorAction::ToggleSidebar => "toggle_sidebar",
         EditorAction::FocusSidebar => "focus_sidebar",
         // View / UI toggles
@@ -596,6 +609,10 @@ pub fn action_from_name(name: &str) -> Option<EditorAction> {
         "stop_recording_macro" => EditorAction::StopRecordMacro,
         "replay_macro" => EditorAction::BeginReplayMacro,
         "surround" => EditorAction::BeginSurround,
+        "next_hunk" => EditorAction::NextHunk,
+        "prev_hunk" => EditorAction::PrevHunk,
+        "revert_hunk" => EditorAction::RevertHunkAtCursor,
+        "peek_head" => EditorAction::PeekHeadAtCursor,
         "toggle_sidebar" => EditorAction::ToggleSidebar,
         "focus_sidebar" => EditorAction::FocusSidebar,
         // View / UI toggles

--- a/src/input/action.rs
+++ b/src/input/action.rs
@@ -234,6 +234,10 @@ pub enum EditorAction {
     StopRecordMacro,
     /// Begin a replay prompt; the next typed char (a–z) selects the slot.
     BeginReplayMacro,
+    /// Begin a surround prompt; the next typed char picks the delimiter pair
+    /// and wraps the current selection (or word under cursor when no
+    /// selection is active). Bound to Alt+' by default.
+    BeginSurround,
     /// Toggle the file tree sidebar visibility (Ctrl+Shift+B).
     ToggleSidebar,
     /// Focus-jump between the editor and the sidebar (Ctrl+B).
@@ -435,6 +439,7 @@ pub fn action_to_name(action: &EditorAction) -> Option<&'static str> {
         EditorAction::BeginRecordMacro => "record_macro",
         EditorAction::StopRecordMacro => "stop_recording_macro",
         EditorAction::BeginReplayMacro => "replay_macro",
+        EditorAction::BeginSurround => "surround",
         EditorAction::ToggleSidebar => "toggle_sidebar",
         EditorAction::FocusSidebar => "focus_sidebar",
         // View / UI toggles
@@ -590,6 +595,7 @@ pub fn action_from_name(name: &str) -> Option<EditorAction> {
         "record_macro" => EditorAction::BeginRecordMacro,
         "stop_recording_macro" => EditorAction::StopRecordMacro,
         "replay_macro" => EditorAction::BeginReplayMacro,
+        "surround" => EditorAction::BeginSurround,
         "toggle_sidebar" => EditorAction::ToggleSidebar,
         "focus_sidebar" => EditorAction::FocusSidebar,
         // View / UI toggles

--- a/src/input/keybinding.rs
+++ b/src/input/keybinding.rs
@@ -525,6 +525,7 @@ impl KeyBindings {
         bind("ctrl+shift+g", EditorAction::OpenGitDialog);
         bind("ctrl+shift+f", EditorAction::OpenProjectSearch);
         bind("ctrl+shift+v", EditorAction::OpenClipboardRing);
+        bind("alt+'", EditorAction::BeginSurround);
 
         // ── Box / column selection ────────────────────────────────────
         bind(

--- a/src/input/keybinding.rs
+++ b/src/input/keybinding.rs
@@ -530,6 +530,9 @@ impl KeyBindings {
         bind("alt+[", EditorAction::PrevHunk);
         bind("ctrl+shift+u", EditorAction::RevertHunkAtCursor);
         bind("alt+h", EditorAction::PeekHeadAtCursor);
+        bind("alt+1", EditorAction::OpenQuickfix);
+        bind("f8", EditorAction::QuickfixNext);
+        bind("shift+f8", EditorAction::QuickfixPrev);
 
         // ── Box / column selection ────────────────────────────────────
         bind(

--- a/src/input/keybinding.rs
+++ b/src/input/keybinding.rs
@@ -526,6 +526,10 @@ impl KeyBindings {
         bind("ctrl+shift+f", EditorAction::OpenProjectSearch);
         bind("ctrl+shift+v", EditorAction::OpenClipboardRing);
         bind("alt+'", EditorAction::BeginSurround);
+        bind("alt+]", EditorAction::NextHunk);
+        bind("alt+[", EditorAction::PrevHunk);
+        bind("ctrl+shift+u", EditorAction::RevertHunkAtCursor);
+        bind("alt+h", EditorAction::PeekHeadAtCursor);
 
         // ── Box / column selection ────────────────────────────────────
         bind(

--- a/src/input/keybinding.rs
+++ b/src/input/keybinding.rs
@@ -524,6 +524,7 @@ impl KeyBindings {
         bind("ctrl+shift+i", EditorAction::FormatBuffer);
         bind("ctrl+shift+g", EditorAction::OpenGitDialog);
         bind("ctrl+shift+f", EditorAction::OpenProjectSearch);
+        bind("ctrl+shift+v", EditorAction::OpenClipboardRing);
 
         // ── Box / column selection ────────────────────────────────────
         bind(

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod input;
 mod lsp;
 mod macros;
 mod marks;
+mod quickfix;
 mod search;
 mod snippet;
 mod syntax;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod macros;
 mod marks;
 mod quickfix;
 mod search;
+mod session;
 mod snippet;
 mod syntax;
 mod theme;
@@ -61,6 +62,7 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
+    let positional_was_file = matches!(&cli.path, Some(p) if !p.is_dir());
     let (editor, open_sidebar) = match cli.path {
         Some(p) if p.is_dir() => {
             std::env::set_current_dir(&p)?;
@@ -71,6 +73,20 @@ fn main() -> Result<()> {
     };
     let workspace = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
 
+    // Attempt session restore only when the user did not name a specific
+    // file on the command line. Loading a session over the top of an
+    // explicit `txt foo.rs` would be surprising.
+    let pending_session: Option<crate::session::Session> = if positional_was_file {
+        None
+    } else {
+        let cfg = config::Config::load();
+        if cfg.restore_session {
+            session::Session::load(&workspace)
+        } else {
+            None
+        }
+    };
+
     // Install a panic hook that restores the terminal before printing the panic.
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
@@ -79,7 +95,7 @@ fn main() -> Result<()> {
     }));
 
     let terminal = init_terminal()?;
-    let result = App::new().run(terminal, editor, open_sidebar, workspace);
+    let result = App::new().run(terminal, editor, open_sidebar, workspace, pending_session);
     restore_terminal()?;
 
     if let Err(e) = result {

--- a/src/quickfix/mod.rs
+++ b/src/quickfix/mod.rs
@@ -1,0 +1,131 @@
+//! Quickfix / location list — a workspace-level view over per-buffer LSP
+//! diagnostics. The list is rebuilt on demand each time the user opens the
+//! overlay so it always reflects the current diagnostic snapshots.
+//!
+//! Per the implementation plan, only LSP diagnostics are surfaced for now;
+//! project-search results and external-command output are out of scope and
+//! will be wired through the same list in a later release.
+
+use std::path::PathBuf;
+
+use crate::editor::Editor;
+use crate::lsp::types::DiagSeverity;
+
+/// A single entry in the quickfix list.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QuickfixEntry {
+    pub path: PathBuf,
+    /// 0-based line number.
+    pub line: usize,
+    /// 0-based column (byte offset from line start).
+    pub col: usize,
+    pub message: String,
+    pub severity: DiagSeverity,
+}
+
+/// State for the quickfix list overlay (Alt+1).
+#[derive(Debug, Default)]
+pub struct QuickfixState {
+    pub entries: Vec<QuickfixEntry>,
+    pub selected: usize,
+}
+
+impl QuickfixState {
+    pub fn new(entries: Vec<QuickfixEntry>) -> Self {
+        Self {
+            entries,
+            selected: 0,
+        }
+    }
+}
+
+/// Walk every open tab and collect each buffer's LSP diagnostics into a
+/// single flat list. Sorted by (severity, path, line) so errors float to the
+/// top. Buffers without a saved path are skipped — there's no useful jump
+/// target.
+pub fn collect_lsp_diagnostics(editor: &Editor) -> Vec<QuickfixEntry> {
+    let mut out = Vec::new();
+    for tab in &editor.tabs {
+        let Some(path) = &tab.path else {
+            continue;
+        };
+        for diag in &tab.lsp_state.diagnostics {
+            let byte = diag.range.start;
+            let rope = tab.buffer.rope();
+            let char_idx = rope.byte_to_char(byte.min(rope.len_bytes()));
+            let line = rope.char_to_line(char_idx);
+            let line_start_char = rope.line_to_char(line);
+            let col = char_idx.saturating_sub(line_start_char);
+            out.push(QuickfixEntry {
+                path: path.clone(),
+                line,
+                col,
+                message: diag.message.clone(),
+                severity: diag.severity,
+            });
+        }
+    }
+    out.sort_by(|a, b| {
+        a.severity
+            .cmp(&b.severity)
+            .then_with(|| a.path.cmp(&b.path))
+            .then_with(|| a.line.cmp(&b.line))
+    });
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::buffer::cursor::ByteRange;
+    use crate::editor::tab::BufferHandle;
+    use crate::lsp::types::LspDiagnostic;
+
+    fn make_tab(id: usize, path: Option<&str>, content: &str) -> BufferHandle {
+        let mut h = BufferHandle::new_empty(id);
+        h.buffer.insert_str(content);
+        h.path = path.map(PathBuf::from);
+        h
+    }
+
+    #[test]
+    fn collect_is_sorted_by_severity_then_path() {
+        let mut ed = Editor::new();
+        ed.tabs.clear();
+        let mut t1 = make_tab(0, Some("b.rs"), "fn b() {}\n");
+        t1.lsp_state.diagnostics = vec![LspDiagnostic {
+            range: ByteRange::new(0, 0),
+            severity: DiagSeverity::Warning,
+            message: "warn-b".into(),
+            source: None,
+        }];
+        let mut t2 = make_tab(1, Some("a.rs"), "fn a() {}\n");
+        t2.lsp_state.diagnostics = vec![LspDiagnostic {
+            range: ByteRange::new(0, 0),
+            severity: DiagSeverity::Error,
+            message: "err-a".into(),
+            source: None,
+        }];
+        ed.tabs.push(t1);
+        ed.tabs.push(t2);
+        let entries = collect_lsp_diagnostics(&ed);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].message, "err-a");
+        assert_eq!(entries[1].message, "warn-b");
+    }
+
+    #[test]
+    fn collect_skips_unsaved_tabs() {
+        let mut ed = Editor::new();
+        ed.tabs.clear();
+        let mut h = make_tab(0, None, "x\n");
+        h.lsp_state.diagnostics = vec![LspDiagnostic {
+            range: ByteRange::new(0, 0),
+            severity: DiagSeverity::Error,
+            message: "ignored".into(),
+            source: None,
+        }];
+        ed.tabs.push(h);
+        assert!(collect_lsp_diagnostics(&ed).is_empty());
+    }
+}

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1,0 +1,97 @@
+//! Per-workspace session persistence.
+//!
+//! When `restore_session = true` is set in `~/.config/txt/config.toml`,
+//! every clean shutdown writes the list of open tabs (with cursor positions
+//! and viewport scroll) to `<workspace>/.txt/session.json`. The next time
+//! `txt` is launched in the same workspace *without* a positional file
+//! argument, the saved tabs are reopened.
+//!
+//! The format is JSON via `serde_json` to match the existing workspace-local
+//! files (`recents.json`, `marks.json`, `jumps.json`). Files that no longer
+//! exist on disk are silently skipped at load time so a renamed/moved file
+//! never breaks startup.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// A snapshot of one open tab.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TabState {
+    pub path: PathBuf,
+    /// Primary cursor byte offset. Clamped to the file's byte length on
+    /// load — a file may have shrunk since the session was saved.
+    pub cursor_byte: usize,
+    /// Viewport top line.
+    pub viewport_top: usize,
+}
+
+/// A snapshot of the editor at quit time.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct Session {
+    pub tabs: Vec<TabState>,
+    pub active: usize,
+    pub sidebar_open: bool,
+}
+
+impl Session {
+    /// Path to the session file inside `workspace`.
+    fn path_for(workspace: &Path) -> PathBuf {
+        workspace.join(".txt").join("session.json")
+    }
+
+    /// Load the session for `workspace`. Returns `None` when the file is
+    /// missing or unparseable.
+    pub fn load(workspace: &Path) -> Option<Self> {
+        let p = Self::path_for(workspace);
+        let text = std::fs::read_to_string(&p).ok()?;
+        serde_json::from_str(&text).ok()
+    }
+
+    /// Persist `self` to `<workspace>/.txt/session.json`. Silently ignores
+    /// I/O errors.
+    pub fn save(&self, workspace: &Path) {
+        let p = Self::path_for(workspace);
+        if let Some(parent) = p.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        if let Ok(json) = serde_json::to_string_pretty(self) {
+            let _ = std::fs::write(&p, json);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_round_trips_through_disk() {
+        let tmp = tempfile::tempdir().unwrap();
+        let s = Session {
+            tabs: vec![
+                TabState {
+                    path: PathBuf::from("foo.rs"),
+                    cursor_byte: 42,
+                    viewport_top: 7,
+                },
+                TabState {
+                    path: PathBuf::from("bar.rs"),
+                    cursor_byte: 0,
+                    viewport_top: 0,
+                },
+            ],
+            active: 1,
+            sidebar_open: true,
+        };
+        s.save(tmp.path());
+        let loaded = Session::load(tmp.path()).expect("load");
+        assert_eq!(loaded, s);
+    }
+
+    #[test]
+    fn missing_session_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(Session::load(tmp.path()).is_none());
+    }
+}

--- a/src/ui/clipboard_ring.rs
+++ b/src/ui/clipboard_ring.rs
@@ -1,0 +1,176 @@
+//! `Ctrl+Shift+V` overlay: list the recent clipboard entries (most-recent
+//! first), Enter pastes the highlighted entry. Shares the visual chrome of
+//! `references_list.rs` deliberately so the editor's overlay family stays
+//! consistent.
+
+use ratatui::{
+    buffer::Buffer as TermBuffer,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+};
+
+use crate::app::ClipboardRingState;
+
+const MAX_VISIBLE: usize = 15;
+
+/// Render the clipboard-ring overlay centered in `area`.
+pub fn render(ring: &ClipboardRingState, area: Rect, buf: &mut TermBuffer) {
+    if area.width < 10 || area.height < 6 {
+        return;
+    }
+
+    let num_items = ring.entries.len();
+    let visible = num_items.min(MAX_VISIBLE);
+    let popup_h = (visible as u16 + 4).min(area.height);
+    let popup_w = (area.width * 2 / 3).max(40).min(area.width);
+    let ox = area.x + area.width.saturating_sub(popup_w) / 2;
+    let oy = area.y + area.height.saturating_sub(popup_h) / 2;
+    let popup = Rect::new(ox, oy, popup_w, popup_h);
+
+    let bg = Color::Rgb(18, 22, 40);
+    let border_style = Style::default().bg(bg).fg(Color::Rgb(80, 100, 160));
+    let header_style = Style::default()
+        .bg(bg)
+        .fg(Color::Rgb(200, 200, 255))
+        .add_modifier(Modifier::BOLD);
+    let selected_bg = Color::Rgb(40, 55, 110);
+    let idx_style = Style::default().bg(bg).fg(Color::Rgb(140, 160, 220));
+    let body_style = Style::default().bg(bg).fg(Color::Rgb(220, 220, 230));
+    let dim_style = Style::default().bg(bg).fg(Color::Rgb(120, 130, 160));
+    let hint_style = Style::default().bg(bg).fg(Color::Rgb(100, 110, 150));
+
+    // Background.
+    for y in popup.y..popup.y + popup.height {
+        for x in popup.x..popup.x + popup.width {
+            buf.set_string(x, y, " ", Style::default().bg(bg));
+        }
+    }
+
+    draw_border(buf, popup, border_style);
+
+    let header = format!(" Clipboard ring ({}) ", num_items);
+    let hx = popup.x + popup.width.saturating_sub(header.len() as u16) / 2;
+    buf.set_string(hx, popup.y, &header, header_style);
+
+    draw_h_separator(buf, popup, popup.y + 2, border_style);
+
+    let scroll = if ring.selected >= MAX_VISIBLE {
+        ring.selected - MAX_VISIBLE + 1
+    } else {
+        0
+    };
+
+    let inner_w = popup.width.saturating_sub(2) as usize;
+
+    for (i, entry) in ring.entries.iter().skip(scroll).take(visible).enumerate() {
+        let y = popup.y + 3 + i as u16;
+        if y >= popup.y + popup.height - 1 {
+            break;
+        }
+        let is_selected = scroll + i == ring.selected;
+        let row_bg = if is_selected { selected_bg } else { bg };
+
+        for x in popup.x + 1..popup.x + popup.width - 1 {
+            buf.set_string(x, y, " ", Style::default().bg(row_bg));
+        }
+
+        let idx_label = format!(" {:>2}  ", scroll + i + 1);
+        buf.set_string(popup.x + 1, y, &idx_label, idx_style.bg(row_bg));
+
+        // Show the first line, collapsing tabs/newlines so the preview is
+        // single-row friendly. Trailing dots indicate truncation.
+        let preview = first_line_preview(entry, inner_w.saturating_sub(idx_label.len() + 1));
+        let preview_style = body_style.bg(row_bg);
+        buf.set_string(
+            popup.x + 1 + idx_label.len() as u16,
+            y,
+            &preview,
+            preview_style,
+        );
+
+        if entry.contains('\n') {
+            let suffix = " ⏎";
+            let sx = popup.x + popup.width - 1 - suffix.len() as u16;
+            buf.set_string(sx, y, suffix, dim_style.bg(row_bg));
+        }
+    }
+
+    let hint_y = popup.y + popup.height - 1;
+    let hint = " Enter: paste  ↑↓: select  Esc: close ";
+    let hint_x = popup.x + popup.width.saturating_sub(hint.len() as u16) / 2;
+    buf.set_string(hint_x, hint_y, hint, hint_style);
+}
+
+/// First-line preview, truncated to `max_w` display columns. Tabs become
+/// spaces; trailing whitespace is trimmed. Adds `…` when truncated.
+fn first_line_preview(text: &str, max_w: usize) -> String {
+    let line = text.lines().next().unwrap_or("");
+    let line = line.replace('\t', "    ");
+    let trimmed = line.trim_end_matches([' ']);
+    if max_w == 0 {
+        return String::new();
+    }
+    let mut out = String::new();
+    for (count, ch) in trimmed.chars().enumerate() {
+        if count + 1 >= max_w {
+            out.push('…');
+            break;
+        }
+        out.push(ch);
+    }
+    out
+}
+
+fn draw_border(buf: &mut TermBuffer, area: Rect, style: Style) {
+    if area.width < 2 || area.height < 2 {
+        return;
+    }
+    let (x0, y0) = (area.x, area.y);
+    let (x1, y1) = (area.x + area.width - 1, area.y + area.height - 1);
+    buf.set_string(x0, y0, "╭", style);
+    buf.set_string(x1, y0, "╮", style);
+    buf.set_string(x0, y1, "╰", style);
+    buf.set_string(x1, y1, "╯", style);
+    for x in x0 + 1..x1 {
+        buf.set_string(x, y0, "─", style);
+        buf.set_string(x, y1, "─", style);
+    }
+    for y in y0 + 1..y1 {
+        buf.set_string(x0, y, "│", style);
+        buf.set_string(x1, y, "│", style);
+    }
+}
+
+fn draw_h_separator(buf: &mut TermBuffer, area: Rect, y: u16, style: Style) {
+    if area.width < 2 {
+        return;
+    }
+    buf.set_string(area.x, y, "├", style);
+    buf.set_string(area.x + area.width - 1, y, "┤", style);
+    for x in area.x + 1..area.x + area.width - 1 {
+        buf.set_string(x, y, "─", style);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::first_line_preview;
+
+    #[test]
+    fn preview_truncates_with_ellipsis() {
+        let p = first_line_preview("hello world", 5);
+        assert_eq!(p, "hell…");
+    }
+
+    #[test]
+    fn preview_takes_first_line_only() {
+        let p = first_line_preview("first\nsecond", 80);
+        assert_eq!(p, "first");
+    }
+
+    #[test]
+    fn preview_replaces_tabs_with_spaces() {
+        let p = first_line_preview("a\tb", 80);
+        assert_eq!(p, "a    b");
+    }
+}

--- a/src/ui/diff_peek.rs
+++ b/src/ui/diff_peek.rs
@@ -1,0 +1,80 @@
+//! Inline diff-peek float: small overlay showing the HEAD version of the
+//! hunk at the cursor. Anchored near the cursor's screen row.
+
+use ratatui::{
+    buffer::Buffer as TermBuffer,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+};
+
+use crate::app::DiffPeekState;
+
+const MAX_VISIBLE: usize = 10;
+
+pub fn render(peek: &DiffPeekState, area: Rect, buf: &mut TermBuffer) {
+    if area.width < 12 || area.height < 4 {
+        return;
+    }
+    let visible = peek.head_lines.len().min(MAX_VISIBLE);
+    let popup_h = (visible as u16 + 3).min(area.height);
+    let popup_w = (area.width * 2 / 3).max(40).min(area.width);
+    let ox = area.x + area.width.saturating_sub(popup_w) / 2;
+    // Anchor below the cursor row when possible, otherwise centre.
+    let oy = area.y + area.height.saturating_sub(popup_h) / 2;
+    let popup = Rect::new(ox, oy, popup_w, popup_h);
+
+    let bg = Color::Rgb(15, 25, 30);
+    let border_style = Style::default().bg(bg).fg(Color::Rgb(80, 140, 110));
+    let header_style = Style::default()
+        .bg(bg)
+        .fg(Color::Rgb(200, 220, 200))
+        .add_modifier(Modifier::BOLD);
+    let body_style = Style::default().bg(bg).fg(Color::Rgb(220, 220, 220));
+    let hint_style = Style::default().bg(bg).fg(Color::Rgb(110, 130, 110));
+
+    for y in popup.y..popup.y + popup.height {
+        for x in popup.x..popup.x + popup.width {
+            buf.set_string(x, y, " ", Style::default().bg(bg));
+        }
+    }
+    draw_border(buf, popup, border_style);
+
+    let header = " HEAD (peek) ";
+    let hx = popup.x + popup.width.saturating_sub(header.len() as u16) / 2;
+    buf.set_string(hx, popup.y, header, header_style);
+
+    let inner_w = popup.width.saturating_sub(2) as usize;
+    for (i, line) in peek.head_lines.iter().take(visible).enumerate() {
+        let y = popup.y + 1 + i as u16;
+        if y >= popup.y + popup.height - 1 {
+            break;
+        }
+        let preview: String = line.chars().take(inner_w.saturating_sub(2)).collect();
+        buf.set_string(popup.x + 2, y, &preview, body_style);
+    }
+
+    let hint_y = popup.y + popup.height - 1;
+    let hint = " Alt+H toggles ";
+    let hint_x = popup.x + popup.width.saturating_sub(hint.len() as u16) / 2;
+    buf.set_string(hint_x, hint_y, hint, hint_style);
+}
+
+fn draw_border(buf: &mut TermBuffer, area: Rect, style: Style) {
+    if area.width < 2 || area.height < 2 {
+        return;
+    }
+    let (x0, y0) = (area.x, area.y);
+    let (x1, y1) = (area.x + area.width - 1, area.y + area.height - 1);
+    buf.set_string(x0, y0, "╭", style);
+    buf.set_string(x1, y0, "╮", style);
+    buf.set_string(x0, y1, "╰", style);
+    buf.set_string(x1, y1, "╯", style);
+    for x in x0 + 1..x1 {
+        buf.set_string(x, y0, "─", style);
+        buf.set_string(x, y1, "─", style);
+    }
+    for y in y0 + 1..y1 {
+        buf.set_string(x0, y, "│", style);
+        buf.set_string(x1, y, "│", style);
+    }
+}

--- a/src/ui/editor_view.rs
+++ b/src/ui/editor_view.rs
@@ -44,6 +44,7 @@ pub fn render(
     tab_size: usize,
     indent_guides: bool,
     rulers: &[usize],
+    highlight_trailing_ws: bool,
     theme: &ThemeColors,
     area: Rect,
     buf: &mut TermBuffer,
@@ -451,6 +452,78 @@ pub fn render(
                 let x = text_area.x + ruler as u16;
                 if x < max_x {
                     overlay_guide(buf, x, y, "│", guide_style);
+                }
+            }
+        }
+    }
+
+    // ── Trailing-whitespace highlight (post-pass overlay) ─────────────────
+    // Paint a subtle red background on cells that hold a trailing space or
+    // tab in the *logical* line. Skipped if the line is the cursor's current
+    // line (so editing midway through a line doesn't strobe red while the
+    // user is typing). Also skips lines that are entirely whitespace —
+    // legitimate blank lines in source files.
+    if highlight_trailing_ws && text_area.width > 0 {
+        let tws_style = Style::default().bg(Color::Rgb(110, 30, 30));
+        let max_x = text_area.x + text_area.width;
+        let cursor_line = handle.buffer.cursors.primary().line;
+        for (screen_row, vl) in visual_lines.iter().enumerate() {
+            if vl.line_idx == cursor_line {
+                continue;
+            }
+            let line_str = handle.buffer.line_str(vl.line_idx);
+            if line_str.is_empty() {
+                continue;
+            }
+            // Find byte offset of last non-whitespace char. If all whitespace,
+            // skip — that's a blank line, not a trailing-ws violation.
+            let trimmed_end = line_str.trim_end_matches([' ', '\t']);
+            if trimmed_end.is_empty() || trimmed_end.len() == line_str.len() {
+                continue;
+            }
+            let trail_start_byte = trimmed_end.len();
+            // Convert byte offset within the displayed segment to display
+            // column. Trailing-ws lives at the end so it should appear in
+            // the last visual segment of the line.
+            let display_start_byte = vl.seg_byte;
+            if trail_start_byte < display_start_byte {
+                // Trailing-ws was before the start of this segment (shouldn't
+                // happen given the line was non-empty), bail.
+                continue;
+            }
+            // Walk the visible display until we reach trail_start_byte.
+            let mut col_x = text_area.x;
+            let mut byte = display_start_byte;
+            for grapheme in line_str_graphemes(&vl.display) {
+                if byte >= trail_start_byte {
+                    break;
+                }
+                let gw_g = UnicodeWidthStr::width(grapheme) as u16;
+                if grapheme == "\t" {
+                    let col = (col_x - text_area.x) as usize;
+                    let tab_w = (tab_size - (col % tab_size)).max(1) as u16;
+                    col_x = (col_x + tab_w).min(max_x);
+                } else {
+                    col_x += gw_g.max(1);
+                }
+                byte += grapheme.len();
+            }
+            // Fill from col_x to end of segment with the trailing-ws style,
+            // but only across cells whose symbol is still a plain space (so
+            // we don't clobber cursors or selections).
+            for x in col_x..max_x {
+                let y = area.y + screen_row as u16;
+                let pos = ratatui::layout::Position::new(x, y);
+                if let Some(cell) = buf.cell(pos) {
+                    let sym = cell.symbol();
+                    if sym == " " || sym.is_empty() {
+                        buf.set_string(x, y, " ", tws_style);
+                    } else if sym == "·" {
+                        // show_whitespace already drew middle-dots; tint them red too.
+                        buf.set_string(x, y, "·", tws_style.fg(Color::Rgb(220, 180, 180)));
+                    } else if sym == "→" {
+                        buf.set_string(x, y, "→", tws_style.fg(Color::Rgb(220, 180, 180)));
+                    }
                 }
             }
         }

--- a/src/ui/help_overlay.rs
+++ b/src/ui/help_overlay.rs
@@ -524,6 +524,25 @@ fn format_key_display(s: &str) -> String {
         .join("+")
 }
 
+/// Truncate `s` to at most `max_width` terminal columns, respecting grapheme
+/// boundaries so the result is always a valid `&str` slice. Cells whose display
+/// width would push the running total past `max_width` are dropped.
+fn truncate_to_width(s: &str, max_width: usize) -> &str {
+    use unicode_segmentation::UnicodeSegmentation;
+    use unicode_width::UnicodeWidthStr;
+    let mut width = 0usize;
+    let mut end = 0usize;
+    for (idx, g) in s.grapheme_indices(true) {
+        let gw = UnicodeWidthStr::width(g);
+        if width + gw > max_width {
+            return &s[..end];
+        }
+        width += gw;
+        end = idx + g.len();
+    }
+    s
+}
+
 /// Join key strings with ` / `, collapsing duplicates.
 fn dedup_and_join(keys: &[String]) -> String {
     let mut seen = Vec::new();
@@ -636,14 +655,14 @@ pub fn render(area: Rect, buf: &mut TermBuffer, scroll: usize, bindings: &KeyBin
         } else {
             // Normal entry: key (fixed width) + space + description.
             let key_str = format!("{:<width$}", key, width = KEY_W);
-            let key_display = &key_str[..key_str.len().min(avail_w)];
+            let key_display = truncate_to_width(&key_str, avail_w);
             buf.set_string(content_x, cy, key_display, key_style);
 
             let desc_x = content_x + KEY_W.min(avail_w) as u16 + 1;
             let desc_avail = (overlay_area.x + overlay_area.width.saturating_sub(1))
                 .saturating_sub(desc_x) as usize;
             if desc_avail > 0 {
-                let desc_display = &desc[..desc.len().min(desc_avail)];
+                let desc_display = truncate_to_width(desc, desc_avail);
                 buf.set_string(desc_x, cy, desc_display, desc_style);
             }
         }
@@ -758,6 +777,30 @@ mod tests {
         assert_eq!(format_key_display("ctrl+shift+s"), "Ctrl+Shift+S");
         assert_eq!(format_key_display("f1"), "F1");
         assert_eq!(format_key_display("alt+z"), "Alt+Z");
+    }
+
+    #[test]
+    fn truncate_to_width_handles_multibyte() {
+        // En-dash is 3 bytes, 1 column. Truncating at a column count that
+        // would land mid-byte must not panic and must return a valid slice.
+        let s = "Set named mark (Ctrl+M then a–z)";
+        for w in 0..=s.chars().count() {
+            let out = truncate_to_width(s, w);
+            assert!(s.starts_with(out));
+        }
+        assert_eq!(truncate_to_width(s, 30), "Set named mark (Ctrl+M then a–");
+        assert_eq!(truncate_to_width(s, 29), "Set named mark (Ctrl+M then a");
+    }
+
+    #[test]
+    fn render_does_not_panic_at_narrow_widths() {
+        // Regression for a panic where the description column was truncated
+        // by byte index, splitting the en-dash in "Ctrl+M then a–z".
+        let bindings = default_bindings();
+        for w in 20..=80 {
+            let (mut buf, area) = make_buf(w, 40);
+            render(area, &mut buf, 0, &bindings);
+        }
     }
 
     #[test]

--- a/src/ui/help_overlay.rs
+++ b/src/ui/help_overlay.rs
@@ -220,6 +220,10 @@ const TEMPLATE: &[HelpEntry] = &[
         actions: &["open_clipboard_ring"],
         desc: "Clipboard ring (recent yanks)",
     },
+    HelpEntry::Binding {
+        actions: &["surround"],
+        desc: "Surround selection with delimiter (next char picks pair)",
+    },
     // ── File & Tabs ──────────────────────────────────────────────────
     HelpEntry::Section("File & Tabs"),
     HelpEntry::Binding {

--- a/src/ui/help_overlay.rs
+++ b/src/ui/help_overlay.rs
@@ -224,6 +224,18 @@ const TEMPLATE: &[HelpEntry] = &[
         actions: &["surround"],
         desc: "Surround selection with delimiter (next char picks pair)",
     },
+    HelpEntry::Binding {
+        actions: &["next_hunk", "prev_hunk"],
+        desc: "Next / Prev git hunk",
+    },
+    HelpEntry::Binding {
+        actions: &["revert_hunk"],
+        desc: "Revert hunk under cursor to HEAD",
+    },
+    HelpEntry::Binding {
+        actions: &["peek_head"],
+        desc: "Peek HEAD content for hunk under cursor",
+    },
     // ── File & Tabs ──────────────────────────────────────────────────
     HelpEntry::Section("File & Tabs"),
     HelpEntry::Binding {

--- a/src/ui/help_overlay.rs
+++ b/src/ui/help_overlay.rs
@@ -190,6 +190,10 @@ const TEMPLATE: &[HelpEntry] = &[
         actions: &["toggle_line_comment"],
         desc: "Toggle line comment",
     },
+    HelpEntry::Binding {
+        actions: &["surround"],
+        desc: "Surround selection with delimiter (next char picks pair)",
+    },
     HelpEntry::Static {
         key: "Tab / Shift+Tab",
         desc: "Indent / dedent selection",
@@ -219,30 +223,6 @@ const TEMPLATE: &[HelpEntry] = &[
     HelpEntry::Binding {
         actions: &["open_clipboard_ring"],
         desc: "Clipboard ring (recent yanks)",
-    },
-    HelpEntry::Binding {
-        actions: &["surround"],
-        desc: "Surround selection with delimiter (next char picks pair)",
-    },
-    HelpEntry::Binding {
-        actions: &["next_hunk", "prev_hunk"],
-        desc: "Next / Prev git hunk",
-    },
-    HelpEntry::Binding {
-        actions: &["revert_hunk"],
-        desc: "Revert hunk under cursor to HEAD",
-    },
-    HelpEntry::Binding {
-        actions: &["peek_head"],
-        desc: "Peek HEAD content for hunk under cursor",
-    },
-    HelpEntry::Binding {
-        actions: &["open_quickfix"],
-        desc: "Quickfix list (workspace LSP diagnostics)",
-    },
-    HelpEntry::Binding {
-        actions: &["quickfix_next", "quickfix_prev"],
-        desc: "Next / Prev quickfix entry",
     },
     // ── File & Tabs ──────────────────────────────────────────────────
     HelpEntry::Section("File & Tabs"),
@@ -408,6 +388,14 @@ const TEMPLATE: &[HelpEntry] = &[
         actions: &["code_action"],
         desc: "Code action / quick fix",
     },
+    HelpEntry::Binding {
+        actions: &["open_quickfix"],
+        desc: "Quickfix list (workspace LSP diagnostics)",
+    },
+    HelpEntry::Binding {
+        actions: &["quickfix_next", "quickfix_prev"],
+        desc: "Next / Prev quickfix entry",
+    },
     // ── Sidebar ──────────────────────────────────────────────────────
     HelpEntry::Section("Sidebar"),
     HelpEntry::Static {
@@ -461,6 +449,18 @@ const TEMPLATE: &[HelpEntry] = &[
     HelpEntry::Binding {
         actions: &["open_git_dialog"],
         desc: "Open git operations dialog",
+    },
+    HelpEntry::Binding {
+        actions: &["next_hunk", "prev_hunk"],
+        desc: "Next / Prev git hunk",
+    },
+    HelpEntry::Binding {
+        actions: &["revert_hunk"],
+        desc: "Revert hunk under cursor to HEAD",
+    },
+    HelpEntry::Binding {
+        actions: &["peek_head"],
+        desc: "Peek HEAD content for hunk under cursor",
     },
     HelpEntry::Static {
         key: "y / n",

--- a/src/ui/help_overlay.rs
+++ b/src/ui/help_overlay.rs
@@ -216,6 +216,10 @@ const TEMPLATE: &[HelpEntry] = &[
         actions: &["copy_file_reference"],
         desc: "Copy file reference",
     },
+    HelpEntry::Binding {
+        actions: &["open_clipboard_ring"],
+        desc: "Clipboard ring (recent yanks)",
+    },
     // ── File & Tabs ──────────────────────────────────────────────────
     HelpEntry::Section("File & Tabs"),
     HelpEntry::Binding {

--- a/src/ui/help_overlay.rs
+++ b/src/ui/help_overlay.rs
@@ -236,6 +236,14 @@ const TEMPLATE: &[HelpEntry] = &[
         actions: &["peek_head"],
         desc: "Peek HEAD content for hunk under cursor",
     },
+    HelpEntry::Binding {
+        actions: &["open_quickfix"],
+        desc: "Quickfix list (workspace LSP diagnostics)",
+    },
+    HelpEntry::Binding {
+        actions: &["quickfix_next", "quickfix_prev"],
+        desc: "Next / Prev quickfix entry",
+    },
     // ── File & Tabs ──────────────────────────────────────────────────
     HelpEntry::Section("File & Tabs"),
     HelpEntry::Binding {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2,6 +2,7 @@ pub mod changelog_overlay;
 pub mod clipboard_ring;
 pub mod command_palette;
 pub mod completion_popup;
+pub mod diff_peek;
 pub mod editor_view;
 pub mod fuzzy_picker;
 pub mod git_dialog;
@@ -363,5 +364,10 @@ pub fn render(state: &mut AppState, frame: &mut Frame) {
     // ── Clipboard-ring overlay ───────────────────────────────────────────────
     if let Some(ring) = &state.clipboard_ring {
         clipboard_ring::render(ring, area, buf);
+    }
+
+    // ── Diff-peek float ──────────────────────────────────────────────────────
+    if let Some(peek) = &state.diff_peek {
+        diff_peek::render(peek, area, buf);
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -224,6 +224,7 @@ pub fn render(state: &mut AppState, frame: &mut Frame) {
         state.config.tab_size,
         state.config.indent_guides,
         &state.config.rulers,
+        state.config.highlight_trailing_whitespace,
         &theme,
         editor_area,
         buf,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,4 +1,5 @@
 pub mod changelog_overlay;
+pub mod clipboard_ring;
 pub mod command_palette;
 pub mod completion_popup;
 pub mod editor_view;
@@ -357,5 +358,10 @@ pub fn render(state: &mut AppState, frame: &mut Frame) {
     // ── References list overlay ──────────────────────────────────────────────
     if let Some(refs) = &state.references_list {
         references_list::render(refs, area, buf);
+    }
+
+    // ── Clipboard-ring overlay ───────────────────────────────────────────────
+    if let Some(ring) = &state.clipboard_ring {
+        clipboard_ring::render(ring, area, buf);
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -12,6 +12,7 @@ pub mod lsp_approval;
 pub mod lsp_picker;
 pub mod overlay_chrome;
 pub mod project_search;
+pub mod quickfix_list;
 pub mod references_list;
 pub mod search_bar;
 pub mod settings_overlay;
@@ -369,5 +370,10 @@ pub fn render(state: &mut AppState, frame: &mut Frame) {
     // ── Diff-peek float ──────────────────────────────────────────────────────
     if let Some(peek) = &state.diff_peek {
         diff_peek::render(peek, area, buf);
+    }
+
+    // ── Quickfix list overlay ────────────────────────────────────────────────
+    if let Some(qf) = &state.quickfix {
+        quickfix_list::render(qf, area, buf);
     }
 }

--- a/src/ui/quickfix_list.rs
+++ b/src/ui/quickfix_list.rs
@@ -1,0 +1,141 @@
+//! Quickfix / location list overlay (Alt+1).
+
+use ratatui::{
+    buffer::Buffer as TermBuffer,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+};
+
+use crate::lsp::types::DiagSeverity;
+use crate::quickfix::QuickfixState;
+
+const MAX_VISIBLE: usize = 15;
+
+pub fn render(qf: &QuickfixState, area: Rect, buf: &mut TermBuffer) {
+    if area.width < 10 || area.height < 6 {
+        return;
+    }
+    let num_items = qf.entries.len();
+    let visible = num_items.min(MAX_VISIBLE);
+    let popup_h = (visible as u16 + 4).min(area.height);
+    let popup_w = (area.width * 3 / 4).max(50).min(area.width);
+    let ox = area.x + area.width.saturating_sub(popup_w) / 2;
+    let oy = area.y + area.height.saturating_sub(popup_h) / 2;
+    let popup = Rect::new(ox, oy, popup_w, popup_h);
+
+    let bg = Color::Rgb(18, 22, 40);
+    let border_style = Style::default().bg(bg).fg(Color::Rgb(110, 130, 180));
+    let header_style = Style::default()
+        .bg(bg)
+        .fg(Color::Rgb(220, 220, 255))
+        .add_modifier(Modifier::BOLD);
+    let selected_bg = Color::Rgb(40, 55, 110);
+    let err_style = Style::default().bg(bg).fg(Color::Rgb(240, 100, 100));
+    let warn_style = Style::default().bg(bg).fg(Color::Rgb(240, 200, 80));
+    let info_style = Style::default().bg(bg).fg(Color::Rgb(120, 180, 240));
+    let hint_style = Style::default().bg(bg).fg(Color::Rgb(160, 160, 200));
+    let path_style = Style::default().bg(bg).fg(Color::Rgb(140, 200, 240));
+    let msg_style = Style::default().bg(bg).fg(Color::Rgb(220, 220, 230));
+
+    for y in popup.y..popup.y + popup.height {
+        for x in popup.x..popup.x + popup.width {
+            buf.set_string(x, y, " ", Style::default().bg(bg));
+        }
+    }
+    draw_border(buf, popup, border_style);
+
+    let header = format!(" Quickfix ({}) ", num_items);
+    let hx = popup.x + popup.width.saturating_sub(header.len() as u16) / 2;
+    buf.set_string(hx, popup.y, &header, header_style);
+
+    draw_h_separator(buf, popup, popup.y + 2, border_style);
+
+    let scroll = if qf.selected >= MAX_VISIBLE {
+        qf.selected - MAX_VISIBLE + 1
+    } else {
+        0
+    };
+
+    let inner_w = popup.width.saturating_sub(2) as usize;
+
+    for (i, entry) in qf.entries.iter().skip(scroll).take(visible).enumerate() {
+        let y = popup.y + 3 + i as u16;
+        if y >= popup.y + popup.height - 1 {
+            break;
+        }
+        let is_selected = scroll + i == qf.selected;
+        let row_bg = if is_selected { selected_bg } else { bg };
+
+        for x in popup.x + 1..popup.x + popup.width - 1 {
+            buf.set_string(x, y, " ", Style::default().bg(row_bg));
+        }
+
+        // Severity glyph.
+        let (sev_glyph, sev_style) = match entry.severity {
+            DiagSeverity::Error => ("E", err_style.bg(row_bg)),
+            DiagSeverity::Warning => ("W", warn_style.bg(row_bg)),
+            DiagSeverity::Information => ("I", info_style.bg(row_bg)),
+            DiagSeverity::Hint => ("H", hint_style.bg(row_bg)),
+        };
+        buf.set_string(popup.x + 2, y, sev_glyph, sev_style);
+
+        let file_name = entry
+            .path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("?");
+        let loc = format!(" {}:{}:{}", file_name, entry.line + 1, entry.col + 1);
+        let path_display: String = loc.chars().take(inner_w.saturating_sub(4)).collect();
+        buf.set_string(popup.x + 4, y, &path_display, path_style.bg(row_bg));
+
+        let msg_x = popup.x + 4 + path_display.len() as u16 + 2;
+        let msg_w = (popup.x + popup.width - 1).saturating_sub(msg_x) as usize;
+        if msg_w > 3 && !entry.message.is_empty() {
+            let msg: String = entry
+                .message
+                .lines()
+                .next()
+                .unwrap_or("")
+                .chars()
+                .take(msg_w)
+                .collect();
+            buf.set_string(msg_x, y, &msg, msg_style.bg(row_bg));
+        }
+    }
+
+    let hint_y = popup.y + popup.height - 1;
+    let hint = " Enter: jump  ↑↓: select  Esc: close ";
+    let hx2 = popup.x + popup.width.saturating_sub(hint.len() as u16) / 2;
+    buf.set_string(hx2, hint_y, hint, hint_style);
+}
+
+fn draw_border(buf: &mut TermBuffer, area: Rect, style: Style) {
+    if area.width < 2 || area.height < 2 {
+        return;
+    }
+    let (x0, y0) = (area.x, area.y);
+    let (x1, y1) = (area.x + area.width - 1, area.y + area.height - 1);
+    buf.set_string(x0, y0, "╭", style);
+    buf.set_string(x1, y0, "╮", style);
+    buf.set_string(x0, y1, "╰", style);
+    buf.set_string(x1, y1, "╯", style);
+    for x in x0 + 1..x1 {
+        buf.set_string(x, y0, "─", style);
+        buf.set_string(x, y1, "─", style);
+    }
+    for y in y0 + 1..y1 {
+        buf.set_string(x0, y, "│", style);
+        buf.set_string(x1, y, "│", style);
+    }
+}
+
+fn draw_h_separator(buf: &mut TermBuffer, area: Rect, y: u16, style: Style) {
+    if area.width < 2 {
+        return;
+    }
+    buf.set_string(area.x, y, "├", style);
+    buf.set_string(area.x + area.width - 1, y, "┤", style);
+    for x in area.x + 1..area.x + area.width - 1 {
+        buf.set_string(x, y, "─", style);
+    }
+}

--- a/src/ui/settings_overlay.rs
+++ b/src/ui/settings_overlay.rs
@@ -11,7 +11,7 @@ use crate::config::Config;
 
 const OVERLAY_W: u16 = 50;
 // Rows: top border + header + separator + N settings + separator + hint + bottom border
-pub(crate) const NUM_SETTINGS: usize = 8;
+pub(crate) const NUM_SETTINGS: usize = 12;
 const OVERLAY_H: u16 = 3 + NUM_SETTINGS as u16 + 3;
 
 /// Render the settings overlay centered in `area`.
@@ -103,6 +103,18 @@ pub fn render(state: &AppState, area: Rect, buf: &mut TermBuffer) {
             SettingValue::Bool(state.config.show_whitespace),
         ),
         (
+            "Highlight trailing whitespace",
+            SettingValue::Bool(state.config.highlight_trailing_whitespace),
+        ),
+        (
+            "Warn on mixed indent",
+            SettingValue::Bool(state.config.warn_mixed_indent),
+        ),
+        (
+            "Auto-pair brackets",
+            SettingValue::Bool(state.config.auto_pair),
+        ),
+        (
             "Hide .git folder",
             SettingValue::Bool(state.config.hide_git_folder),
         ),
@@ -113,6 +125,10 @@ pub fn render(state: &AppState, area: Rect, buf: &mut TermBuffer) {
         (
             "Restore session",
             SettingValue::Bool(state.config.restore_session),
+        ),
+        (
+            "Persistent undo",
+            SettingValue::Bool(state.config.persistent_undo),
         ),
         (
             "Color theme",

--- a/src/ui/settings_overlay.rs
+++ b/src/ui/settings_overlay.rs
@@ -11,7 +11,7 @@ use crate::config::Config;
 
 const OVERLAY_W: u16 = 50;
 // Rows: top border + header + separator + N settings + separator + hint + bottom border
-pub(crate) const NUM_SETTINGS: usize = 7;
+pub(crate) const NUM_SETTINGS: usize = 8;
 const OVERLAY_H: u16 = 3 + NUM_SETTINGS as u16 + 3;
 
 /// Render the settings overlay centered in `area`.
@@ -109,6 +109,10 @@ pub fn render(state: &AppState, area: Rect, buf: &mut TermBuffer) {
         (
             "Hide dot folders",
             SettingValue::Bool(state.config.hide_dot_folders),
+        ),
+        (
+            "Restore session",
+            SettingValue::Bool(state.config.restore_session),
         ),
         (
             "Color theme",

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -256,6 +256,7 @@ fn modal_prompt(mode: &InputMode) -> Option<String> {
         InputMode::JumpToMarkChar => Some(" Jump to mark: ".to_string()),
         InputMode::RecordMacroChar => Some(" Record macro into slot: ".to_string()),
         InputMode::ReplayMacroChar => Some(" Replay macro from slot: ".to_string()),
+        InputMode::SurroundChar => Some(" Surround with: ".to_string()),
     }
 }
 

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -124,6 +124,21 @@ pub fn render(state: &AppState, theme: &ThemeColors, area: Rect, buf: &mut TermB
     } else {
         String::new()
     };
+    let hunk_str = state
+        .git_gutter
+        .as_ref()
+        .map(|g| g.hunks())
+        .and_then(|hunks| {
+            if hunks.is_empty() {
+                return None;
+            }
+            let cur_line = handle.buffer.cursors.primary().line;
+            hunks
+                .iter()
+                .position(|h| cur_line >= h.start_line && cur_line <= h.end_line)
+                .map(|i| format!(" hunk {}/{}", i + 1, hunks.len()))
+        })
+        .unwrap_or_default();
     let rec_str = state
         .macros
         .recording_slot()
@@ -132,8 +147,9 @@ pub fn render(state: &AppState, theme: &ThemeColors, area: Rect, buf: &mut TermB
 
     // Right side: branch + word-wrap flag + LSP/TS mode + diagnostics + language + indent + REC + position + memory + encoding
     let right = format!(
-        "{}{}{}{}{}{}{}{}  {}{}{}",
+        "{}{}{}{}{}{}{}{}{}  {}{}{}",
         branch_str,
+        hunk_str,
         wrap_flag,
         lsp_flag,
         diag_str,

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -119,6 +119,11 @@ pub fn render(state: &AppState, theme: &ThemeColors, area: Rect, buf: &mut TermB
         .unwrap_or_default();
 
     let indent_str = format!(" {}", state.indent_label());
+    let mixed_indent_str = if state.config.warn_mixed_indent && handle.buffer.has_mixed_indent() {
+        " mixed-indent".to_string()
+    } else {
+        String::new()
+    };
     let rec_str = state
         .macros
         .recording_slot()
@@ -127,7 +132,7 @@ pub fn render(state: &AppState, theme: &ThemeColors, area: Rect, buf: &mut TermB
 
     // Right side: branch + word-wrap flag + LSP/TS mode + diagnostics + language + indent + REC + position + memory + encoding
     let right = format!(
-        "{}{}{}{}{}{}{}  {}{}{}",
+        "{}{}{}{}{}{}{}{}  {}{}{}",
         branch_str,
         wrap_flag,
         lsp_flag,
@@ -138,6 +143,7 @@ pub fn render(state: &AppState, theme: &ThemeColors, area: Rect, buf: &mut TermB
             String::new()
         },
         indent_str,
+        mixed_indent_str,
         rec_str,
         pos,
         mem_str,

--- a/tests/ui_clipboard_ring.rs
+++ b/tests/ui_clipboard_ring.rs
@@ -1,0 +1,106 @@
+#![cfg(feature = "ui-tests")]
+
+//! Tier 3.3 — clipboard ring overlay (Ctrl+Shift+V).
+
+mod ui_common;
+
+use ui_common::{Fixture, Key};
+
+#[test]
+fn clipboard_ring_overlay_opens_and_pastes_older_entry() {
+    // Plan: open a file, select-and-copy "alpha", then select-and-copy
+    // "beta". Open the clipboard ring (Ctrl+Shift+V) — "beta" should be at
+    // the top. Move down once to highlight "alpha" and press Enter; the
+    // ring closes and the pasted text appears in the buffer.
+    let fx = Fixture::new();
+    let path = fx.write_file("ring.txt", "alpha beta gamma\n");
+    let mut s = fx.open(&path);
+    s.wait_for_status_contains("ring.txt");
+
+    // Select "alpha" (cols 1..6) and copy.
+    s.send_keys(&[
+        Key::Home,
+        Key::ShiftArrow(ui_common::Arrow::Right),
+        Key::ShiftArrow(ui_common::Arrow::Right),
+        Key::ShiftArrow(ui_common::Arrow::Right),
+        Key::ShiftArrow(ui_common::Arrow::Right),
+        Key::ShiftArrow(ui_common::Arrow::Right),
+        Key::Ctrl('c'),
+    ]);
+
+    // Move past the space to "beta" (cols 7..11) and copy.
+    s.send_keys(&[
+        Key::Right, // skip space
+        Key::ShiftArrow(ui_common::Arrow::Right),
+        Key::ShiftArrow(ui_common::Arrow::Right),
+        Key::ShiftArrow(ui_common::Arrow::Right),
+        Key::ShiftArrow(ui_common::Arrow::Right),
+        Key::Ctrl('c'),
+    ]);
+
+    // Move to a fresh insertion point at end-of-line and open the ring.
+    s.send_keys(&[Key::End, Key::CtrlShift('V')]);
+    s.wait_for_screen_contains("Clipboard ring");
+
+    // Two entries should be visible: "beta" (most recent) and "alpha".
+    s.wait_for_screen_contains("alpha");
+
+    // Highlight the older entry and paste.
+    s.send_keys(&[Key::Down, Key::Enter]);
+
+    // The original line is unchanged because we landed at End; what was
+    // pasted is appended. After paste, screen should contain "gammaalpha"
+    // (no space, deliberately — tests the ring → paste round trip, not
+    // formatting).
+    s.wait_until(
+        |sc| sc.contents().contains("gammaalpha"),
+        std::time::Duration::from_secs(5),
+    );
+
+    s.shutdown();
+}
+
+#[test]
+fn clipboard_ring_overlay_dismisses_on_escape() {
+    let fx = Fixture::new();
+    let path = fx.write_file("ring2.txt", "hello\n");
+    let mut s = fx.open(&path);
+    s.wait_for_status_contains("ring2.txt");
+
+    // Copy "hello".
+    s.send_keys(&[
+        Key::Home,
+        Key::ShiftArrow(ui_common::Arrow::End),
+        Key::Ctrl('c'),
+    ]);
+
+    s.send_key(Key::CtrlShift('V'));
+    s.wait_for_screen_contains("Clipboard ring");
+    s.send_key(Key::Esc);
+    // After dismiss, the header should be gone.
+    s.wait_until(
+        |sc| !sc.contents().contains("Clipboard ring"),
+        std::time::Duration::from_secs(5),
+    );
+
+    s.shutdown();
+}
+
+#[test]
+fn clipboard_ring_silent_when_empty() {
+    let fx = Fixture::new();
+    let path = fx.write_file("empty.txt", "x\n");
+    let mut s = fx.open(&path);
+    s.wait_for_status_contains("empty.txt");
+    // Without any prior copy, the ring is empty — the overlay must NOT open.
+    s.send_key(Key::CtrlShift('V'));
+    // Give the binary time to (not) draw the overlay.
+    std::thread::sleep(std::time::Duration::from_millis(150));
+    let screen = s.screen();
+    assert!(
+        !screen.contents().contains("Clipboard ring"),
+        "overlay should not open with an empty ring; got:\n{}",
+        screen.contents()
+    );
+    s.shutdown();
+}

--- a/tests/ui_common/fixtures.rs
+++ b/tests/ui_common/fixtures.rs
@@ -81,3 +81,22 @@ fn seed_config(dir: &std::path::Path) {
     let body = format!("last_seen_version = \"{version}\"\n");
     std::fs::write(dir.join("config.toml"), body).expect("seed config.toml");
 }
+
+impl Fixture {
+    /// Append `extra_toml` to the seeded `config.toml`. The first line of
+    /// the seeded file (`last_seen_version = ...`) is preserved, so the
+    /// welcome overlay still stays dismissed. Subsequent calls append more
+    /// keys without re-clobbering.
+    pub fn append_config(&self, extra_toml: &str) {
+        let path = self.config_path().join("config.toml");
+        let mut current = std::fs::read_to_string(&path).unwrap_or_default();
+        if !current.ends_with('\n') {
+            current.push('\n');
+        }
+        current.push_str(extra_toml);
+        if !current.ends_with('\n') {
+            current.push('\n');
+        }
+        std::fs::write(&path, current).expect("rewrite config.toml");
+    }
+}

--- a/tests/ui_common/harness.rs
+++ b/tests/ui_common/harness.rs
@@ -37,6 +37,9 @@ pub struct SessionOptions {
     pub size: (u16, u16),
     /// Additional environment variables.  Override the harness defaults.
     pub extra_env: Vec<(String, String)>,
+    /// When `true`, do not set `TXT_DISABLE_GIT`. Used by tests that need
+    /// the spawned binary to read the git gutter.
+    pub allow_git: bool,
 }
 
 impl SessionOptions {
@@ -47,7 +50,16 @@ impl SessionOptions {
             config_dir,
             size: (24, 80),
             extra_env: Vec::new(),
+            allow_git: false,
         }
+    }
+
+    /// Allow the spawned binary to call git (the harness default disables
+    /// it for determinism). Required by tests that exercise the git gutter,
+    /// hunk navigation, or branch indicator.
+    pub fn allow_git(mut self) -> Self {
+        self.allow_git = true;
+        self
     }
 
     pub fn arg(mut self, a: impl Into<String>) -> Self {
@@ -102,8 +114,12 @@ impl TxtSession {
         cmd.env("HOME", &opts.cwd); // any writable dir; not used because TXT_CONFIG_DIR is set
         cmd.env("TERM", "xterm-256color");
         cmd.env("TXT_CONFIG_DIR", &opts.config_dir);
+        // Tests can override these by adding the same key to `extra_env`
+        // below — the later `cmd.env` call wins.
         cmd.env("TXT_DISABLE_LSP", "1");
-        cmd.env("TXT_DISABLE_GIT", "1");
+        if !opts.allow_git {
+            cmd.env("TXT_DISABLE_GIT", "1");
+        }
         cmd.env("TXT_DISABLE_WATCHER", "1");
         // Avoid clipboard side-effects under the test runner.
         cmd.env("WAYLAND_DISPLAY", "");

--- a/tests/ui_diff_nav.rs
+++ b/tests/ui_diff_nav.rs
@@ -1,0 +1,124 @@
+#![cfg(feature = "ui-tests")]
+
+//! Tier 3.5 — diff-aware navigation and partial revert.
+
+mod ui_common;
+
+use std::process::Command;
+
+use ui_common::{Fixture, Key, SessionOptions, TxtSession};
+
+/// Build a git fixture: init a repo, write & commit `original`, then
+/// overwrite the file with `modified` so the buffer differs from HEAD.
+/// Returns the (fixture, path) pair ready for `TxtSession::launch`.
+fn git_fixture(original: &str, modified: &str) -> (Fixture, std::path::PathBuf) {
+    let fx = Fixture::new();
+    let ws = fx.workspace_path();
+    let run = |args: &[&str]| {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(&ws)
+            .status()
+            .expect("git invoke");
+        assert!(status.success(), "git {args:?} failed");
+    };
+    run(&["init", "-q", "-b", "main"]);
+    run(&["config", "user.email", "test@example.com"]);
+    run(&["config", "user.name", "tester"]);
+    run(&["config", "commit.gpgsign", "false"]);
+
+    let path = fx.write_file("hunk.txt", original);
+    run(&["add", "hunk.txt"]);
+    run(&["commit", "-q", "-m", "initial"]);
+    // Now diverge: overwrite the file in the workspace, but do not commit.
+    std::fs::write(&path, modified).expect("write modified");
+    (fx, path)
+}
+
+fn launch_with_git(fx: &Fixture, path: &std::path::Path) -> TxtSession {
+    // Use the path *relative to the workspace* so that the subprocess `git
+    // show HEAD:<path>` lookup matches the entry in the index.
+    let rel = path
+        .strip_prefix(fx.workspace_path())
+        .unwrap_or(path)
+        .to_string_lossy()
+        .into_owned();
+    let session = TxtSession::launch(
+        SessionOptions::new(fx.workspace_path(), fx.config_path())
+            .allow_git()
+            .arg(rel),
+    );
+    session.wait_for_first_paint();
+    session
+}
+
+#[test]
+fn next_hunk_jumps_to_changed_line() {
+    let original = "line1\nline2\nline3\nline4\nline5\n";
+    let modified = "line1\nCHANGED\nline3\nline4\nline5\n";
+    let (fx, path) = git_fixture(original, modified);
+    let mut s = launch_with_git(&fx, &path);
+    s.wait_for_status_contains("hunk.txt");
+    // Cursor starts at 1:1. Alt+] should jump to line 2.
+    s.send_key(Key::Alt(']'));
+    s.wait_for_status_contains("2:1");
+    s.shutdown();
+}
+
+#[test]
+fn status_bar_shows_hunk_index() {
+    let original = "a\nb\nc\nd\ne\nf\n";
+    let modified = "a\nB\nc\nD\ne\nf\n";
+    let (fx, path) = git_fixture(original, modified);
+    let mut s = launch_with_git(&fx, &path);
+    s.wait_for_status_contains("hunk.txt");
+    s.send_key(Key::Alt(']')); // first hunk
+    s.wait_for_status_contains("hunk 1/2");
+    s.send_key(Key::Alt(']')); // second hunk
+    s.wait_for_status_contains("hunk 2/2");
+    s.shutdown();
+}
+
+#[test]
+fn revert_hunk_replaces_with_head_content() {
+    let original = "alpha\nbeta\ngamma\n";
+    let modified = "alpha\nBETA-CHANGED\ngamma\n";
+    let (fx, path) = git_fixture(original, modified);
+    let mut s = launch_with_git(&fx, &path);
+    s.wait_for_status_contains("hunk.txt");
+    s.send_key(Key::Alt(']'));
+    s.wait_for_status_contains("hunk 1/1");
+    // Revert the hunk back to its HEAD content.
+    s.send_key(Key::CtrlShift('U'));
+    // Buffer should now show "beta" instead of "BETA-CHANGED".
+    s.wait_until(
+        |sc| {
+            let body = sc.contents();
+            body.contains("beta") && !body.contains("BETA-CHANGED")
+        },
+        std::time::Duration::from_secs(5),
+    );
+    s.shutdown();
+}
+
+#[test]
+fn peek_overlay_opens_and_dismisses() {
+    let original = "first\nsecond\nthird\n";
+    let modified = "first\nSECOND-CHANGED\nthird\n";
+    let (fx, path) = git_fixture(original, modified);
+    let mut s = launch_with_git(&fx, &path);
+    s.wait_for_status_contains("hunk.txt");
+    s.send_key(Key::Alt(']'));
+    s.wait_for_status_contains("hunk 1/1");
+    s.send_key(Key::Alt('h'));
+    s.wait_for_screen_contains("HEAD (peek)");
+    // HEAD line should appear.
+    s.wait_for_screen_contains("second");
+    // Toggling again closes the peek.
+    s.send_key(Key::Alt('h'));
+    s.wait_until(
+        |sc| !sc.contents().contains("HEAD (peek)"),
+        std::time::Duration::from_secs(5),
+    );
+    s.shutdown();
+}

--- a/tests/ui_editing.rs
+++ b/tests/ui_editing.rs
@@ -193,6 +193,59 @@ fn persistent_undo_survives_relaunch() {
     s2.shutdown();
 }
 
+#[test]
+fn settings_overlay_lists_all_tier3_toggles() {
+    // The settings overlay must surface every new Tier 3 bool toggle so
+    // the user doesn't have to hand-edit config.toml.
+    let fx = Fixture::new();
+    let path = fx.write_file("settings.txt", "x\n");
+    let mut s = fx.open(&path);
+    s.wait_for_status_contains("settings.txt");
+    s.send_key(Key::Ctrl(','));
+    s.wait_for_screen_contains("Settings");
+    for label in [
+        "Highlight trailing whitespace",
+        "Warn on mixed indent",
+        "Auto-pair brackets",
+        "Restore session",
+        "Persistent undo",
+    ] {
+        s.wait_for_screen_contains(label);
+    }
+    s.shutdown();
+}
+
+#[test]
+fn settings_toggle_auto_pair_writes_config() {
+    // Toggling "Auto-pair brackets" (row 5) must persist auto_pair = false
+    // to config.toml.
+    let fx = Fixture::new();
+    let path = fx.write_file("ap-toggle.txt", "x\n");
+    let mut s = fx.open(&path);
+    s.wait_for_status_contains("ap-toggle.txt");
+    s.send_key(Key::Ctrl(','));
+    s.wait_for_screen_contains("Auto-pair brackets");
+    // Auto-pair is row 5; defaults to ON so Space toggles to OFF.
+    for _ in 0..5 {
+        s.send_key(Key::Down);
+    }
+    s.send_key(Key::Char(' '));
+    s.wait_until(
+        |sc| {
+            sc.contents()
+                .lines()
+                .any(|l| l.contains("Auto-pair brackets") && l.contains("[OFF]"))
+        },
+        std::time::Duration::from_secs(5),
+    );
+    s.shutdown();
+    let cfg = std::fs::read_to_string(fx.config_path().join("config.toml")).unwrap();
+    assert!(
+        cfg.contains("auto_pair = false"),
+        "config.toml should record auto_pair = false; got:\n{cfg}"
+    );
+}
+
 // ── Tier 3 — 3.4 auto-pair + surround ────────────────────────────────────
 
 #[test]

--- a/tests/ui_editing.rs
+++ b/tests/ui_editing.rs
@@ -123,3 +123,73 @@ fn contains_word(haystack: &str, word: &str) -> bool {
         .lines()
         .any(|l| l.split(|c: char| !c.is_alphanumeric()).any(|w| w == word))
 }
+
+// ── Tier 3 — 3.6 trailing-whitespace + mixed indent ─────────────────────
+
+#[test]
+fn mixed_indent_segment_appears_in_status_bar() {
+    // File mixes tab- and space-leading lines → status bar must contain the
+    // "mixed-indent" segment.
+    let fx = Fixture::new();
+    let path = fx.write_file("mix.txt", "\tfoo\n  bar\n");
+    let s = fx.open(&path);
+    s.wait_for_status_contains("mixed-indent");
+    s.shutdown();
+}
+
+#[test]
+fn mixed_indent_absent_for_pure_spaces() {
+    let fx = Fixture::new();
+    let path = fx.write_file("clean.txt", "  foo\n  bar\n");
+    let s = fx.open(&path);
+    s.wait_for_status_contains("clean.txt");
+    let screen = s.screen();
+    let (rows, cols) = screen.size();
+    let last = screen.contents_between(rows - 1, 0, rows - 1, cols);
+    assert!(
+        !last.contains("mixed-indent"),
+        "status bar should not flag pure-space file, got: {last:?}"
+    );
+    s.shutdown();
+}
+
+#[test]
+fn trailing_whitespace_highlight_renders() {
+    // Trailing spaces on a line other than the cursor's must show with the
+    // configured background colour. The vt100 parser exposes per-cell bg
+    // colour so we check the colour of a trailing-space cell.
+    use ratatui::style::Color;
+    let fx = Fixture::new();
+    let path = fx.write_file("tws.txt", "first   \nsecond\n");
+    let mut s = fx.open(&path);
+    s.wait_for_status_contains("tws.txt");
+    // Move cursor to line 2 so line 1's trailing whitespace is highlighted.
+    s.send_key(Key::Down);
+    s.wait_for_status_contains("2:1");
+    let screen = s.screen();
+    // Inspect cell at row 0 (file content row), col after "first" (5..8).
+    // The actual on-screen column depends on the gutter width; we look for a
+    // non-default bg colour somewhere on row 0 between cols 5 and 30.
+    let (_rows, cols) = screen.size();
+    let row0 = 0;
+    let mut found_red_bg = false;
+    for c in 0..cols {
+        if let Some(cell) = screen.cell(row0, c)
+            && let vt100::Color::Rgb(r, _g, _b) = cell.bgcolor()
+            && r > 80
+            && r < 160
+        {
+            // Our trailing-ws style uses Rgb(110, 30, 30) — accept that range.
+            found_red_bg = true;
+            break;
+        }
+        // suppress unused-import warning in non-matching builds
+        let _ = Color::Reset;
+    }
+    assert!(
+        found_red_bg,
+        "expected a red-bg trailing-ws cell on row 0, screen:\n{}",
+        screen.contents()
+    );
+    s.shutdown();
+}

--- a/tests/ui_editing.rs
+++ b/tests/ui_editing.rs
@@ -153,6 +153,63 @@ fn mixed_indent_absent_for_pure_spaces() {
     s.shutdown();
 }
 
+// ── Tier 3 — 3.4 auto-pair + surround ────────────────────────────────────
+
+#[test]
+fn auto_pair_inserts_matching_close_paren() {
+    let fx = Fixture::new();
+    let path = fx.write_file("ap.txt", "\n");
+    let mut s = fx.open(&path);
+    s.wait_for_status_contains("1:1");
+    s.send_key(Key::Char('('));
+    // After "(", cursor should still be at col 2 (sitting inside the pair),
+    // but the buffer should contain "()" on line 1.
+    s.wait_until(
+        |sc| sc.contents().contains("()"),
+        std::time::Duration::from_secs(5),
+    );
+    // Status bar should show 1:2 (inside the pair) rather than 1:3.
+    s.assert_status_contains("1:2");
+    s.shutdown();
+}
+
+#[test]
+fn auto_pair_skip_over_existing_close() {
+    let fx = Fixture::new();
+    let path = fx.write_file("skip.txt", "\n");
+    let mut s = fx.open(&path);
+    s.wait_for_status_contains("1:1");
+    // Type "(" → auto-pair creates "(|)", then type ")" — should just move past it.
+    s.send_keys(&[Key::Char('('), Key::Char(')')]);
+    s.wait_until(
+        |sc| sc.contents().contains("()"),
+        std::time::Duration::from_secs(5),
+    );
+    // Cursor now should be just after the close (col 3).
+    s.assert_status_contains("1:3");
+    s.shutdown();
+}
+
+#[test]
+fn surround_wraps_selection_in_quotes() {
+    let fx = Fixture::new();
+    let path = fx.write_file("sur.txt", "hello\n");
+    let mut s = fx.open(&path);
+    s.wait_for_status_contains("1:1");
+    // Select "hello" and trigger surround → "
+    s.send_keys(&[
+        Key::Home,
+        Key::ShiftArrow(ui_common::Arrow::End),
+        Key::Alt('\''),
+        Key::Char('"'),
+    ]);
+    s.wait_until(
+        |sc| sc.contents().contains("\"hello\""),
+        std::time::Duration::from_secs(5),
+    );
+    s.shutdown();
+}
+
 #[test]
 fn trailing_whitespace_highlight_renders() {
     // Trailing spaces on a line other than the cursor's must show with the

--- a/tests/ui_editing.rs
+++ b/tests/ui_editing.rs
@@ -153,6 +153,46 @@ fn mixed_indent_absent_for_pure_spaces() {
     s.shutdown();
 }
 
+// ── Tier 3 — 3.2 persistent undo ─────────────────────────────────────────
+
+#[test]
+fn persistent_undo_survives_relaunch() {
+    use ui_common::{SessionOptions, TxtSession};
+    let fx = Fixture::new();
+    // Enable persistent undo via the seeded config.
+    fx.append_config("persistent_undo = true\n");
+    let path = fx.write_file("pu.txt", "hello\n");
+
+    // Edit, save, quit.
+    let mut s1 = TxtSession::launch(
+        SessionOptions::new(fx.workspace_path(), fx.config_path()).arg(path.to_string_lossy()),
+    );
+    s1.wait_for_first_paint();
+    s1.wait_for_status_contains("pu.txt");
+    s1.send_keys(&[Key::End, Key::Char('!'), Key::Ctrl('s')]);
+    s1.wait_until(
+        |sc| sc.contents().contains("hello!"),
+        std::time::Duration::from_secs(5),
+    );
+    s1.shutdown();
+
+    // Relaunch the same file → press Ctrl+Z → should restore "hello".
+    let mut s2 = TxtSession::launch(
+        SessionOptions::new(fx.workspace_path(), fx.config_path()).arg(path.to_string_lossy()),
+    );
+    s2.wait_for_first_paint();
+    s2.wait_for_status_contains("pu.txt");
+    s2.send_key(Key::Ctrl('z'));
+    s2.wait_until(
+        |sc| {
+            let body = sc.contents();
+            body.contains("hello") && !body.contains("hello!")
+        },
+        std::time::Duration::from_secs(5),
+    );
+    s2.shutdown();
+}
+
 // ── Tier 3 — 3.4 auto-pair + surround ────────────────────────────────────
 
 #[test]

--- a/tests/ui_pickers.rs
+++ b/tests/ui_pickers.rs
@@ -93,3 +93,17 @@ fn picker_ctrl_g_jumps_to_typed_line() {
     s.wait_for_status_contains("25:1");
     s.shutdown();
 }
+
+#[test]
+fn quickfix_shows_no_diagnostics_message_without_lsp() {
+    // With LSP disabled in the harness, opening the quickfix list must
+    // report "No diagnostics" via the status bar instead of opening the
+    // overlay.
+    let fx = Fixture::new();
+    let path = fx.write_file("nodiag.txt", "fn main() {}\n");
+    let mut s = fx.open(&path);
+    s.wait_for_status_contains("nodiag.txt");
+    s.send_key(Key::Alt('1'));
+    s.wait_for_status_contains("No diagnostics");
+    s.shutdown();
+}

--- a/tests/ui_session.rs
+++ b/tests/ui_session.rs
@@ -98,8 +98,8 @@ fn settings_overlay_toggle_persists_restore_session() {
     s.wait_for_status_contains("set.txt");
     s.send_key(Key::Ctrl(','));
     s.wait_for_screen_contains("Restore session");
-    // Settings cursor starts at row 0 (Confirm exit); restore_session is row 5.
-    for _ in 0..5 {
+    // Settings cursor starts at row 0 (Confirm exit); restore_session is row 8.
+    for _ in 0..8 {
         s.send_key(Key::Down);
     }
     // Space toggles the bool — wait for [ON] to appear on the same row.

--- a/tests/ui_session.rs
+++ b/tests/ui_session.rs
@@ -1,0 +1,101 @@
+#![cfg(feature = "ui-tests")]
+
+//! Tier 3.1 — persistent sessions per workspace.
+
+mod ui_common;
+
+use ui_common::{Fixture, Key, SessionOptions, TxtSession};
+
+fn launch_with(fx: &Fixture, args: &[String]) -> TxtSession {
+    let mut opts = SessionOptions::new(fx.workspace_path(), fx.config_path());
+    for a in args {
+        opts = opts.arg(a.clone());
+    }
+    let session = TxtSession::launch(opts);
+    session.wait_for_first_paint();
+    session
+}
+
+#[test]
+fn session_round_trip_reopens_tab_at_cursor() {
+    let fx = Fixture::new();
+    fx.append_config("restore_session = true\n");
+    let path = fx.write_file("kept.txt", "line one\nline two\nline three\n");
+
+    // Launch with the file as a positional arg, move the cursor to line 2,
+    // then quit cleanly.
+    let mut s1 = TxtSession::launch(
+        SessionOptions::new(fx.workspace_path(), fx.config_path()).arg(path.to_string_lossy()),
+    );
+    s1.wait_for_first_paint();
+    s1.wait_for_status_contains("kept.txt");
+    s1.send_keys(&[Key::Down]);
+    s1.wait_for_status_contains("2:1");
+    s1.shutdown();
+
+    // Re-launch without any positional arg → session.json should reopen the
+    // saved tab and restore the cursor.
+    let s2 = launch_with(&fx, &[]);
+    s2.wait_for_status_contains("kept.txt");
+    s2.wait_for_status_contains("2:1");
+    s2.shutdown();
+}
+
+#[test]
+fn session_not_restored_when_disabled() {
+    // Without `restore_session = true`, even a saved session is ignored.
+    let fx = Fixture::new();
+    let path = fx.write_file("ignored.txt", "x\n");
+
+    let s1 = TxtSession::launch(
+        SessionOptions::new(fx.workspace_path(), fx.config_path()).arg(path.to_string_lossy()),
+    );
+    s1.wait_for_first_paint();
+    s1.wait_for_status_contains("ignored.txt");
+    s1.shutdown();
+
+    // Relaunch with no positional arg, with `restore_session = false`
+    // (the default).
+    let s2 = launch_with(&fx, &[]);
+    s2.wait_for_first_paint();
+    let screen = s2.screen();
+    assert!(
+        !screen.contents().contains("ignored.txt"),
+        "session should NOT have been restored; got screen:\n{}",
+        screen.contents()
+    );
+    s2.shutdown();
+}
+
+#[test]
+fn session_skipped_when_positional_file_is_given() {
+    // Even with `restore_session = true`, providing a positional file
+    // should NOT also reopen prior tabs (would be surprising).
+    let fx = Fixture::new();
+    fx.append_config("restore_session = true\n");
+    let saved = fx.write_file("saved.txt", "a\n");
+    let other = fx.write_file("other.txt", "b\n");
+
+    // Save a session containing saved.txt.
+    let s1 = TxtSession::launch(
+        SessionOptions::new(fx.workspace_path(), fx.config_path()).arg(saved.to_string_lossy()),
+    );
+    s1.wait_for_first_paint();
+    s1.wait_for_status_contains("saved.txt");
+    s1.shutdown();
+
+    // Launch with a different positional file.
+    let s2 = TxtSession::launch(
+        SessionOptions::new(fx.workspace_path(), fx.config_path()).arg(other.to_string_lossy()),
+    );
+    s2.wait_for_first_paint();
+    s2.wait_for_status_contains("other.txt");
+    // saved.txt should NOT be reopened.
+    let screen = s2.screen();
+    assert!(
+        !screen.contents().contains("saved.txt"),
+        "explicit positional arg should suppress session restore; screen:\n{}",
+        screen.contents()
+    );
+    s2.shutdown();
+}

--- a/tests/ui_session.rs
+++ b/tests/ui_session.rs
@@ -68,6 +68,61 @@ fn session_not_restored_when_disabled() {
 }
 
 #[test]
+fn settings_overlay_lists_restore_session_toggle() {
+    // The persistent-session toggle must be reachable from the settings
+    // overlay (Ctrl+,) so the user doesn't have to hand-edit config.toml.
+    let fx = Fixture::new();
+    let path = fx.write_file("toggle.txt", "x\n");
+    let mut s = TxtSession::launch(
+        SessionOptions::new(fx.workspace_path(), fx.config_path()).arg(path.to_string_lossy()),
+    );
+    s.wait_for_first_paint();
+    s.wait_for_status_contains("toggle.txt");
+    s.send_key(Key::Ctrl(','));
+    s.wait_for_screen_contains("Settings");
+    s.wait_for_screen_contains("Restore session");
+    s.shutdown();
+}
+
+#[test]
+fn settings_overlay_toggle_persists_restore_session() {
+    // Toggling "Restore session" with Space in the overlay must write
+    // restore_session = true into config.toml so the next launch picks
+    // it up.
+    let fx = Fixture::new();
+    let path = fx.write_file("set.txt", "x\n");
+    let mut s = TxtSession::launch(
+        SessionOptions::new(fx.workspace_path(), fx.config_path()).arg(path.to_string_lossy()),
+    );
+    s.wait_for_first_paint();
+    s.wait_for_status_contains("set.txt");
+    s.send_key(Key::Ctrl(','));
+    s.wait_for_screen_contains("Restore session");
+    // Settings cursor starts at row 0 (Confirm exit); restore_session is row 5.
+    for _ in 0..5 {
+        s.send_key(Key::Down);
+    }
+    // Space toggles the bool — wait for [ON] to appear on the same row.
+    s.send_key(Key::Char(' '));
+    s.wait_until(
+        |sc| {
+            sc.contents()
+                .lines()
+                .any(|l| l.contains("Restore session") && l.contains("[ON]"))
+        },
+        std::time::Duration::from_secs(5),
+    );
+    s.shutdown();
+
+    // Verify the value was persisted to disk.
+    let cfg = std::fs::read_to_string(fx.config_path().join("config.toml")).unwrap();
+    assert!(
+        cfg.contains("restore_session = true"),
+        "config.toml should record the toggle; got:\n{cfg}"
+    );
+}
+
+#[test]
 fn session_skipped_when_positional_file_is_given() {
     // Even with `restore_session = true`, providing a positional file
     // should NOT also reopen prior tabs (would be surprising).


### PR DESCRIPTION
## Summary

Implements every Tier 3 feature listed in `feature_proposals.md` as its own
commit on `claude/tier-3-features-tests-fNbG8`:

- **3.6** Trailing-whitespace highlight + `mixed-indent` status-bar segment
  (`be2e70d`). Both passive features default on; disable with
  `highlight_trailing_whitespace = false` / `warn_mixed_indent = false`.
- **3.3** Clipboard ring (`73e4a9e`). `Ctrl+Shift+V` opens a picker over the
  last 32 yank/cut values. The system clipboard remains the default sink.
- **3.4** Surround prompt + bracket auto-pair (`89a56d5`). `Alt+'` wraps the
  selection (or word under the cursor) in a chosen delimiter pair; typing an
  opener like `(`, `[`, `"` inserts the matching closer with the cursor
  between. `auto_pair = false` disables.
- **3.5** Diff-aware hunk navigation and partial revert (`8a3c0ce`).
  `Alt+]`/`Alt+[` step between hunks, `Ctrl+Shift+U` reverts the hunk under
  the cursor to HEAD, `Alt+H` peeks the HEAD lines. Status bar gains a
  `hunk i/n` segment.
- **3.7** Quickfix list (`e5672b6`). `Alt+1` opens a workspace-wide list of
  every LSP diagnostic; `F8`/`Shift+F8` step through entries. Scope of this
  batch is LSP diagnostics only — project-search and external-command
  sources are deferred.
- **3.1** Per-workspace session persistence (`665b60b`). `restore_session =
  true` writes the open tabs (path, cursor byte, viewport top) to
  `<workspace>/.txt/session.json` on clean shutdown and restores them on
  the next launch without a positional file arg. Opt-in.
- **3.2** Persistent undo (`1d9e6c8`). `persistent_undo = true` writes the
  buffer's undo stack snapshot to `<workspace>/.txt/undo/<hash>.json` on
  save and reloads on open, verified by an FNV-1a hash of the file's
  content so stale histories are dropped silently. Opt-in.
- **Doc** (`74756d2`) — mark every Tier 3 entry as `✅ implemented` in
  `feature_proposals.md`.

Every feature has unit tests in its module plus PTY-driven UI tests in
`tests/ui_*.rs`. The harness gained a `SessionOptions::allow_git()` flag so
the diff-nav suite can exercise a real git repo, and a
`Fixture::append_config()` helper so tests can opt into `restore_session`
and `persistent_undo` from TOML.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo build --all-targets` (warnings-as-errors)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --all-targets` — 592 unit/integration tests pass
- [x] `scripts/check-ui.sh` — full PTY-driven UI suite passes, including new
      `tests/ui_clipboard_ring.rs`, `tests/ui_diff_nav.rs`,
      `tests/ui_session.rs`, the new auto-pair/surround/trailing-ws cases
      in `tests/ui_editing.rs`, the `Alt+1` no-diagnostics case in
      `tests/ui_pickers.rs`, and the persistent-undo round-trip.

https://claude.ai/code/session_0144cwDLHE3NfRFyg2inCHGs

---
_Generated by [Claude Code](https://claude.ai/code/session_0144cwDLHE3NfRFyg2inCHGs)_