### PR TITLE
Add background version checker with row-0 release badge

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -23,7 +23,7 @@ use crate::{
     search::{SearchState, project::ProjectSearchResults},
     ui,
     ui::command_palette::CommandPaletteState,
-    ui::editor_view::gutter_width,
+    ui::editor_view::effective_gutter_width,
     ui::git_dialog::GitDialogState,
     watcher::FileWatcher,
 };
@@ -966,6 +966,9 @@ pub struct AppState {
     /// on a 2 s cadence so external `git checkout`s are picked up live.
     pub git_branch: Option<String>,
     git_branch_last_checked: Instant,
+    /// Background "is there a newer release?" checker. Always present, but
+    /// stays inert when `TXT_DISABLE_VERSION_CHECK` is set (used by tests).
+    pub version_check: crate::version_check::VersionChecker,
 }
 
 impl AppState {
@@ -1068,6 +1071,7 @@ impl AppState {
             memory_last_checked: Instant::now(),
             git_branch,
             git_branch_last_checked: Instant::now(),
+            version_check: crate::version_check::VersionChecker::spawn(),
         };
         // Apply config to initial buffer.
         if state.config.word_wrap {
@@ -4236,6 +4240,14 @@ impl AppState {
         }
     }
 
+    /// Owned copy of the row-0 gutter badge string ("↑X.Y.Z") that
+    /// `editor_view::render` overlays when a newer release is available. Used
+    /// by the layout helpers to widen the gutter width consistently across
+    /// renderer and mouse hit-testing.
+    pub fn version_badge(&self) -> Option<String> {
+        self.version_check.newer_version().map(|v| format!("↑{v}"))
+    }
+
     /// Recompute the git gutter for the currently active buffer (if it has a path).
     fn refresh_git_gutter(&mut self) {
         let path = self.editor.active().path.clone();
@@ -5463,7 +5475,8 @@ impl AppState {
     /// the buffer-derived dimensions from current `AppState`.
     fn clamp_viewport_scroll(&mut self, text_h: usize) {
         let total_lines = self.editor.active().buffer.len_lines();
-        let gutter = crate::ui::editor_view::gutter_width(total_lines);
+        let label = self.version_badge();
+        let gutter = effective_gutter_width(total_lines, label.as_deref());
         let sidebar_w: u16 = if self.sidebar.is_some() {
             self.sidebar_width + 1
         } else {
@@ -5576,7 +5589,8 @@ impl AppState {
         let adjusted_col = col.saturating_sub(sidebar_offset);
         let handle = self.editor.active();
         let total_lines = handle.buffer.len_lines();
-        let gutter = gutter_width(total_lines);
+        let label = self.version_badge();
+        let gutter = effective_gutter_width(total_lines, label.as_deref());
         let git_col_w: u16 = if self.git_gutter.is_some() {
             crate::ui::editor_view::GIT_GUTTER_W
         } else {
@@ -5650,7 +5664,9 @@ impl App {
             } else {
                 0
             };
-            let gutter = gutter_width(state.editor.active().buffer.len_lines());
+            let badge = state.version_badge();
+            let gutter =
+                effective_gutter_width(state.editor.active().buffer.len_lines(), badge.as_deref());
             let text_w = term_width.saturating_sub(gutter + 1 + sidebar_w) as usize;
 
             let curr_anchor = (
@@ -5679,6 +5695,7 @@ impl App {
             state.poll_auto_save();
             state.refresh_memory();
             state.refresh_git_branch();
+            state.version_check.poll();
 
             // Drain pending LSP server updates (non-blocking).
             state.poll_lsp_updates();

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod snippet;
 mod syntax;
 mod theme;
 mod ui;
+mod version_check;
 mod watcher;
 
 use std::{io, path::PathBuf};

--- a/src/ui/editor_view.rs
+++ b/src/ui/editor_view.rs
@@ -39,6 +39,7 @@ pub fn render(
     search: Option<&SearchState>,
     highlights: &[HighlightSpan],
     git_gutter: Option<&GitGutter>,
+    new_version: Option<&str>,
     focused: bool,
     show_whitespace: bool,
     tab_size: usize,
@@ -61,7 +62,10 @@ pub fn render(
     // candidate range — keeps the gutter tight for plaintext and short files.
     let has_folds = (0..total_lines).any(|i| handle.folds.is_fold_start_candidate(i));
     let fold_col_w: u16 = if has_folds { FOLD_GUTTER_W } else { 0 };
-    let gw = gutter_width(total_lines);
+    // When a newer release is available, widen the line-number gutter just
+    // enough to fit `↑X.Y.Z` on row 0 so the badge never has to truncate.
+    let version_label = new_version.map(|v| format!("↑{v}"));
+    let gw = effective_gutter_width(total_lines, version_label.as_deref());
     let text_area = text_area(area, gw, git_col_w, diag_col_w, fold_col_w);
 
     // Build per-line diagnostic severity map (highest severity per line).
@@ -253,7 +257,21 @@ pub fn render(
         } else {
             line_num_style
         };
-        if vl.is_first_seg {
+        if screen_row == 0 && version_label.is_some() {
+            // Overlay the topmost gutter row with the "new release available"
+            // badge — the line number for this row gets replaced.
+            let label = version_label.as_deref().unwrap();
+            let badge_style = Style::default()
+                .fg(Color::Rgb(255, 230, 100))
+                .bg(Color::Rgb(80, 60, 0))
+                .add_modifier(Modifier::BOLD);
+            let mut padded = label.to_string();
+            let label_w = UnicodeWidthStr::width(label) as u16;
+            if label_w < gw {
+                padded.push_str(&" ".repeat((gw - label_w) as usize));
+            }
+            buf.set_string(gutter_x, y, &padded, badge_style);
+        } else if vl.is_first_seg {
             let num_str = format!("{:>width$}", line_idx + 1, width = gw as usize);
             buf.set_string(gutter_x, y, &num_str, num_style);
         } else {
@@ -567,6 +585,17 @@ pub fn gutter_width(total_lines: usize) -> u16 {
         (total_lines as f64).log10().floor() as u16 + 1
     };
     digits.max(1)
+}
+
+/// Line-number gutter width, widened to fit a row-0 badge such as the
+/// "new release available" indicator. Mouse hit-testing must use this so the
+/// text area's x-origin matches the renderer.
+pub fn effective_gutter_width(total_lines: usize, version_label: Option<&str>) -> u16 {
+    let base = gutter_width(total_lines);
+    match version_label {
+        Some(l) => base.max(UnicodeWidthStr::width(l) as u16),
+        None => base,
+    }
 }
 
 // ── Private helpers ───────────────────────────────────────────────────────────

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -219,6 +219,7 @@ pub fn render(state: &mut AppState, frame: &mut Frame) {
         state.search_state.as_ref(),
         &highlight_spans,
         state.git_gutter.as_ref(),
+        state.version_check.newer_version(),
         editor_focused,
         state.config.show_whitespace,
         state.config.tab_size,

--- a/src/version_check.rs
+++ b/src/version_check.rs
@@ -1,0 +1,181 @@
+//! Asynchronous "is there a newer version of `txt`?" check.
+//!
+//! `VersionChecker::spawn` returns immediately and starts a background thread
+//! that queries the GitHub Releases API for `ErikHellman/txt`. Any failure
+//! (no `curl`, no network, malformed JSON, non-200 response, …) is silent —
+//! nothing reaches the main thread and the editor behaves as if the feature
+//! had never been enabled.
+//!
+//! Honours `TXT_DISABLE_VERSION_CHECK` so the PTY-driven test harness stays
+//! deterministic and offline.
+
+use std::sync::mpsc::{self, Receiver, TryRecvError};
+use std::thread;
+
+const RELEASES_URL: &str = "https://api.github.com/repos/ErikHellman/txt/releases/latest";
+
+pub struct VersionChecker {
+    rx: Option<Receiver<String>>,
+    latest: Option<String>,
+}
+
+impl VersionChecker {
+    pub fn spawn() -> Self {
+        if std::env::var_os("TXT_DISABLE_VERSION_CHECK").is_some() {
+            return Self {
+                rx: None,
+                latest: None,
+            };
+        }
+        let (tx, rx) = mpsc::channel();
+        thread::spawn(move || {
+            if let Some(tag) = fetch_latest_tag() {
+                let _ = tx.send(tag.trim_start_matches('v').to_string());
+            }
+        });
+        Self {
+            rx: Some(rx),
+            latest: None,
+        }
+    }
+
+    /// Drain any pending message from the worker. Non-blocking.
+    pub fn poll(&mut self) {
+        let Some(rx) = self.rx.as_ref() else { return };
+        match rx.try_recv() {
+            Ok(v) => {
+                self.latest = Some(v);
+                self.rx = None;
+            }
+            Err(TryRecvError::Empty) => {}
+            Err(TryRecvError::Disconnected) => {
+                self.rx = None;
+            }
+        }
+    }
+
+    /// Latest tag, only when strictly newer than the built-in version.
+    pub fn newer_version(&self) -> Option<&str> {
+        let latest = self.latest.as_deref()?;
+        if is_strictly_newer(env!("CARGO_PKG_VERSION"), latest) {
+            Some(latest)
+        } else {
+            None
+        }
+    }
+}
+
+fn fetch_latest_tag() -> Option<String> {
+    use std::process::Command;
+    let ua = format!("txt/{}", env!("CARGO_PKG_VERSION"));
+    let output = Command::new("curl")
+        .args([
+            "-fsSL",
+            "--max-time",
+            "5",
+            "-H",
+            "Accept: application/vnd.github+json",
+            "-A",
+            &ua,
+            RELEASES_URL,
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let body = std::str::from_utf8(&output.stdout).ok()?;
+    let json: serde_json::Value = serde_json::from_str(body).ok()?;
+    Some(json.get("tag_name")?.as_str()?.to_string())
+}
+
+/// Strict semver-ish comparison. Numeric components are compared as integers;
+/// missing trailing components are treated as zero. Pre-release/build suffixes
+/// (`-rc1`, `+build`) are dropped so an unsuffixed `0.5.0` is not "newer" than
+/// `0.5.0-rc1`.
+pub fn is_strictly_newer(current: &str, latest: &str) -> bool {
+    let a = parse_parts(current);
+    let b = parse_parts(latest);
+    let n = a.len().max(b.len());
+    for i in 0..n {
+        let av = a.get(i).copied().unwrap_or(0);
+        let bv = b.get(i).copied().unwrap_or(0);
+        if bv > av {
+            return true;
+        }
+        if bv < av {
+            return false;
+        }
+    }
+    false
+}
+
+fn parse_parts(v: &str) -> Vec<u64> {
+    let v = v.trim_start_matches('v');
+    let v = v.split(['-', '+']).next().unwrap_or(v);
+    v.split('.').filter_map(|p| p.parse::<u64>().ok()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn newer_minor() {
+        assert!(is_strictly_newer("0.5.0", "0.6.0"));
+    }
+
+    #[test]
+    fn newer_patch() {
+        assert!(is_strictly_newer("0.5.0", "0.5.1"));
+    }
+
+    #[test]
+    fn newer_major() {
+        assert!(is_strictly_newer("0.5.9", "1.0.0"));
+    }
+
+    #[test]
+    fn equal_not_newer() {
+        assert!(!is_strictly_newer("0.5.0", "0.5.0"));
+    }
+
+    #[test]
+    fn older_not_newer() {
+        assert!(!is_strictly_newer("0.6.0", "0.5.9"));
+    }
+
+    #[test]
+    fn v_prefix_ok() {
+        assert!(is_strictly_newer("0.5.0", "v0.6.0"));
+        assert!(is_strictly_newer("v0.5.0", "0.6.0"));
+    }
+
+    #[test]
+    fn missing_components_treated_as_zero() {
+        assert!(!is_strictly_newer("0.5", "0.5.0"));
+        assert!(is_strictly_newer("0.5", "0.5.1"));
+    }
+
+    #[test]
+    fn prerelease_suffix_stripped() {
+        assert!(!is_strictly_newer("0.5.0", "0.5.0-rc1"));
+        assert!(is_strictly_newer("0.5.0-rc1", "0.5.1"));
+    }
+
+    #[test]
+    fn disabled_via_env_yields_no_news() {
+        // Safety: this test only reads the env var via Self::spawn, doesn't
+        // modify globals. The harness sets this var; ensure spawn produces an
+        // inert checker.
+        unsafe {
+            std::env::set_var("TXT_DISABLE_VERSION_CHECK", "1");
+        }
+        let mut vc = VersionChecker::spawn();
+        vc.poll();
+        assert!(vc.newer_version().is_none());
+        unsafe {
+            std::env::remove_var("TXT_DISABLE_VERSION_CHECK");
+        }
+    }
+}

--- a/tests/ui_common/harness.rs
+++ b/tests/ui_common/harness.rs
@@ -105,6 +105,7 @@ impl TxtSession {
         cmd.env("TXT_DISABLE_LSP", "1");
         cmd.env("TXT_DISABLE_GIT", "1");
         cmd.env("TXT_DISABLE_WATCHER", "1");
+        cmd.env("TXT_DISABLE_VERSION_CHECK", "1");
         // Avoid clipboard side-effects under the test runner.
         cmd.env("WAYLAND_DISPLAY", "");
         cmd.env("DISPLAY", "");


### PR DESCRIPTION
## Summary
Adds an asynchronous version checker that queries GitHub Releases API in a background thread and displays a "new release available" badge in the editor's top-left gutter when a newer version is detected.

## Key Changes
- **New `version_check` module**: Implements `VersionChecker` that spawns a background thread to fetch the latest release tag from GitHub's API via `curl`. Failures are silent and non-blocking. Respects `TXT_DISABLE_VERSION_CHECK` environment variable for deterministic testing.

- **Version comparison logic**: Implements semantic versioning comparison (`is_strictly_newer`) that:
  - Compares numeric version components as integers
  - Treats missing trailing components as zero
  - Strips pre-release/build suffixes so `0.5.0` is not newer than `0.5.0-rc1`
  - Handles `v` prefix normalization

- **UI integration**: 
  - Displays `↑X.Y.Z` badge in the line-number gutter at row 0 when a newer version is available
  - Uses distinctive styling (yellow text on dark brown background, bold)
  - Automatically widens the gutter to fit the badge without truncation

- **Layout consistency**: Introduces `effective_gutter_width()` helper that accounts for the version badge width, ensuring the gutter width is consistent between the renderer and mouse hit-testing logic.

- **AppState integration**: 
  - Adds `version_check` field to `AppState`
  - Calls `version_check.poll()` on each render frame to drain pending messages from the background thread
  - Provides `version_badge()` method for layout calculations

- **Test harness**: Disables version checking in the PTY-driven test harness via `TXT_DISABLE_VERSION_CHECK` environment variable to maintain determinism and offline operation.

## Implementation Details
- Version checking is non-blocking: `VersionChecker::spawn()` returns immediately and the background thread communicates via `mpsc::channel`
- `poll()` uses non-blocking `try_recv()` to check for results without stalling the UI
- All network/parsing failures are silently ignored—the feature degrades gracefully
- The badge only appears when the fetched version is strictly newer than the built-in version

https://claude.ai/code/session_015t2omeqHU3qiuw7ptAZGBv