### PR TITLE
Consolidate duplicated overlay chrome, batch edits, and modal input

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,13 +89,34 @@ Actions are intercepted in this order — higher priority handlers `return` earl
 - Syntax highlights are computed only for the visible viewport range — never for the full file.
 - Tree-sitter parsing is synchronous and runs after every edit (`SyntaxHost::reparse_rope()`).
 
+## Shared helpers
+
+When you find yourself reaching for one of these patterns, check the helper first instead of reimplementing:
+
+| Need | Use |
+|---|---|
+| Draw a rounded border around an overlay | `crate::ui::overlay_chrome::draw_border` |
+| Draw `├─────┤` row inside an overlay | `crate::ui::overlay_chrome::draw_h_separator` |
+| Paint a solid background fill | `crate::ui::overlay_chrome::fill_rect` |
+| Centre a title row in an overlay | `crate::ui::overlay_chrome::render_centered_header` |
+| Truncate by terminal columns (grapheme-aware) | `crate::ui::text_utils::truncate_to_width` |
+| Truncate by byte budget at a char boundary | `crate::ui::text_utils::truncate_bytes` |
+| Keep the right side of a path/breadcrumb | `crate::ui::text_utils::truncate_left_keep_right` |
+| Mutate the prompt buffer in any string-carrying `InputMode` | `InputMode::string_mut` |
+| Wrap multi-op edits in a single undo entry | `Buffer::in_batch(\|buf\| { … })` — closure form, can't leak |
+| Insert/delete/replace + record history atomically | `Buffer::recorded_insert` / `recorded_delete` / `recorded_replace` |
+| Scroll a centred overlay on Up/Down/Page/wheel input | `scroll_action(&action, &mut self.x_scroll)` in `app.rs` |
+
 ## Extension points
 
 **New UI overlay:**
-Follow `src/ui/fuzzy_picker.rs` or `src/ui/help_overlay.rs` — centered float rendered last in `ui::render()`, `Option<State>` field on `AppState`, handler that returns `bool` wired into the priority chain above.
+Follow `src/ui/fuzzy_picker.rs` or `src/ui/help_overlay.rs` — centered float rendered last in `ui::render()`, `Option<State>` field on `AppState`, handler that returns `bool` wired into the priority chain above. Use the helpers in `src/ui/overlay_chrome.rs` so the chrome stays consistent.
 
 **New key binding:**
 Add to `src/input/mod.rs` (`handle_key`, `handle_ctrl_char`, or `handle_ctrl_shift_char`) and add a corresponding entry to the `ENTRIES` array in `src/ui/help_overlay.rs`.
+
+**New `InputMode` prompt variant:**
+If the variant carries an editable `String`, add it to the match in `InputMode::string_mut` so the shared `handle_modal_input` InsertChar/DeleteBackward path operates on it automatically.
 
 **Config & data files** (runtime, not source):
 - Config: `~/.config/txt/config.toml`

--- a/src/app.rs
+++ b/src/app.rs
@@ -31,6 +31,43 @@ use crate::{
 /// The scroll amount for a single scroll-wheel tick or Ctrl+Up/Down.
 const SCROLL_LINES: usize = 3;
 
+/// Translate an action into a scroll-position update for a centred-overlay
+/// scroll counter. Returns `true` if the action was a scroll input that the
+/// caller should consume; on `false` the caller can run its own match arms.
+///
+/// One line per arrow tick, ten lines per page key, `SCROLL_LINES` per
+/// mouse-wheel tick. Saturates at zero; the upper bound is clamped by the
+/// renderer.
+fn scroll_action(action: &EditorAction, scroll: &mut usize) -> bool {
+    match action {
+        EditorAction::MoveCursor(Direction::Up) => {
+            *scroll = scroll.saturating_sub(1);
+            true
+        }
+        EditorAction::MoveCursor(Direction::Down) => {
+            *scroll = scroll.saturating_add(1);
+            true
+        }
+        EditorAction::MoveCursorPage(Direction::Up) => {
+            *scroll = scroll.saturating_sub(10);
+            true
+        }
+        EditorAction::MoveCursorPage(Direction::Down) => {
+            *scroll = scroll.saturating_add(10);
+            true
+        }
+        EditorAction::MouseScroll { dir, .. } => {
+            match dir {
+                ScrollDir::Up => *scroll = scroll.saturating_sub(SCROLL_LINES),
+                ScrollDir::Down => *scroll = scroll.saturating_add(SCROLL_LINES),
+                _ => {}
+            }
+            true
+        }
+        _ => false,
+    }
+}
+
 /// Default sidebar width in terminal columns. The active width is stored on
 /// `AppState::sidebar_width` so the user can resize by dragging the separator.
 pub const DEFAULT_SIDEBAR_WIDTH: u16 = 28;
@@ -95,6 +132,33 @@ pub enum InputMode {
 impl InputMode {
     pub fn is_normal(&self) -> bool {
         matches!(self, InputMode::Normal)
+    }
+
+    /// Mutable access to the prompt buffer for string-carrying variants.
+    ///
+    /// Used by `handle_modal_input` to share a single InsertChar/DeleteBackward
+    /// code path across every text-entry prompt. Returns `None` for variants
+    /// that don't store an editable string (Normal, *Char variants).
+    pub fn string_mut(&mut self) -> Option<&mut String> {
+        match self {
+            InputMode::JumpToLine(s)
+            | InputMode::OpenFilePath(s)
+            | InputMode::SaveAsPath(s)
+            | InputMode::RenamePath(_, s)
+            | InputMode::NewFolderName(_, s)
+            | InputMode::Rename(s)
+            | InputMode::GitCommitMessage(s)
+            | InputMode::GitNewBranch(s)
+            | InputMode::GitStashMessage(s)
+            | InputMode::ShellFilter(s)
+            | InputMode::AlignChar(s) => Some(s),
+            InputMode::Normal
+            | InputMode::SetMarkChar
+            | InputMode::JumpToMarkChar
+            | InputMode::RecordMacroChar
+            | InputMode::ReplayMacroChar
+            | InputMode::SurroundChar => None,
+        }
     }
 }
 
@@ -2399,47 +2463,19 @@ impl AppState {
         // Mutate the input string for typing/backspace without accessing other fields.
         match action {
             EditorAction::InsertChar(c) => {
-                match &mut self.input_mode {
-                    InputMode::JumpToLine(s) if c.is_ascii_digit() || c == ':' => {
-                        s.push(c);
-                    }
-                    InputMode::OpenFilePath(s)
-                    | InputMode::SaveAsPath(s)
-                    | InputMode::RenamePath(_, s)
-                    | InputMode::NewFolderName(_, s)
-                    | InputMode::Rename(s)
-                    | InputMode::GitCommitMessage(s)
-                    | InputMode::GitNewBranch(s)
-                    | InputMode::GitStashMessage(s)
-                    | InputMode::ShellFilter(s)
-                    | InputMode::AlignChar(s) => {
-                        s.push(c);
-                    }
-                    _ => {}
+                // JumpToLine only accepts digits and `:`; every other
+                // string-carrying mode accepts any char.
+                let allow = !matches!(&self.input_mode, InputMode::JumpToLine(_))
+                    || c.is_ascii_digit()
+                    || c == ':';
+                if allow && let Some(s) = self.input_mode.string_mut() {
+                    s.push(c);
                 }
                 return;
             }
             EditorAction::DeleteBackward => {
-                match &mut self.input_mode {
-                    InputMode::JumpToLine(s)
-                    | InputMode::OpenFilePath(s)
-                    | InputMode::SaveAsPath(s)
-                    | InputMode::RenamePath(_, s)
-                    | InputMode::NewFolderName(_, s)
-                    | InputMode::Rename(s)
-                    | InputMode::GitCommitMessage(s)
-                    | InputMode::GitNewBranch(s)
-                    | InputMode::GitStashMessage(s)
-                    | InputMode::ShellFilter(s)
-                    | InputMode::AlignChar(s) => {
-                        s.pop();
-                    }
-                    InputMode::Normal
-                    | InputMode::SetMarkChar
-                    | InputMode::JumpToMarkChar
-                    | InputMode::RecordMacroChar
-                    | InputMode::ReplayMacroChar
-                    | InputMode::SurroundChar => {}
+                if let Some(s) = self.input_mode.string_mut() {
+                    s.pop();
                 }
                 return;
             }
@@ -3117,35 +3153,10 @@ impl AppState {
     /// (Enter / Esc / F1 / Ctrl+Q-style ToggleHelp) dismisses it; arrows and
     /// the mouse wheel scroll its content. Returns `true` to consume.
     fn handle_welcome(&mut self, action: &EditorAction) -> bool {
+        if scroll_action(action, &mut self.welcome_scroll) {
+            return true;
+        }
         match action {
-            EditorAction::MoveCursor(Direction::Up) => {
-                self.welcome_scroll = self.welcome_scroll.saturating_sub(1);
-                true
-            }
-            EditorAction::MoveCursor(Direction::Down) => {
-                self.welcome_scroll = self.welcome_scroll.saturating_add(1);
-                true
-            }
-            EditorAction::MoveCursorPage(Direction::Up) => {
-                self.welcome_scroll = self.welcome_scroll.saturating_sub(10);
-                true
-            }
-            EditorAction::MoveCursorPage(Direction::Down) => {
-                self.welcome_scroll = self.welcome_scroll.saturating_add(10);
-                true
-            }
-            EditorAction::MouseScroll { dir, .. } => {
-                match dir {
-                    ScrollDir::Up => {
-                        self.welcome_scroll = self.welcome_scroll.saturating_sub(SCROLL_LINES);
-                    }
-                    ScrollDir::Down => {
-                        self.welcome_scroll = self.welcome_scroll.saturating_add(SCROLL_LINES);
-                    }
-                    _ => {}
-                }
-                true
-            }
             EditorAction::InsertNewline | EditorAction::CloseSearch => {
                 self.show_welcome = false;
                 self.record_version_seen();
@@ -3160,35 +3171,10 @@ impl AppState {
     /// Handle input while the changelog overlay is visible. Same dismiss /
     /// scroll semantics as the welcome overlay.
     fn handle_changelog(&mut self, action: &EditorAction) -> bool {
+        if scroll_action(action, &mut self.changelog_scroll) {
+            return true;
+        }
         match action {
-            EditorAction::MoveCursor(Direction::Up) => {
-                self.changelog_scroll = self.changelog_scroll.saturating_sub(1);
-                true
-            }
-            EditorAction::MoveCursor(Direction::Down) => {
-                self.changelog_scroll = self.changelog_scroll.saturating_add(1);
-                true
-            }
-            EditorAction::MoveCursorPage(Direction::Up) => {
-                self.changelog_scroll = self.changelog_scroll.saturating_sub(10);
-                true
-            }
-            EditorAction::MoveCursorPage(Direction::Down) => {
-                self.changelog_scroll = self.changelog_scroll.saturating_add(10);
-                true
-            }
-            EditorAction::MouseScroll { dir, .. } => {
-                match dir {
-                    ScrollDir::Up => {
-                        self.changelog_scroll = self.changelog_scroll.saturating_sub(SCROLL_LINES);
-                    }
-                    ScrollDir::Down => {
-                        self.changelog_scroll = self.changelog_scroll.saturating_add(SCROLL_LINES);
-                    }
-                    _ => {}
-                }
-                true
-            }
             EditorAction::InsertNewline | EditorAction::CloseSearch => {
                 self.show_changelog = false;
                 self.record_version_seen();
@@ -3202,41 +3188,16 @@ impl AppState {
     /// Handle input while the help overlay is visible.
     /// Returns `true` if the action was consumed (caller should `return`).
     fn handle_help(&mut self, action: &EditorAction) -> bool {
+        if scroll_action(action, &mut self.help_scroll) {
+            return true;
+        }
         match action {
-            EditorAction::MoveCursor(Direction::Up) => {
-                self.help_scroll = self.help_scroll.saturating_sub(1);
-                true
-            }
-            EditorAction::MoveCursor(Direction::Down) => {
-                self.help_scroll = self.help_scroll.saturating_add(1);
-                true
-            }
-            EditorAction::MoveCursorPage(Direction::Up) => {
-                self.help_scroll = self.help_scroll.saturating_sub(10);
-                true
-            }
-            EditorAction::MoveCursorPage(Direction::Down) => {
-                self.help_scroll = self.help_scroll.saturating_add(10);
-                true
-            }
             EditorAction::MoveCursorFileStart => {
                 self.help_scroll = 0;
                 true
             }
             EditorAction::MoveCursorFileEnd => {
                 self.help_scroll = usize::MAX; // clamped in render
-                true
-            }
-            EditorAction::MouseScroll { dir, .. } => {
-                match dir {
-                    ScrollDir::Up => {
-                        self.help_scroll = self.help_scroll.saturating_sub(SCROLL_LINES);
-                    }
-                    ScrollDir::Down => {
-                        self.help_scroll = self.help_scroll.saturating_add(SCROLL_LINES);
-                    }
-                    _ => {}
-                }
                 true
             }
             EditorAction::ToggleHelp | EditorAction::CloseSearch => {

--- a/src/buffer/CLAUDE.md
+++ b/src/buffer/CLAUDE.md
@@ -1,0 +1,41 @@
+# src/buffer — rope, cursors, undo
+
+The rope and its cursors live here. Everything outside `src/buffer/` must go through `Buffer`'s public API; reach for the underlying `ropey::Rope` directly only inside this directory.
+
+## Critical invariants (also in root CLAUDE.md)
+
+- **Byte offsets only.** Every cursor/range/edit is in byte offsets, never char offsets. Round-trip via `rope.byte_to_char()` / `rope.char_to_byte()` only when ropey forces it.
+- **Char boundaries.** `Cursor::byte_offset` must always be a valid UTF-8 char boundary.
+- **Sorted cursors.** `MultiCursor::cursors` is sorted by `byte_offset`; overlapping selections merge on insert.
+- **Selection normalisation.** `Selection::anchor` is fixed, `active` moves. Range ops always normalise to `start ≤ end`.
+
+Breaking any of these will not produce a compile error but will silently corrupt cursor placement or selections.
+
+## Edit + history coupling
+
+Every rope mutation must be recorded in the undo history *and* the pending-edits queue (so off-buffer trackers — marks, jumps, fold ranges — can adjust their byte offsets). The helpers that do both atomically:
+
+- **`Buffer::recorded_insert(at, text)`** — rope `insert` + `EditCommand::Insert`.
+- **`Buffer::recorded_delete(start, end)`** — rope `delete` + `EditCommand::Delete`. Returns the deleted text.
+- **`Buffer::recorded_replace(start, end, new_text)`** — rope `replace` + `EditCommand::Replace`. Returns the replaced text.
+
+Always use these. Calling `rope_edit::insert` (or `::delete`, `::replace`) directly is reserved for the undo/redo apply path in `Buffer::apply_command_*`, which deliberately bypasses recording to avoid double-undo entries.
+
+## Batches
+
+Multi-op edits that should undo as a single entry must wrap the recordings in a batch. The closure form is the only safe one — it cannot leak an open batch on early return:
+
+```rust
+self.in_batch(|buf| {
+    buf.recorded_delete(start, end);
+    buf.recorded_insert(start, &replacement);
+});
+```
+
+`begin_batch` / `commit_batch` still exist on `Buffer` (public) for external callers in `app.rs`, but new code inside `Buffer` should use `in_batch`. The historical `BatchGuard` struct was removed — it was a no-op stub with no real RAII.
+
+## When extending
+
+- Adding a new editing operation? Reach for `recorded_*` and `in_batch`. Do not duplicate `record(&mut self.history, &mut self.pending_edits, ...)` calls.
+- Adding a new cursor mutation? Re-normalise (`MultiCursor::normalize()` does sort + dedup) after the mutation so the sorted/non-overlap invariant holds.
+- Adding a new undo-able command type? Update `EditCommand`, the apply/inverse paths in `Buffer::apply_command_forward` and `Buffer::apply_command_inverse`, and add a `recorded_*` helper that ties it to history.

--- a/src/buffer/history.rs
+++ b/src/buffer/history.rs
@@ -1,7 +1,7 @@
 //! Undo/redo history for the text buffer.
 //!
 //! Uses the Command pattern: every edit is recorded as an `EditCommand` that
-//! knows how to undo itself. A `BatchGuard` groups multiple commands into one
+//! knows how to undo itself. `begin_batch` / `commit_batch` group commands into one
 //! logical undo step (e.g., Replace All).
 
 use serde::{Deserialize, Serialize};
@@ -71,7 +71,7 @@ pub struct UndoStack {
     undo_stack: Vec<UndoEntry>,
     /// Future commands (after an undo). Cleared whenever a new edit is made.
     redo_stack: Vec<UndoEntry>,
-    /// Accumulator for the current batch (Some while a BatchGuard is alive).
+    /// Accumulator for the current batch (Some between begin_batch/commit_batch).
     current_batch: Option<Vec<EditCommand>>,
     /// Maximum number of entries on the undo stack. Oldest are dropped when
     /// exceeded.
@@ -208,40 +208,6 @@ pub struct UndoStackSnapshot {
 impl Default for UndoStack {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-/// RAII guard that keeps a batch open for its lifetime.
-///
-/// Commit by calling `guard.commit(stack)`. If dropped without committing, the
-/// batch is aborted. Typical usage:
-///
-/// ```ignore
-/// let guard = BatchGuard::begin(&mut stack);
-/// // ... record commands ...
-/// guard.commit(&mut stack);
-/// ```
-#[allow(dead_code)]
-pub struct BatchGuard;
-
-#[allow(dead_code)]
-impl BatchGuard {
-    pub fn begin(stack: &mut UndoStack) -> Self {
-        stack.begin_batch();
-        Self
-    }
-
-    pub fn commit(self, stack: &mut UndoStack) {
-        stack.commit_batch();
-        std::mem::forget(self); // prevent Drop from aborting
-    }
-}
-
-impl Drop for BatchGuard {
-    fn drop(&mut self) {
-        // If not committed, the caller should have called commit() or explicitly abort.
-        // We can't access the stack here; callers must be careful.
-        // In practice, always call .commit() before the guard goes out of scope.
     }
 }
 

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -71,6 +71,68 @@ fn record(history: &mut UndoStack, pending: &mut Vec<EditCommand>, cmd: EditComm
 }
 
 impl Buffer {
+    /// Insert `text` at byte offset `at` and record the matching
+    /// `EditCommand::Insert` for undo and off-buffer trackers. Pairs the
+    /// rope mutation with history recording so the two can't drift apart.
+    fn recorded_insert(&mut self, at: usize, text: &str) {
+        rope_edit::insert(&mut self.rope, at, text);
+        record(
+            &mut self.history,
+            &mut self.pending_edits,
+            EditCommand::Insert {
+                at,
+                text: text.to_string(),
+            },
+        );
+    }
+
+    /// Delete bytes `[start, end)` and record the matching
+    /// `EditCommand::Delete`. Returns the deleted text (also stored on the
+    /// recorded command, so the caller rarely needs the return value).
+    fn recorded_delete(&mut self, start: usize, end: usize) -> String {
+        let deleted = rope_edit::delete(&mut self.rope, start, end);
+        record(
+            &mut self.history,
+            &mut self.pending_edits,
+            EditCommand::Delete {
+                start,
+                end,
+                deleted: deleted.clone(),
+            },
+        );
+        deleted
+    }
+
+    /// Run `f` between `begin_batch` and `commit_batch` so every recorded
+    /// edit inside the closure collapses into a single undo entry. The batch
+    /// is always committed when `f` returns — callers can no longer leak an
+    /// open batch by forgetting a `commit_batch` call on an early return.
+    fn in_batch<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
+        self.history.begin_batch();
+        let r = f(self);
+        self.history.commit_batch();
+        r
+    }
+
+    /// Replace bytes `[start, end)` with `new_text` and record the matching
+    /// `EditCommand::Replace`.
+    fn recorded_replace(&mut self, start: usize, end: usize, new_text: &str) -> String {
+        let old_text = rope_edit::replace(&mut self.rope, start, end, new_text);
+        record(
+            &mut self.history,
+            &mut self.pending_edits,
+            EditCommand::Replace {
+                start,
+                end,
+                old_text: old_text.clone(),
+                new_text: new_text.to_string(),
+            },
+        );
+        old_text
+    }
+}
+
+impl Buffer {
     // ------------------------------------------------------------------ //
     // Rope accessors (read-only)
     // ------------------------------------------------------------------ //
@@ -252,32 +314,15 @@ impl Buffer {
         let cursor = self.cursors.primary_mut();
         let at = if cursor.has_selection() {
             let range = cursor.selection_bytes();
-            let deleted = rope_edit::delete(&mut self.rope, range.start, range.end);
-            record(
-                &mut self.history,
-                &mut self.pending_edits,
-                EditCommand::Delete {
-                    start: range.start,
-                    end: range.end,
-                    deleted,
-                },
-            );
             cursor.byte_offset = range.start;
             cursor.selection = None;
+            self.recorded_delete(range.start, range.end);
             range.start
         } else {
             cursor.byte_offset
         };
 
-        rope_edit::insert(&mut self.rope, at, text);
-        record(
-            &mut self.history,
-            &mut self.pending_edits,
-            EditCommand::Insert {
-                at,
-                text: text.to_string(),
-            },
-        );
+        self.recorded_insert(at, text);
 
         // Move cursor to after the inserted text
         let new_offset = at + text.len();
@@ -324,16 +369,7 @@ impl Buffer {
         if start == end {
             return;
         }
-        let deleted = rope_edit::delete(&mut self.rope, start, end);
-        record(
-            &mut self.history,
-            &mut self.pending_edits,
-            EditCommand::Delete {
-                start,
-                end,
-                deleted,
-            },
-        );
+        self.recorded_delete(start, end);
         *self.cursors.primary_mut() = Cursor::from_byte_offset(&self.rope, start);
         self.cursors.primary_mut().selection = None;
         self.modified = true;
@@ -398,27 +434,19 @@ impl Buffer {
             tracked.push(s.active);
         }
 
-        self.history.begin_batch();
-        // Insert at each line's start, descending so earlier line offsets stay
-        // valid for the next iteration.
-        for line in (first_line..=last_line).rev() {
-            let start = self.line_start_byte(line);
-            rope_edit::insert(&mut self.rope, start, &unit);
-            record(
-                &mut self.history,
-                &mut self.pending_edits,
-                EditCommand::Insert {
-                    at: start,
-                    text: unit.clone(),
-                },
-            );
-            for off in tracked.iter_mut() {
-                if *off >= start {
-                    *off += unit_bytes;
+        self.in_batch(|buf| {
+            // Insert at each line's start, descending so earlier line offsets
+            // stay valid for the next iteration.
+            for line in (first_line..=last_line).rev() {
+                let start = buf.line_start_byte(line);
+                buf.recorded_insert(start, &unit);
+                for off in tracked.iter_mut() {
+                    if *off >= start {
+                        *off += unit_bytes;
+                    }
                 }
             }
-        }
-        self.history.commit_batch();
+        });
 
         let new_offset = tracked[0];
         *self.cursors.primary_mut() = Cursor::from_byte_offset(&self.rope, new_offset);
@@ -459,31 +487,22 @@ impl Buffer {
             tracked.push(s.active);
         }
 
-        self.history.begin_batch();
-        // Apply highest-offset deletions first so earlier offsets stay valid.
-        for (start, strip) in strips.iter().rev() {
-            let end = start + strip.len();
-            let deleted = rope_edit::delete(&mut self.rope, *start, end);
-            record(
-                &mut self.history,
-                &mut self.pending_edits,
-                EditCommand::Delete {
-                    start: *start,
-                    end,
-                    deleted,
-                },
-            );
-            let strip_len = strip.len();
-            for off in tracked.iter_mut() {
-                if *off >= end {
-                    *off -= strip_len;
-                } else if *off > *start {
-                    // Was inside the stripped whitespace — clamp to start.
-                    *off = *start;
+        self.in_batch(|buf| {
+            // Apply highest-offset deletions first so earlier offsets stay valid.
+            for (start, strip) in strips.iter().rev() {
+                let end = start + strip.len();
+                buf.recorded_delete(*start, end);
+                let strip_len = strip.len();
+                for off in tracked.iter_mut() {
+                    if *off >= end {
+                        *off -= strip_len;
+                    } else if *off > *start {
+                        // Was inside the stripped whitespace — clamp to start.
+                        *off = *start;
+                    }
                 }
             }
-        }
-        self.history.commit_batch();
+        });
 
         let new_offset = tracked[0];
         *self.cursors.primary_mut() = Cursor::from_byte_offset(&self.rope, new_offset);
@@ -509,14 +528,16 @@ impl Buffer {
             self.insert_char(c);
             return;
         }
-        let cursor = self.cursors.primary();
-        if cursor.has_selection() {
+        let (line, cursor_byte_offset, has_sel) = {
+            let cursor = self.cursors.primary();
+            (cursor.line, cursor.byte_offset, cursor.has_selection())
+        };
+        if has_sel {
             self.insert_char(c);
             return;
         }
-        let line = cursor.line;
         let line_start = self.line_start_byte(line);
-        let prefix_bytes = cursor.byte_offset - line_start;
+        let prefix_bytes = cursor_byte_offset - line_start;
         let line_str = self.line_str(line);
         let prefix = &line_str[..prefix_bytes.min(line_str.len())];
         if prefix.is_empty() || !prefix.chars().all(|ch| ch == ' ' || ch == '\t') {
@@ -528,25 +549,16 @@ impl Buffer {
             self.insert_char(c);
             return;
         }
-        self.history.begin_batch();
         let strip_end = line_start + strip.len();
-        let deleted = rope_edit::delete(&mut self.rope, line_start, strip_end);
-        record(
-            &mut self.history,
-            &mut self.pending_edits,
-            EditCommand::Delete {
-                start: line_start,
-                end: strip_end,
-                deleted,
-            },
-        );
-        let new_offset = cursor.byte_offset - strip.len();
-        *self.cursors.primary_mut() = Cursor::from_byte_offset(&self.rope, new_offset);
+        let new_offset = cursor_byte_offset - strip.len();
         let mut s = String::with_capacity(c.len_utf8());
         s.push(c);
-        // insert_str handles cursor advance + history recording.
-        self.insert_str(&s);
-        self.history.commit_batch();
+        self.in_batch(|buf| {
+            buf.recorded_delete(line_start, strip_end);
+            *buf.cursors.primary_mut() = Cursor::from_byte_offset(&buf.rope, new_offset);
+            // insert_str handles cursor advance + history recording.
+            buf.insert_str(&s);
+        });
     }
 
     /// Wrap the current selection with `open` and `close`. When no selection
@@ -586,27 +598,11 @@ impl Buffer {
         let open_bytes = open.len();
         let close_bytes = close.len();
 
-        self.history.begin_batch();
-        // Insert close first so the open-insert offset doesn't shift.
-        rope_edit::insert(&mut self.rope, end, close);
-        record(
-            &mut self.history,
-            &mut self.pending_edits,
-            EditCommand::Insert {
-                at: end,
-                text: close.to_string(),
-            },
-        );
-        rope_edit::insert(&mut self.rope, start, open);
-        record(
-            &mut self.history,
-            &mut self.pending_edits,
-            EditCommand::Insert {
-                at: start,
-                text: open.to_string(),
-            },
-        );
-        self.history.commit_batch();
+        self.in_batch(|buf| {
+            // Insert close first so the open-insert offset doesn't shift.
+            buf.recorded_insert(end, close);
+            buf.recorded_insert(start, open);
+        });
 
         // Update primary cursor + selection to wrap the new inner range
         // (after the inserted open delimiter, before the inserted close).
@@ -633,9 +629,7 @@ impl Buffer {
             .slice(self.rope.byte_to_char(line_start)..self.rope.byte_to_char(line_end))
             .chars()
             .collect();
-        rope_edit::insert(&mut self.rope, line_end, &text);
-        self.history
-            .record(EditCommand::Insert { at: line_end, text });
+        self.recorded_insert(line_end, &text);
         self.modified = true;
     }
 
@@ -1199,46 +1193,29 @@ impl Buffer {
         // new_positions[cursor_idx] = byte offset after the edit.
         let mut new_positions = vec![0usize; n];
 
-        self.history.begin_batch();
-        for op in &ops {
-            if op.del_end > op.ins_pt {
-                let del_len = op.del_end - op.ins_pt;
-                let deleted = rope_edit::delete(&mut self.rope, op.ins_pt, op.del_end);
-                record(
-                    &mut self.history,
-                    &mut self.pending_edits,
-                    EditCommand::Delete {
-                        start: op.ins_pt,
-                        end: op.del_end,
-                        deleted,
-                    },
-                );
-                // Deletion at [ins_pt, del_end) shifts all tracked positions >= del_end down.
-                for pos in new_positions.iter_mut() {
-                    if *pos >= op.del_end {
-                        *pos -= del_len;
+        self.in_batch(|buf| {
+            for op in &ops {
+                if op.del_end > op.ins_pt {
+                    let del_len = op.del_end - op.ins_pt;
+                    buf.recorded_delete(op.ins_pt, op.del_end);
+                    // Deletion at [ins_pt, del_end) shifts all tracked positions >= del_end down.
+                    for pos in new_positions.iter_mut() {
+                        if *pos >= op.del_end {
+                            *pos -= del_len;
+                        }
                     }
                 }
-            }
-            rope_edit::insert(&mut self.rope, op.ins_pt, text);
-            record(
-                &mut self.history,
-                &mut self.pending_edits,
-                EditCommand::Insert {
-                    at: op.ins_pt,
-                    text: text.to_string(),
-                },
-            );
-            // Insertion at ins_pt shifts all tracked positions >= ins_pt up.
-            // (Processed descending, so all previously-set positions are above ins_pt.)
-            for pos in new_positions.iter_mut() {
-                if *pos >= op.ins_pt {
-                    *pos += text.len();
+                buf.recorded_insert(op.ins_pt, text);
+                // Insertion at ins_pt shifts all tracked positions >= ins_pt up.
+                // (Processed descending, so all previously-set positions are above ins_pt.)
+                for pos in new_positions.iter_mut() {
+                    if *pos >= op.ins_pt {
+                        *pos += text.len();
+                    }
                 }
+                new_positions[op.cursor_idx] = op.ins_pt + text.len();
             }
-            new_positions[op.cursor_idx] = op.ins_pt + text.len();
-        }
-        self.history.commit_batch();
+        });
 
         let primary_new = new_positions[primary_cursor_idx];
         let new_cursors: Vec<Cursor> = new_positions
@@ -1318,28 +1295,19 @@ impl Buffer {
             .map(|c| c.byte_offset)
             .collect();
 
-        self.history.begin_batch();
-        for op in &ops {
-            let del_len = op.del_end - op.del_start;
-            let deleted = rope_edit::delete(&mut self.rope, op.del_start, op.del_end);
-            record(
-                &mut self.history,
-                &mut self.pending_edits,
-                EditCommand::Delete {
-                    start: op.del_start,
-                    end: op.del_end,
-                    deleted,
-                },
-            );
-            // Deletion at [del_start, del_end) shifts all tracked positions >= del_end down.
-            for pos in new_positions.iter_mut() {
-                if *pos >= op.del_end {
-                    *pos -= del_len;
+        self.in_batch(|buf| {
+            for op in &ops {
+                let del_len = op.del_end - op.del_start;
+                buf.recorded_delete(op.del_start, op.del_end);
+                // Deletion at [del_start, del_end) shifts all tracked positions >= del_end down.
+                for pos in new_positions.iter_mut() {
+                    if *pos >= op.del_end {
+                        *pos -= del_len;
+                    }
                 }
+                new_positions[op.cursor_idx] = op.del_start;
             }
-            new_positions[op.cursor_idx] = op.del_start;
-        }
-        self.history.commit_batch();
+        });
 
         let primary_new = new_positions[primary_cursor_idx];
         let new_cursors: Vec<Cursor> = new_positions
@@ -1417,28 +1385,19 @@ impl Buffer {
             .map(|c| c.byte_offset)
             .collect();
 
-        self.history.begin_batch();
-        for op in &ops {
-            let del_len = op.del_end - op.del_start;
-            let deleted = rope_edit::delete(&mut self.rope, op.del_start, op.del_end);
-            record(
-                &mut self.history,
-                &mut self.pending_edits,
-                EditCommand::Delete {
-                    start: op.del_start,
-                    end: op.del_end,
-                    deleted,
-                },
-            );
-            // Deletion at [del_start, del_end) shifts all tracked positions >= del_end down.
-            for pos in new_positions.iter_mut() {
-                if *pos >= op.del_end {
-                    *pos -= del_len;
+        self.in_batch(|buf| {
+            for op in &ops {
+                let del_len = op.del_end - op.del_start;
+                buf.recorded_delete(op.del_start, op.del_end);
+                // Deletion at [del_start, del_end) shifts all tracked positions >= del_end down.
+                for pos in new_positions.iter_mut() {
+                    if *pos >= op.del_end {
+                        *pos -= del_len;
+                    }
                 }
+                new_positions[op.cursor_idx] = op.del_start;
             }
-            new_positions[op.cursor_idx] = op.del_start;
-        }
-        self.history.commit_batch();
+        });
 
         let primary_new = new_positions[primary_cursor_idx];
         let new_cursors: Vec<Cursor> = new_positions
@@ -1473,19 +1432,7 @@ impl Buffer {
         // End of the last line content, EXCLUDING its trailing newline.
         let end = self.line_start_byte(last_line) + line_byte_len_no_newline(&self.rope, last_line);
         let new_text = new_lines.join("\n");
-        self.history.begin_batch();
-        let old_text = rope_edit::replace(&mut self.rope, start, end, &new_text);
-        record(
-            &mut self.history,
-            &mut self.pending_edits,
-            EditCommand::Replace {
-                start,
-                end,
-                old_text,
-                new_text: new_text.clone(),
-            },
-        );
-        self.history.commit_batch();
+        self.in_batch(|buf| buf.recorded_replace(start, end, &new_text));
         let new_offset = start + new_text.len();
         *self.cursors.primary_mut() = Cursor::from_byte_offset(&self.rope, new_offset);
         self.cursors.primary_mut().selection = None;
@@ -1599,19 +1546,7 @@ impl Buffer {
         if transformed == original {
             return;
         }
-        self.history.begin_batch();
-        let old_text = rope_edit::replace(&mut self.rope, range.start, range.end, &transformed);
-        record(
-            &mut self.history,
-            &mut self.pending_edits,
-            EditCommand::Replace {
-                start: range.start,
-                end: range.end,
-                old_text,
-                new_text: transformed.clone(),
-            },
-        );
-        self.history.commit_batch();
+        self.in_batch(|buf| buf.recorded_replace(range.start, range.end, &transformed));
         let new_end = range.start + transformed.len();
         *self.cursors.primary_mut() = Cursor::from_byte_offset(&self.rope, new_end);
         self.cursors.primary_mut().selection =
@@ -1665,19 +1600,7 @@ impl Buffer {
         }
         // Trim trailing space introduced if selection ended with newline.
         let joined = joined.trim_end_matches(' ').to_string();
-        self.history.begin_batch();
-        let old_text = rope_edit::replace(&mut self.rope, range.start, range.end, &joined);
-        record(
-            &mut self.history,
-            &mut self.pending_edits,
-            EditCommand::Replace {
-                start: range.start,
-                end: range.end,
-                old_text,
-                new_text: joined.clone(),
-            },
-        );
-        self.history.commit_batch();
+        self.in_batch(|buf| buf.recorded_replace(range.start, range.end, &joined));
         let new_offset = range.start + joined.len();
         *self.cursors.primary_mut() = Cursor::from_byte_offset(&self.rope, new_offset);
         self.cursors.primary_mut().selection = None;
@@ -1776,40 +1699,30 @@ impl Buffer {
         // update positions; cursors are rebuilt from byte offsets.
         let mut new_positions: Vec<usize> = cursors.iter().map(|c| c.byte_offset).collect();
         let primary_idx = self.cursors.primary_idx();
-        self.history.begin_batch();
-        // Process descending.
-        let mut hits_desc = hits;
-        hits_desc.sort_by_key(|h| std::cmp::Reverse(h.start));
-        for h in &hits_desc {
-            let new_str = match h.zero_padded_width {
-                Some(w) => format!("{:0>width$}", h.original, width = w),
-                None => format!("{}", h.original),
-            };
-            let old_text = rope_edit::replace(&mut self.rope, h.start, h.end, &new_str);
-            record(
-                &mut self.history,
-                &mut self.pending_edits,
-                EditCommand::Replace {
-                    start: h.start,
-                    end: h.end,
-                    old_text,
-                    new_text: new_str.clone(),
-                },
-            );
-            // Adjust new_positions for this edit.
-            let old_len = h.end - h.start;
-            let new_len = new_str.len();
-            let delta_len = new_len as i64 - old_len as i64;
-            for pos in new_positions.iter_mut() {
-                if *pos > h.end {
-                    *pos = ((*pos as i64) + delta_len) as usize;
-                } else if *pos >= h.start {
-                    // Cursor was within the digit run; place at end of new.
-                    *pos = h.start + new_len;
+        self.in_batch(|buf| {
+            // Process descending.
+            let mut hits_desc = hits;
+            hits_desc.sort_by_key(|h| std::cmp::Reverse(h.start));
+            for h in &hits_desc {
+                let new_str = match h.zero_padded_width {
+                    Some(w) => format!("{:0>width$}", h.original, width = w),
+                    None => format!("{}", h.original),
+                };
+                buf.recorded_replace(h.start, h.end, &new_str);
+                // Adjust new_positions for this edit.
+                let old_len = h.end - h.start;
+                let new_len = new_str.len();
+                let delta_len = new_len as i64 - old_len as i64;
+                for pos in new_positions.iter_mut() {
+                    if *pos > h.end {
+                        *pos = ((*pos as i64) + delta_len) as usize;
+                    } else if *pos >= h.start {
+                        // Cursor was within the digit run; place at end of new.
+                        *pos = h.start + new_len;
+                    }
                 }
             }
-        }
-        self.history.commit_batch();
+        });
         let new_cursors: Vec<Cursor> = new_positions
             .iter()
             .map(|&off| Cursor::from_byte_offset(&self.rope, off))
@@ -1909,19 +1822,7 @@ impl Buffer {
             return;
         }
         let len = self.rope.len_bytes();
-        self.history.begin_batch();
-        let old_text = rope_edit::replace(&mut self.rope, 0, len, &new_text);
-        record(
-            &mut self.history,
-            &mut self.pending_edits,
-            EditCommand::Replace {
-                start: 0,
-                end: len,
-                old_text,
-                new_text: new_text.clone(),
-            },
-        );
-        self.history.commit_batch();
+        self.in_batch(|buf| buf.recorded_replace(0, len, &new_text));
         *self.cursors.primary_mut() = Cursor::from_byte_offset(&self.rope, 0);
         self.cursors.primary_mut().selection = None;
         self.modified = true;
@@ -2007,28 +1908,8 @@ impl Buffer {
         let b_end = b_start + line_b.len();
 
         // Replace b first (higher offset) so a's offsets stay valid.
-        let old_b = rope_edit::replace(&mut self.rope, b_start, b_end, &line_a);
-        record(
-            &mut self.history,
-            &mut self.pending_edits,
-            EditCommand::Replace {
-                start: b_start,
-                end: b_end,
-                old_text: old_b,
-                new_text: line_a.clone(),
-            },
-        );
-        let old_a = rope_edit::replace(&mut self.rope, a_start, a_end, &line_b);
-        record(
-            &mut self.history,
-            &mut self.pending_edits,
-            EditCommand::Replace {
-                start: a_start,
-                end: a_end,
-                old_text: old_a,
-                new_text: line_b,
-            },
-        );
+        self.recorded_replace(b_start, b_end, &line_a);
+        self.recorded_replace(a_start, a_end, &line_b);
     }
 }
 

--- a/src/ui/CLAUDE.md
+++ b/src/ui/CLAUDE.md
@@ -1,0 +1,33 @@
+# src/ui — overlay & rendering helpers
+
+Every `pub fn render(...)` in this directory is invoked from `ui::mod::render` once per frame. Each module owns a self-contained renderer plus any `*State` types referenced by `AppState`. State mutation lives in `src/app.rs`, never here.
+
+## Shared chrome (do not reimplement)
+
+`overlay_chrome.rs` and `text_utils.rs` exist so the family of centred overlays renders consistently. Use them:
+
+- **`overlay_chrome::draw_border`** — rounded `╭╮╰╯` box around any `Rect`.
+- **`overlay_chrome::draw_h_separator`** — `├─────┤` row at row `y` inside the border.
+- **`overlay_chrome::fill_rect`** — solid background fill before drawing chrome.
+- **`overlay_chrome::render_centered_header`** — write a title centred on a row.
+- **`text_utils::truncate_to_width`** — grapheme-aware column-budget truncate, returns `&str`. Default choice for visible UI text.
+- **`text_utils::truncate_bytes`** — byte-budget truncate snapped to a UTF-8 boundary, returns `&str`. Use only when the budget really is in bytes.
+- **`text_utils::truncate_left_keep_right`** — prefix `…` and keep the right side. For paths and breadcrumbs.
+
+If you find yourself opening a `for x in area.x..area.x + area.width` to paint a row, or pushing `╭ ╮ ╰ ╯` into a buffer by hand, stop and use the helper instead. The local copies were removed in the duplication cleanup; reintroducing them is a regression.
+
+## Overlay file conventions
+
+- File name matches the feature (`fuzzy_picker.rs`, `lsp_picker.rs`, …).
+- Public surface is the renderer plus any `*State` struct held on `AppState`.
+- Render order is decided by `ui::mod::render`. Overlays paint on top of the editor buffer last, in the same priority order as their input handlers in `AppState::update()`.
+- Renderers must be pure: read `&State`, write to `&mut TermBuffer`. No I/O, no mutation of `AppState`.
+
+## Tests
+
+Renderers have `#[cfg(test)]` smoke tests that exercise tiny / narrow areas to confirm they don't panic. When adding a new overlay, add at least:
+
+- A `render_does_not_panic_on_narrow_widths` test that sweeps small `Rect`s.
+- A `render_skips_tiny_area` test that asserts the bail-out branch.
+
+Visual regression is covered by the PTY suite (`tests/ui_*.rs`) — that lives outside this directory.

--- a/src/ui/clipboard_ring.rs
+++ b/src/ui/clipboard_ring.rs
@@ -10,6 +10,7 @@ use ratatui::{
 };
 
 use crate::app::ClipboardRingState;
+use crate::ui::overlay_chrome::{draw_border, draw_h_separator};
 
 const MAX_VISIBLE: usize = 15;
 
@@ -119,37 +120,6 @@ fn first_line_preview(text: &str, max_w: usize) -> String {
         out.push(ch);
     }
     out
-}
-
-fn draw_border(buf: &mut TermBuffer, area: Rect, style: Style) {
-    if area.width < 2 || area.height < 2 {
-        return;
-    }
-    let (x0, y0) = (area.x, area.y);
-    let (x1, y1) = (area.x + area.width - 1, area.y + area.height - 1);
-    buf.set_string(x0, y0, "╭", style);
-    buf.set_string(x1, y0, "╮", style);
-    buf.set_string(x0, y1, "╰", style);
-    buf.set_string(x1, y1, "╯", style);
-    for x in x0 + 1..x1 {
-        buf.set_string(x, y0, "─", style);
-        buf.set_string(x, y1, "─", style);
-    }
-    for y in y0 + 1..y1 {
-        buf.set_string(x0, y, "│", style);
-        buf.set_string(x1, y, "│", style);
-    }
-}
-
-fn draw_h_separator(buf: &mut TermBuffer, area: Rect, y: u16, style: Style) {
-    if area.width < 2 {
-        return;
-    }
-    buf.set_string(area.x, y, "├", style);
-    buf.set_string(area.x + area.width - 1, y, "┤", style);
-    for x in area.x + 1..area.x + area.width - 1 {
-        buf.set_string(x, y, "─", style);
-    }
 }
 
 #[cfg(test)]

--- a/src/ui/command_palette.rs
+++ b/src/ui/command_palette.rs
@@ -6,6 +6,7 @@ use ratatui::{
 
 use crate::input::action::EditorAction;
 use crate::theme::ThemeColors;
+use crate::ui::overlay_chrome::{draw_border, fill_rect};
 
 /// A single entry in the command palette.
 pub struct CommandEntry {
@@ -453,14 +454,7 @@ pub fn render(
         .bg(theme.picker_sel_bg)
         .fg(Color::Rgb(160, 220, 160));
 
-    // Background fill.
-    for y in overlay.y..overlay.y + overlay.height {
-        for x in overlay.x..overlay.x + overlay.width {
-            buf.set_string(x, y, " ", Style::default().bg(bg));
-        }
-    }
-
-    // Border.
+    fill_rect(buf, overlay, Style::default().bg(bg));
     draw_border(buf, overlay, border_style);
 
     // Query input row.
@@ -521,27 +515,6 @@ pub fn render(
         let kh = pad_clip(cmd.key_hint, kh_w);
         let kh_x = overlay.x + overlay.width - 1 - kh_w as u16;
         buf.set_string(kh_x, y, &kh, kh_style);
-    }
-}
-
-fn draw_border(buf: &mut TermBuffer, area: Rect, style: Style) {
-    if area.width < 2 || area.height < 2 {
-        return;
-    }
-    let (x0, y0) = (area.x, area.y);
-    let (x1, y1) = (area.x + area.width - 1, area.y + area.height - 1);
-
-    buf.set_string(x0, y0, "╭", style);
-    buf.set_string(x1, y0, "╮", style);
-    buf.set_string(x0, y1, "╰", style);
-    buf.set_string(x1, y1, "╯", style);
-    for x in x0 + 1..x1 {
-        buf.set_string(x, y0, "─", style);
-        buf.set_string(x, y1, "─", style);
-    }
-    for y in y0 + 1..y1 {
-        buf.set_string(x0, y, "│", style);
-        buf.set_string(x1, y, "│", style);
     }
 }
 

--- a/src/ui/completion_popup.rs
+++ b/src/ui/completion_popup.rs
@@ -5,6 +5,7 @@ use ratatui::{
 };
 
 use crate::app::CompletionState;
+use crate::ui::overlay_chrome::draw_border;
 
 const MAX_VISIBLE: usize = 10;
 
@@ -100,25 +101,5 @@ pub fn render(
                 }
             }
         }
-    }
-}
-
-fn draw_border(buf: &mut TermBuffer, area: Rect, style: Style) {
-    if area.width < 2 || area.height < 2 {
-        return;
-    }
-    let (x0, y0) = (area.x, area.y);
-    let (x1, y1) = (area.x + area.width - 1, area.y + area.height - 1);
-    buf.set_string(x0, y0, "╭", style);
-    buf.set_string(x1, y0, "╮", style);
-    buf.set_string(x0, y1, "╰", style);
-    buf.set_string(x1, y1, "╯", style);
-    for x in x0 + 1..x1 {
-        buf.set_string(x, y0, "─", style);
-        buf.set_string(x, y1, "─", style);
-    }
-    for y in y0 + 1..y1 {
-        buf.set_string(x0, y, "│", style);
-        buf.set_string(x1, y, "│", style);
     }
 }

--- a/src/ui/diff_peek.rs
+++ b/src/ui/diff_peek.rs
@@ -8,6 +8,7 @@ use ratatui::{
 };
 
 use crate::app::DiffPeekState;
+use crate::ui::overlay_chrome::draw_border;
 
 const MAX_VISIBLE: usize = 10;
 
@@ -57,24 +58,4 @@ pub fn render(peek: &DiffPeekState, area: Rect, buf: &mut TermBuffer) {
     let hint = " Alt+H toggles ";
     let hint_x = popup.x + popup.width.saturating_sub(hint.len() as u16) / 2;
     buf.set_string(hint_x, hint_y, hint, hint_style);
-}
-
-fn draw_border(buf: &mut TermBuffer, area: Rect, style: Style) {
-    if area.width < 2 || area.height < 2 {
-        return;
-    }
-    let (x0, y0) = (area.x, area.y);
-    let (x1, y1) = (area.x + area.width - 1, area.y + area.height - 1);
-    buf.set_string(x0, y0, "╭", style);
-    buf.set_string(x1, y0, "╮", style);
-    buf.set_string(x0, y1, "╰", style);
-    buf.set_string(x1, y1, "╯", style);
-    for x in x0 + 1..x1 {
-        buf.set_string(x, y0, "─", style);
-        buf.set_string(x, y1, "─", style);
-    }
-    for y in y0 + 1..y1 {
-        buf.set_string(x0, y, "│", style);
-        buf.set_string(x1, y, "│", style);
-    }
 }

--- a/src/ui/git_dialog.rs
+++ b/src/ui/git_dialog.rs
@@ -14,6 +14,7 @@ use ratatui::{
 
 use crate::git::ops::{BranchEntry, StashEntry, StatusEntry};
 use crate::theme::ThemeColors;
+use crate::ui::overlay_chrome::draw_border;
 
 // ── Menu items ───────────────────────────────────────────────────────────────
 
@@ -566,37 +567,8 @@ impl BodyCtx<'_> {
 
 // ── Drawing helpers ──────────────────────────────────────────────────────────
 
-fn draw_border(buf: &mut TermBuffer, area: Rect, style: Style) {
-    if area.width < 2 || area.height < 2 {
-        return;
-    }
-    let (x0, y0) = (area.x, area.y);
-    let (x1, y1) = (area.x + area.width - 1, area.y + area.height - 1);
-
-    buf.set_string(x0, y0, "╭", style);
-    buf.set_string(x1, y0, "╮", style);
-    buf.set_string(x0, y1, "╰", style);
-    buf.set_string(x1, y1, "╯", style);
-    for x in x0 + 1..x1 {
-        buf.set_string(x, y0, "─", style);
-        buf.set_string(x, y1, "─", style);
-    }
-    for y in y0 + 1..y1 {
-        buf.set_string(x0, y, "│", style);
-        buf.set_string(x1, y, "│", style);
-    }
-}
-
 fn clip(s: &str, width: usize) -> String {
-    if s.len() <= width {
-        s.to_string()
-    } else {
-        let mut end = width;
-        while end > 0 && !s.is_char_boundary(end) {
-            end -= 1;
-        }
-        s[..end].to_string()
-    }
+    crate::ui::text_utils::truncate_bytes(s, width).to_string()
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────

--- a/src/ui/help_overlay.rs
+++ b/src/ui/help_overlay.rs
@@ -5,6 +5,8 @@ use ratatui::{
 };
 
 use crate::input::keybinding::KeyBindings;
+use crate::ui::overlay_chrome::draw_border;
+use crate::ui::text_utils::truncate_to_width;
 
 /// Help template entry.  `Section` headers separate groups of bindings.
 enum HelpEntry {
@@ -524,25 +526,6 @@ fn format_key_display(s: &str) -> String {
         .join("+")
 }
 
-/// Truncate `s` to at most `max_width` terminal columns, respecting grapheme
-/// boundaries so the result is always a valid `&str` slice. Cells whose display
-/// width would push the running total past `max_width` are dropped.
-fn truncate_to_width(s: &str, max_width: usize) -> &str {
-    use unicode_segmentation::UnicodeSegmentation;
-    use unicode_width::UnicodeWidthStr;
-    let mut width = 0usize;
-    let mut end = 0usize;
-    for (idx, g) in s.grapheme_indices(true) {
-        let gw = UnicodeWidthStr::width(g);
-        if width + gw > max_width {
-            return &s[..end];
-        }
-        width += gw;
-        end = idx + g.len();
-    }
-    s
-}
-
 /// Join key strings with ` / `, collapsing duplicates.
 fn dedup_and_join(keys: &[String]) -> String {
     let mut seen = Vec::new();
@@ -684,30 +667,6 @@ pub fn render(area: Rect, buf: &mut TermBuffer, scroll: usize, bindings: &KeyBin
             " \u{2193} ",
             border_style,
         );
-    }
-}
-
-fn draw_border(buf: &mut TermBuffer, area: Rect, style: Style) {
-    if area.width < 2 || area.height < 2 {
-        return;
-    }
-    let x0 = area.x;
-    let y0 = area.y;
-    let x1 = area.x + area.width - 1;
-    let y1 = area.y + area.height - 1;
-
-    buf.set_string(x0, y0, "\u{256d}", style);
-    buf.set_string(x1, y0, "\u{256e}", style);
-    buf.set_string(x0, y1, "\u{2570}", style);
-    buf.set_string(x1, y1, "\u{256f}", style);
-
-    for x in x0 + 1..x1 {
-        buf.set_string(x, y0, "\u{2500}", style);
-        buf.set_string(x, y1, "\u{2500}", style);
-    }
-    for y in y0 + 1..y1 {
-        buf.set_string(x0, y, "\u{2502}", style);
-        buf.set_string(x1, y, "\u{2502}", style);
     }
 }
 

--- a/src/ui/hover_popup.rs
+++ b/src/ui/hover_popup.rs
@@ -5,6 +5,7 @@ use ratatui::{
 };
 
 use crate::app::HoverState;
+use crate::ui::overlay_chrome::draw_border;
 
 const MAX_W: u16 = 60;
 const MAX_H: u16 = 15;
@@ -63,25 +64,5 @@ pub fn render(
         let y = popup.y + 1 + i as u16;
         let display: String = line.chars().take(inner_w).collect();
         buf.set_string(popup.x + 1, y, &display, text_style);
-    }
-}
-
-fn draw_border(buf: &mut TermBuffer, area: Rect, style: Style) {
-    if area.width < 2 || area.height < 2 {
-        return;
-    }
-    let (x0, y0) = (area.x, area.y);
-    let (x1, y1) = (area.x + area.width - 1, area.y + area.height - 1);
-    buf.set_string(x0, y0, "╭", style);
-    buf.set_string(x1, y0, "╮", style);
-    buf.set_string(x0, y1, "╰", style);
-    buf.set_string(x1, y1, "╯", style);
-    for x in x0 + 1..x1 {
-        buf.set_string(x, y0, "─", style);
-        buf.set_string(x, y1, "─", style);
-    }
-    for y in y0 + 1..y1 {
-        buf.set_string(x0, y, "│", style);
-        buf.set_string(x1, y, "│", style);
     }
 }

--- a/src/ui/lsp_approval.rs
+++ b/src/ui/lsp_approval.rs
@@ -5,6 +5,7 @@ use ratatui::{
 };
 
 use crate::app::{LspApprovalReason, PendingLspApproval};
+use crate::ui::overlay_chrome::{draw_border, draw_h_separator};
 
 const OVERLAY_W: u16 = 72;
 
@@ -191,38 +192,6 @@ fn truncate_middle(s: &str, max: usize) -> String {
         .rev()
         .collect();
     format!("{head_str}…{tail_str}")
-}
-
-fn draw_border(buf: &mut TermBuffer, area: Rect, style: Style) {
-    if area.width < 2 || area.height < 2 {
-        return;
-    }
-    let (x0, y0) = (area.x, area.y);
-    let (x1, y1) = (area.x + area.width - 1, area.y + area.height - 1);
-
-    buf.set_string(x0, y0, "╭", style);
-    buf.set_string(x1, y0, "╮", style);
-    buf.set_string(x0, y1, "╰", style);
-    buf.set_string(x1, y1, "╯", style);
-    for x in x0 + 1..x1 {
-        buf.set_string(x, y0, "─", style);
-        buf.set_string(x, y1, "─", style);
-    }
-    for y in y0 + 1..y1 {
-        buf.set_string(x0, y, "│", style);
-        buf.set_string(x1, y, "│", style);
-    }
-}
-
-fn draw_h_separator(buf: &mut TermBuffer, area: Rect, y: u16, style: Style) {
-    if area.width < 2 {
-        return;
-    }
-    buf.set_string(area.x, y, "├", style);
-    buf.set_string(area.x + area.width - 1, y, "┤", style);
-    for x in area.x + 1..area.x + area.width - 1 {
-        buf.set_string(x, y, "─", style);
-    }
 }
 
 #[cfg(test)]

--- a/src/ui/lsp_picker.rs
+++ b/src/ui/lsp_picker.rs
@@ -5,6 +5,7 @@ use ratatui::{
 };
 
 use crate::app::{LSP_SERVER_OPTIONS, LspPickerState};
+use crate::ui::overlay_chrome::{draw_border, draw_h_separator};
 
 // ── Layout constants ─────────────────────────────────────────────────────────
 
@@ -137,35 +138,3 @@ pub fn render(picker: &LspPickerState, area: Rect, buf: &mut TermBuffer) {
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
-
-fn draw_border(buf: &mut TermBuffer, area: Rect, style: Style) {
-    if area.width < 2 || area.height < 2 {
-        return;
-    }
-    let (x0, y0) = (area.x, area.y);
-    let (x1, y1) = (area.x + area.width - 1, area.y + area.height - 1);
-
-    buf.set_string(x0, y0, "╭", style);
-    buf.set_string(x1, y0, "╮", style);
-    buf.set_string(x0, y1, "╰", style);
-    buf.set_string(x1, y1, "╯", style);
-    for x in x0 + 1..x1 {
-        buf.set_string(x, y0, "─", style);
-        buf.set_string(x, y1, "─", style);
-    }
-    for y in y0 + 1..y1 {
-        buf.set_string(x0, y, "│", style);
-        buf.set_string(x1, y, "│", style);
-    }
-}
-
-fn draw_h_separator(buf: &mut TermBuffer, area: Rect, y: u16, style: Style) {
-    if area.width < 2 {
-        return;
-    }
-    buf.set_string(area.x, y, "├", style);
-    buf.set_string(area.x + area.width - 1, y, "┤", style);
-    for x in area.x + 1..area.x + area.width - 1 {
-        buf.set_string(x, y, "─", style);
-    }
-}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -21,6 +21,7 @@ pub mod status_bar;
 pub mod sticky_header;
 pub mod symbol_picker;
 pub mod tab_bar;
+pub mod text_utils;
 pub mod welcome_overlay;
 
 use ratatui::{

--- a/src/ui/overlay_chrome.rs
+++ b/src/ui/overlay_chrome.rs
@@ -1,9 +1,22 @@
-//! Shared chrome helpers for floating overlays (welcome, changelog, etc.).
+//! Shared chrome helpers for floating overlays.
 //!
-//! `help_overlay.rs` and `settings_overlay.rs` predate this module and keep
-//! their own private `draw_border`. New overlays should reuse the helper here.
+//! Every centred float in `src/ui/` follows the same chrome pattern:
+//! a solid background fill, a rounded-corner border, optional internal
+//! `├─────┤` separators, and a centred header line. The helpers below are
+//! the single source of truth for that chrome — overlay modules should
+//! call them instead of reimplementing the loops.
 
 use ratatui::{buffer::Buffer as TermBuffer, layout::Rect, style::Style};
+
+/// Fill every cell of `area` with a single space using `style`. Use this to
+/// paint the background of an overlay before drawing its border and content.
+pub fn fill_rect(buf: &mut TermBuffer, area: Rect, style: Style) {
+    for y in area.y..area.y + area.height {
+        for x in area.x..area.x + area.width {
+            buf.set_string(x, y, " ", style);
+        }
+    }
+}
 
 /// Draw a rounded box around `area` using the given style. No-op for areas
 /// smaller than 2×2.
@@ -16,17 +29,37 @@ pub fn draw_border(buf: &mut TermBuffer, area: Rect, style: Style) {
     let x1 = area.x + area.width - 1;
     let y1 = area.y + area.height - 1;
 
-    buf.set_string(x0, y0, "\u{256d}", style);
-    buf.set_string(x1, y0, "\u{256e}", style);
-    buf.set_string(x0, y1, "\u{2570}", style);
-    buf.set_string(x1, y1, "\u{256f}", style);
+    buf.set_string(x0, y0, "╭", style);
+    buf.set_string(x1, y0, "╮", style);
+    buf.set_string(x0, y1, "╰", style);
+    buf.set_string(x1, y1, "╯", style);
 
     for x in x0 + 1..x1 {
-        buf.set_string(x, y0, "\u{2500}", style);
-        buf.set_string(x, y1, "\u{2500}", style);
+        buf.set_string(x, y0, "─", style);
+        buf.set_string(x, y1, "─", style);
     }
     for y in y0 + 1..y1 {
-        buf.set_string(x0, y, "\u{2502}", style);
-        buf.set_string(x1, y, "\u{2502}", style);
+        buf.set_string(x0, y, "│", style);
+        buf.set_string(x1, y, "│", style);
     }
+}
+
+/// Draw a horizontal `├─────┤` separator at row `y` spanning the width of
+/// `area`. The caller is responsible for ensuring `y` lies inside the border.
+pub fn draw_h_separator(buf: &mut TermBuffer, area: Rect, y: u16, style: Style) {
+    if area.width < 2 {
+        return;
+    }
+    buf.set_string(area.x, y, "├", style);
+    buf.set_string(area.x + area.width - 1, y, "┤", style);
+    for x in area.x + 1..area.x + area.width - 1 {
+        buf.set_string(x, y, "─", style);
+    }
+}
+
+/// Render `text` horizontally centred on row `y` of `area`, using `style`.
+/// The string is written verbatim — callers must pre-truncate it to fit.
+pub fn render_centered_header(buf: &mut TermBuffer, area: Rect, y: u16, text: &str, style: Style) {
+    let tx = area.x + area.width.saturating_sub(text.len() as u16) / 2;
+    buf.set_string(tx, y, text, style);
 }

--- a/src/ui/quickfix_list.rs
+++ b/src/ui/quickfix_list.rs
@@ -8,6 +8,7 @@ use ratatui::{
 
 use crate::lsp::types::DiagSeverity;
 use crate::quickfix::QuickfixState;
+use crate::ui::overlay_chrome::{draw_border, draw_h_separator};
 
 const MAX_VISIBLE: usize = 15;
 
@@ -107,35 +108,4 @@ pub fn render(qf: &QuickfixState, area: Rect, buf: &mut TermBuffer) {
     let hint = " Enter: jump  ↑↓: select  Esc: close ";
     let hx2 = popup.x + popup.width.saturating_sub(hint.len() as u16) / 2;
     buf.set_string(hx2, hint_y, hint, hint_style);
-}
-
-fn draw_border(buf: &mut TermBuffer, area: Rect, style: Style) {
-    if area.width < 2 || area.height < 2 {
-        return;
-    }
-    let (x0, y0) = (area.x, area.y);
-    let (x1, y1) = (area.x + area.width - 1, area.y + area.height - 1);
-    buf.set_string(x0, y0, "╭", style);
-    buf.set_string(x1, y0, "╮", style);
-    buf.set_string(x0, y1, "╰", style);
-    buf.set_string(x1, y1, "╯", style);
-    for x in x0 + 1..x1 {
-        buf.set_string(x, y0, "─", style);
-        buf.set_string(x, y1, "─", style);
-    }
-    for y in y0 + 1..y1 {
-        buf.set_string(x0, y, "│", style);
-        buf.set_string(x1, y, "│", style);
-    }
-}
-
-fn draw_h_separator(buf: &mut TermBuffer, area: Rect, y: u16, style: Style) {
-    if area.width < 2 {
-        return;
-    }
-    buf.set_string(area.x, y, "├", style);
-    buf.set_string(area.x + area.width - 1, y, "┤", style);
-    for x in area.x + 1..area.x + area.width - 1 {
-        buf.set_string(x, y, "─", style);
-    }
 }

--- a/src/ui/references_list.rs
+++ b/src/ui/references_list.rs
@@ -5,6 +5,7 @@ use ratatui::{
 };
 
 use crate::app::ReferencesListState;
+use crate::ui::overlay_chrome::{draw_border, draw_h_separator};
 
 const MAX_VISIBLE: usize = 15;
 
@@ -95,35 +96,4 @@ pub fn render(refs: &ReferencesListState, area: Rect, buf: &mut TermBuffer) {
     let hint = " Enter: go  Esc: close ";
     let hint_x = popup.x + popup.width.saturating_sub(hint.len() as u16) / 2;
     buf.set_string(hint_x, hint_y, hint, hint_style);
-}
-
-fn draw_border(buf: &mut TermBuffer, area: Rect, style: Style) {
-    if area.width < 2 || area.height < 2 {
-        return;
-    }
-    let (x0, y0) = (area.x, area.y);
-    let (x1, y1) = (area.x + area.width - 1, area.y + area.height - 1);
-    buf.set_string(x0, y0, "╭", style);
-    buf.set_string(x1, y0, "╮", style);
-    buf.set_string(x0, y1, "╰", style);
-    buf.set_string(x1, y1, "╯", style);
-    for x in x0 + 1..x1 {
-        buf.set_string(x, y0, "─", style);
-        buf.set_string(x, y1, "─", style);
-    }
-    for y in y0 + 1..y1 {
-        buf.set_string(x0, y, "│", style);
-        buf.set_string(x1, y, "│", style);
-    }
-}
-
-fn draw_h_separator(buf: &mut TermBuffer, area: Rect, y: u16, style: Style) {
-    if area.width < 2 {
-        return;
-    }
-    buf.set_string(area.x, y, "├", style);
-    buf.set_string(area.x + area.width - 1, y, "┤", style);
-    for x in area.x + 1..area.x + area.width - 1 {
-        buf.set_string(x, y, "─", style);
-    }
 }

--- a/src/ui/settings_overlay.rs
+++ b/src/ui/settings_overlay.rs
@@ -6,6 +6,7 @@ use ratatui::{
 
 use crate::app::AppState;
 use crate::config::Config;
+use crate::ui::overlay_chrome::{draw_border, draw_h_separator, render_centered_header};
 
 // ── Layout constants ──────────────────────────────────────────────────────────
 
@@ -59,9 +60,7 @@ pub fn render(state: &AppState, area: Rect, buf: &mut TermBuffer) {
     draw_border(buf, overlay, border_style);
 
     // ── Header ────────────────────────────────────────────────────────────────
-    let header = " Settings ";
-    let hx = overlay.x + overlay.width.saturating_sub(header.len() as u16) / 2;
-    buf.set_string(hx, overlay.y, header, header_style);
+    render_centered_header(buf, overlay, overlay.y, " Settings ", header_style);
 
     // ── Path subtitle (row 1, y+1) ────────────────────────────────────────────
     let inner_w_u16 = overlay.width.saturating_sub(4);
@@ -199,36 +198,4 @@ pub fn render(state: &AppState, area: Rect, buf: &mut TermBuffer) {
 enum SettingValue<'a> {
     Bool(bool),
     Enum(&'a str),
-}
-
-fn draw_border(buf: &mut TermBuffer, area: Rect, style: Style) {
-    if area.width < 2 || area.height < 2 {
-        return;
-    }
-    let (x0, y0) = (area.x, area.y);
-    let (x1, y1) = (area.x + area.width - 1, area.y + area.height - 1);
-
-    buf.set_string(x0, y0, "╭", style);
-    buf.set_string(x1, y0, "╮", style);
-    buf.set_string(x0, y1, "╰", style);
-    buf.set_string(x1, y1, "╯", style);
-    for x in x0 + 1..x1 {
-        buf.set_string(x, y0, "─", style);
-        buf.set_string(x, y1, "─", style);
-    }
-    for y in y0 + 1..y1 {
-        buf.set_string(x0, y, "│", style);
-        buf.set_string(x1, y, "│", style);
-    }
-}
-
-fn draw_h_separator(buf: &mut TermBuffer, area: Rect, y: u16, style: Style) {
-    if area.width < 2 {
-        return;
-    }
-    buf.set_string(area.x, y, "├", style);
-    buf.set_string(area.x + area.width - 1, y, "┤", style);
-    for x in area.x + 1..area.x + area.width - 1 {
-        buf.set_string(x, y, "─", style);
-    }
 }

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -6,6 +6,7 @@ use ratatui::{
 
 use crate::app::{AppState, InputMode};
 use crate::theme::ThemeColors;
+use crate::ui::text_utils::truncate_bytes;
 
 /// Render the status bar at the bottom of the screen.
 ///
@@ -287,14 +288,5 @@ fn format_memory(kb: u64) -> String {
 }
 
 fn truncate_str(s: &str, max_bytes: usize) -> String {
-    if s.len() <= max_bytes {
-        s.to_string()
-    } else {
-        // Truncate at a char boundary.
-        let mut end = max_bytes;
-        while end > 0 && !s.is_char_boundary(end) {
-            end -= 1;
-        }
-        s[..end].to_string()
-    }
+    truncate_bytes(s, max_bytes).to_string()
 }

--- a/src/ui/sticky_header.rs
+++ b/src/ui/sticky_header.rs
@@ -12,6 +12,7 @@ use ratatui::{
 };
 
 use crate::syntax::EnclosingSymbol;
+use crate::ui::text_utils::truncate_left_keep_right;
 
 /// Format the breadcrumb path as `kind name › kind name › …`. Returns an
 /// empty string for an empty path.
@@ -55,23 +56,6 @@ pub fn render(path: &[EnclosingSymbol], area: Rect, buf: &mut TermBuffer) {
         &truncated,
         bar_style.add_modifier(Modifier::BOLD),
     );
-}
-
-/// Truncate `s` to fit in `max_chars` columns, keeping the rightmost
-/// (innermost) part of the breadcrumb. Falls back to a left truncate if the
-/// string already fits.
-fn truncate_left_keep_right(s: &str, max_chars: usize) -> String {
-    let len = s.chars().count();
-    if len <= max_chars || max_chars == 0 {
-        return s.chars().take(max_chars).collect();
-    }
-    let want = max_chars.saturating_sub(1);
-    let skip = len - want;
-    let tail: String = s.chars().skip(skip).collect();
-    let mut out = String::with_capacity(tail.len() + 1);
-    out.push('…');
-    out.push_str(&tail);
-    out
 }
 
 #[cfg(test)]

--- a/src/ui/text_utils.rs
+++ b/src/ui/text_utils.rs
@@ -1,0 +1,93 @@
+//! Shared text-truncation helpers used by overlay and status-bar renderers.
+//!
+//! Three flavours exist because callers have different budgets:
+//!
+//! - [`truncate_to_width`] respects grapheme clusters and `unicode-width`
+//!   display columns. Use this whenever the budget is in *terminal cells*,
+//!   which is almost always the right call for visible UI text.
+//! - [`truncate_bytes`] is a cheap byte-budget cut that snaps back to a UTF-8
+//!   char boundary. Use only when the budget really is in bytes (e.g. when
+//!   serialising into a fixed-width field).
+//! - [`truncate_left_keep_right`] preserves the trailing portion (with a
+//!   leading `…`). Useful for paths and breadcrumbs where the rightmost
+//!   segment carries the most information.
+
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
+
+/// Truncate `s` to at most `max_width` terminal columns, respecting grapheme
+/// boundaries. The result is always a valid `&str` slice.
+pub fn truncate_to_width(s: &str, max_width: usize) -> &str {
+    let mut width = 0usize;
+    let mut end = 0usize;
+    for (idx, g) in s.grapheme_indices(true) {
+        let gw = UnicodeWidthStr::width(g);
+        if width + gw > max_width {
+            return &s[..end];
+        }
+        width += gw;
+        end = idx + g.len();
+    }
+    s
+}
+
+/// Truncate `s` to at most `max_bytes` bytes, snapping back to the nearest
+/// UTF-8 char boundary so the result is always valid UTF-8.
+pub fn truncate_bytes(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
+/// Truncate `s` to fit in `max_chars` columns, keeping the rightmost
+/// (innermost) part. When the string already fits, the full string is
+/// returned; otherwise an ellipsis `…` is prefixed to the kept suffix.
+pub fn truncate_left_keep_right(s: &str, max_chars: usize) -> String {
+    let len = s.chars().count();
+    if len <= max_chars || max_chars == 0 {
+        return s.chars().take(max_chars).collect();
+    }
+    let want = max_chars.saturating_sub(1);
+    let skip = len - want;
+    let tail: String = s.chars().skip(skip).collect();
+    let mut out = String::with_capacity(tail.len() + 1);
+    out.push('…');
+    out.push_str(&tail);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn width_truncation_handles_wide_chars() {
+        // CJK characters are 2 columns wide each.
+        assert_eq!(truncate_to_width("日本語", 4), "日本");
+        assert_eq!(truncate_to_width("日本語", 5), "日本");
+        assert_eq!(truncate_to_width("日本語", 6), "日本語");
+        assert_eq!(truncate_to_width("abc", 2), "ab");
+        assert_eq!(truncate_to_width("abc", 100), "abc");
+    }
+
+    #[test]
+    fn byte_truncation_snaps_to_char_boundary() {
+        // "é" is two bytes; trimming inside it must back off.
+        assert_eq!(truncate_bytes("café", 3), "caf");
+        assert_eq!(truncate_bytes("café", 4), "caf");
+        assert_eq!(truncate_bytes("café", 5), "café");
+        assert_eq!(truncate_bytes("abc", 10), "abc");
+    }
+
+    #[test]
+    fn left_truncation_prefixes_ellipsis() {
+        assert_eq!(truncate_left_keep_right("hello", 10), "hello");
+        assert_eq!(truncate_left_keep_right("hello", 3), "…lo");
+        assert_eq!(truncate_left_keep_right("hello", 0), "");
+    }
+}

--- a/src/ui/welcome_overlay.rs
+++ b/src/ui/welcome_overlay.rs
@@ -159,10 +159,7 @@ pub fn render(area: Rect, buf: &mut TermBuffer, scroll: usize, version: &str) {
 }
 
 fn truncate_to(s: &str, max: usize) -> String {
-    if s.chars().count() <= max {
-        return s.to_string();
-    }
-    s.chars().take(max).collect()
+    crate::ui::text_utils::truncate_to_width(s, max).to_string()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Six independent simplifications collapsing duplication found in a four-agent codebase audit. Net **-335 lines** while adding new helpers and three CLAUDE.md guides.

| # | Change | What it removes |
|---|---|---|
| 1 | Centralise overlay chrome in `ui::overlay_chrome` (border, separator, fill-rect, centred header) | 10+ private `draw_border` / `draw_h_separator` copies across the overlay files |
| 2 | Add `ui::text_utils` with `truncate_to_width` / `truncate_bytes` / `truncate_left_keep_right` | Four divergent truncation strategies sprinkled through 20+ sites |
| 3 | `InputMode::string_mut` helper | Two ~40-line match blocks in `handle_modal_input` that listed every string-carrying variant |
| 4 | `scroll_action` helper for welcome/changelog/help overlays | ~130 lines of repeated Up/Down/Page/wheel arms |
| 5 | `Buffer::recorded_insert` / `recorded_delete` / `recorded_replace` | 17+ paired `rope_edit::*` + `record(...)` call sites |
| 6 | Closure-based `Buffer::in_batch` replacing manual `begin_batch`/`commit_batch` pairs | 11 manual pairs, plus the no-op `BatchGuard` stub |

The CLAUDE.md updates point new contributors at the shared helpers so the patterns don't drift back. Adds `src/ui/CLAUDE.md` and `src/buffer/CLAUDE.md` for module-local conventions.

## Test plan

- [x] `scripts/check.sh` — fmt, build, clippy, unit tests
- [x] `cargo test --features ui-tests --tests` — PTY UI suite (670+ tests passing)
- [ ] Manual smoke: open a directory, exercise the fuzzy picker / LSP picker / command palette / help / settings / git dialog so the visual chrome and the truncated strings still look correct
- [ ] Manual smoke: an indent + dedent + multi-cursor edit + undo to exercise the new `in_batch` and `recorded_*` paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)