### PR TITLE
Coalesce scroll events to prevent input starvation

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -5478,6 +5478,64 @@ impl AppState {
             .clamp_user_scroll(total_lines, longest, text_h, text_w);
     }
 
+    /// Returns `true` when `action` is a vertical scroll that the viewport
+    /// (or sidebar) can't honour because it's already at the corresponding
+    /// edge. Used by the run loop to drop end-of-buffer wheel spam before
+    /// it ever reaches `update` and triggers a redraw.
+    ///
+    /// Horizontal and non-scroll actions always return `false` — the
+    /// horizontal case would need an O(n) max-line-width scan per event,
+    /// which is more expensive than letting `update` handle it normally.
+    pub(crate) fn scroll_action_is_no_op(
+        &self,
+        action: &EditorAction,
+        terminal_height: u16,
+    ) -> bool {
+        let dir = match action {
+            EditorAction::Scroll(d) => *d,
+            EditorAction::MouseScroll { dir, col, row } => {
+                if self.point_in_sidebar(*col, *row) {
+                    return self.sidebar_scroll_is_no_op(*dir);
+                }
+                *dir
+            }
+            _ => return false,
+        };
+
+        // Match the value `update` derives for scroll handlers.
+        let text_h = (terminal_height as usize).saturating_sub(1);
+        let tab = self.editor.active();
+        let vp = &tab.viewport;
+        let total_lines = tab.buffer.len_lines();
+        let max_row = total_lines.saturating_sub(1).saturating_sub(text_h / 2);
+
+        match dir {
+            ScrollDir::Up | ScrollDir::HalfPageUp => vp.scroll_row == 0,
+            ScrollDir::Down | ScrollDir::HalfPageDown => vp.scroll_row >= max_row,
+            ScrollDir::Left | ScrollDir::Right => false,
+        }
+    }
+
+    /// Whether a wheel-scroll over the sidebar would be a no-op (already at
+    /// top or already past the end of the entry list).
+    fn sidebar_scroll_is_no_op(&self, dir: ScrollDir) -> bool {
+        let sb = match self.sidebar.as_ref() {
+            Some(sb) => sb,
+            None => return true,
+        };
+        let h = self.sidebar_area.map(|r| r.height as usize).unwrap_or(0);
+        let max = if h == 0 || sb.entries.len() <= h {
+            0
+        } else {
+            sb.entries.len() - h
+        };
+        match dir {
+            ScrollDir::Up => sb.scroll_offset == 0,
+            ScrollDir::Down => sb.scroll_offset >= max,
+            _ => true,
+        }
+    }
+
     /// Returns true if the given screen point is inside the sidebar's
     /// entry-list area (excludes the separator column).
     fn point_in_sidebar(&self, col: u16, row: u16) -> bool {
@@ -5692,14 +5750,33 @@ impl App {
                 continue;
             }
 
-            let action = match event::read()? {
-                Event::Key(k) if k.kind == KeyEventKind::Press => state.input.handle_key(k),
-                Event::Mouse(m) => state.input.handle_mouse(m),
-                Event::Resize(_, _) => EditorAction::Unhandled,
-                _ => EditorAction::Unhandled,
-            };
-
-            state.update(action, term_height);
+            // Drain everything already queued up before the next draw. A
+            // mouse-wheel spin or held arrow key can generate input faster
+            // than a single frame can render, so without this the editor
+            // falls one render behind every event and visibly "freezes"
+            // while it catches up — keystrokes queued behind a scroll
+            // burst then take ages to register.
+            //
+            // A scroll the viewport can't honour (already at the top or
+            // bottom) is dropped before it reaches `update`, so a held
+            // wheel at end-of-file costs nothing.
+            loop {
+                let action = match event::read()? {
+                    Event::Key(k) if k.kind == KeyEventKind::Press => state.input.handle_key(k),
+                    Event::Mouse(m) => state.input.handle_mouse(m),
+                    Event::Resize(_, _) => EditorAction::Unhandled,
+                    _ => EditorAction::Unhandled,
+                };
+                if !state.scroll_action_is_no_op(&action, term_height) {
+                    state.update(action, term_height);
+                    if state.should_quit {
+                        break;
+                    }
+                }
+                if !event::poll(Duration::from_millis(0))? {
+                    break;
+                }
+            }
 
             if state.should_quit {
                 break;

--- a/tests/ui_scrolling.rs
+++ b/tests/ui_scrolling.rs
@@ -1,0 +1,109 @@
+#![cfg(feature = "ui-tests")]
+
+mod ui_common;
+
+use ui_common::{Arrow, Fixture, Key};
+
+/// A long file scrolls down when Ctrl+Down is pressed enough times.
+#[test]
+fn scroll_ctrl_down_moves_viewport() {
+    let fx = Fixture::new();
+    let body: String = (1..=200).map(|i| format!("line {i}\n")).collect();
+    let path = fx.write_file("long.txt", &body);
+    let s = fx.open(&path);
+    s.wait_for_status_contains("1:1");
+
+    // Pre-condition: "line 1" is visible on its own row.
+    s.wait_until(
+        |sc| {
+            sc.contents()
+                .lines()
+                .any(|l| l.trim_end().ends_with("line 1"))
+        },
+        std::time::Duration::from_secs(5),
+    );
+
+    // Ctrl+Down scrolls the viewport (default `SCROLL_LINES` = 3 per press).
+    // 20 presses moves the viewport ~60 lines down, well past the first row.
+    let mut s = s;
+    for _ in 0..20 {
+        s.send_key(Key::CtrlArrow(Arrow::Down));
+    }
+    s.wait_until(
+        |sc| {
+            !sc.contents()
+                .lines()
+                .any(|l| l.trim_end().ends_with("line 1"))
+        },
+        std::time::Duration::from_secs(5),
+    );
+
+    s.shutdown();
+}
+
+/// A flood of scroll events at the end of the file is drained without
+/// freezing other input: the very next keystroke after the spam still
+/// takes effect promptly.
+///
+/// Without coalescing and no-op detection this would push the editor
+/// many render cycles behind and Ctrl+Home would feel "stuck" until the
+/// queue drains.
+#[test]
+fn scroll_burst_past_end_does_not_block_other_keys() {
+    let fx = Fixture::new();
+    let body: String = (1..=200).map(|i| format!("line {i}\n")).collect();
+    let path = fx.write_file("long.txt", &body);
+    let mut s = fx.open(&path);
+    s.wait_for_status_contains("1:1");
+
+    // Send hundreds of Ctrl+Down at once. 200 lines / 3-per-scroll → the
+    // viewport saturates after ~67 events; the rest hit the no-op path
+    // in `AppState::scroll_action_is_no_op`.
+    let keys: Vec<Key> = std::iter::repeat(Key::CtrlArrow(Arrow::Down))
+        .take(300)
+        .collect();
+    s.send_keys(&keys);
+
+    // The follow-up keystroke must register without being starved by the
+    // backlog of dropped scrolls.
+    s.send_key(Key::CtrlArrow(Arrow::Home));
+    s.wait_for_status_contains("1:1");
+    s.wait_until(
+        |sc| {
+            sc.contents()
+                .lines()
+                .any(|l| l.trim_end().ends_with("line 1"))
+        },
+        std::time::Duration::from_secs(5),
+    );
+
+    s.shutdown();
+}
+
+/// Scrolling up when already at the top is a no-op and never moves the
+/// cursor either (`Scroll` is independent from cursor motion).
+#[test]
+fn scroll_up_at_top_is_a_no_op() {
+    let fx = Fixture::new();
+    let body: String = (1..=200).map(|i| format!("line {i}\n")).collect();
+    let path = fx.write_file("long.txt", &body);
+    let mut s = fx.open(&path);
+    s.wait_for_status_contains("1:1");
+
+    for _ in 0..50 {
+        s.send_key(Key::CtrlArrow(Arrow::Up));
+    }
+    // Cursor must still be on line 1, column 1.
+    s.assert_status_contains("1:1");
+    // "line 1" remains visible.
+    s.wait_until(
+        |sc| {
+            sc.contents()
+                .lines()
+                .any(|l| l.trim_end().ends_with("line 1"))
+        },
+        std::time::Duration::from_secs(5),
+    );
+
+    s.shutdown();
+}


### PR DESCRIPTION
## Summary

Implement scroll event coalescing and no-op detection to prevent the editor from falling behind when receiving rapid scroll input (e.g., mouse wheel spam or held arrow keys). This ensures that keystrokes queued behind a scroll burst register promptly instead of being starved by a backlog of redundant render cycles.

## Changes

- **`AppState::scroll_action_is_no_op()`**: New public method that detects when a vertical scroll action cannot be honoured because the viewport is already at the corresponding edge (top or bottom). Handles both regular scrolls and mouse wheel events, with special logic for sidebar scrolling.

- **`AppState::sidebar_scroll_is_no_op()`**: New private helper that determines whether a wheel-scroll over the sidebar would be a no-op (already at top or past the end of the entry list).

- **Event loop refactoring in `App::run()`**: Changed from processing a single event per frame to draining all queued events before the next draw. A tight loop now:
  - Reads all available input without blocking
  - Filters out no-op scrolls before they reach `update()` and trigger a redraw
  - Breaks when the input queue is empty or `should_quit` is set
  - Uses `event::poll(Duration::from_millis(0))` to check for pending input without blocking

- **UI tests**: Added three comprehensive integration tests (`tests/ui_scrolling.rs`):
  - `scroll_ctrl_down_moves_viewport`: Verifies that repeated Ctrl+Down scrolls the viewport correctly
  - `scroll_burst_past_end_does_not_block_other_keys`: Confirms that 300 rapid scroll events at end-of-file don't starve a follow-up Ctrl+Home keystroke
  - `scroll_up_at_top_is_a_no_op`: Ensures scrolling up at the top is a true no-op with no side effects

## Implementation Details

The no-op detection mirrors the scroll logic in `update()` by computing the same `max_row` threshold and comparing against the current `viewport.scroll_row`. Horizontal scrolls always return `false` to avoid the O(n) cost of scanning for max line width per event — the normal `update()` path handles them efficiently.

The event loop now processes input in a tight loop that drains the queue before rendering, which is more efficient than blocking on a single event and allows the renderer to catch up when input arrives faster than frames can be drawn.

https://claude.ai/code/session_01DPXyuwXxyGvJ4ghmzDEybn