### PR TITLE
Revert PR #52 (horizontal scrolling + viewport-centre cap)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -976,35 +976,32 @@ impl AppState {
                     }
                 } else {
                     // Route to the editor scroll just like a keyboard scroll.
+                    let total_lines = self.editor.active().buffer.len_lines();
                     let vp = &mut self.editor.active_mut().viewport;
                     match dir {
                         ScrollDir::Up => {
                             vp.scroll_row = vp.scroll_row.saturating_sub(SCROLL_LINES);
                         }
                         ScrollDir::Down => {
-                            vp.scroll_row = vp.scroll_row.saturating_add(SCROLL_LINES);
-                        }
-                        ScrollDir::Left if !vp.word_wrap => {
-                            vp.scroll_col = vp.scroll_col.saturating_sub(4);
-                        }
-                        ScrollDir::Right if !vp.word_wrap => {
-                            vp.scroll_col = vp.scroll_col.saturating_add(4);
+                            vp.scroll_row =
+                                (vp.scroll_row + SCROLL_LINES).min(total_lines.saturating_sub(1));
                         }
                         _ => {}
                     }
-                    self.clamp_viewport_scroll(text_h);
                 }
             }
 
             // ── Scroll ────────────────────────────────────────────────
             EditorAction::Scroll(dir) => {
+                let total_lines = self.editor.active().buffer.len_lines();
                 let vp = &mut self.editor.active_mut().viewport;
                 match dir {
                     ScrollDir::Up => {
                         vp.scroll_row = vp.scroll_row.saturating_sub(SCROLL_LINES);
                     }
                     ScrollDir::Down => {
-                        vp.scroll_row = vp.scroll_row.saturating_add(SCROLL_LINES);
+                        vp.scroll_row =
+                            (vp.scroll_row + SCROLL_LINES).min(total_lines.saturating_sub(1));
                     }
                     ScrollDir::Left => {
                         vp.scroll_col = vp.scroll_col.saturating_sub(4);
@@ -1016,10 +1013,10 @@ impl AppState {
                         vp.scroll_row = vp.scroll_row.saturating_sub(text_h / 2);
                     }
                     ScrollDir::HalfPageDown => {
-                        vp.scroll_row = vp.scroll_row.saturating_add(text_h / 2);
+                        vp.scroll_row =
+                            (vp.scroll_row + text_h / 2).min(total_lines.saturating_sub(1));
                     }
                 }
-                self.clamp_viewport_scroll(text_h);
             }
             EditorAction::ScrollCursorCenter => {
                 let cursor_line = self.editor.active().buffer.cursors.primary().line;
@@ -1621,7 +1618,7 @@ impl App {
                     Event::Resize(_, _) => EditorAction::Unhandled,
                     _ => EditorAction::Unhandled,
                 };
-                if !state.scroll_action_is_no_op(&action, term_height) {
+                if !state.scroll_action_is_no_op(&action) {
                     state.update(action, term_height);
                     if state.should_quit {
                         break;

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -11,27 +11,6 @@ impl AppState {
         let area = self.tab_bar_area?;
         crate::ui::tab_bar::tab_at(&self.editor, area, col, row)
     }
-    /// Cap user-initiated scrolling so the last line cannot pass the vertical
-    /// centre of the viewport and the longest line's end cannot pass the
-    /// horizontal centre. Mirrors `Viewport::clamp_user_scroll` but supplies
-    /// the buffer-derived dimensions from current `AppState`.
-    pub(super) fn clamp_viewport_scroll(&mut self, text_h: usize) {
-        let total_lines = self.editor.active().buffer.len_lines();
-        let label = self.version_badge();
-        let gutter = effective_gutter_width(total_lines, label.as_deref());
-        let sidebar_w: u16 = if self.sidebar.is_some() {
-            self.sidebar_width + 1
-        } else {
-            0
-        };
-        let text_w =
-            (self.term_width as usize).saturating_sub(gutter as usize + 1 + sidebar_w as usize);
-
-        let tab = self.editor.active_mut();
-        let longest = crate::editor::viewport::max_line_display_width(&tab.buffer);
-        tab.viewport
-            .clamp_user_scroll(total_lines, longest, text_h, text_w);
-    }
     /// Returns `true` when `action` is a vertical scroll that the viewport
     /// (or sidebar) can't honour because it's already at the corresponding
     /// edge. Used by the run loop to drop end-of-buffer wheel spam before
@@ -40,11 +19,7 @@ impl AppState {
     /// Horizontal and non-scroll actions always return `false` — the
     /// horizontal case would need an O(n) max-line-width scan per event,
     /// which is more expensive than letting `update` handle it normally.
-    pub(crate) fn scroll_action_is_no_op(
-        &self,
-        action: &EditorAction,
-        terminal_height: u16,
-    ) -> bool {
+    pub(crate) fn scroll_action_is_no_op(&self, action: &EditorAction) -> bool {
         let dir = match action {
             EditorAction::Scroll(d) => *d,
             EditorAction::MouseScroll { dir, col, row } => {
@@ -56,12 +31,10 @@ impl AppState {
             _ => return false,
         };
 
-        // Match the value `update` derives for scroll handlers.
-        let text_h = (terminal_height as usize).saturating_sub(1);
         let tab = self.editor.active();
         let vp = &tab.viewport;
         let total_lines = tab.buffer.len_lines();
-        let max_row = total_lines.saturating_sub(1).saturating_sub(text_h / 2);
+        let max_row = total_lines.saturating_sub(1);
 
         match dir {
             ScrollDir::Up | ScrollDir::HalfPageUp => vp.scroll_row == 0,

--- a/src/editor/viewport.rs
+++ b/src/editor/viewport.rs
@@ -46,29 +46,6 @@ impl Viewport {
         }
     }
 
-    /// Cap user-initiated scrolling so the buffer cannot scroll past a
-    /// "half-viewport" margin: the last line cannot move past the vertical
-    /// centre of the viewport, and the longest line's end cannot move past
-    /// the horizontal centre. When `word_wrap` is true, the horizontal cap
-    /// is skipped.
-    pub fn clamp_user_scroll(
-        &mut self,
-        total_lines: usize,
-        longest_line: usize,
-        text_height: usize,
-        text_width: usize,
-    ) {
-        let max_row = total_lines
-            .saturating_sub(1)
-            .saturating_sub(text_height / 2);
-        self.scroll_row = self.scroll_row.min(max_row);
-
-        if !self.word_wrap {
-            let max_col = longest_line.saturating_sub(text_width / 2);
-            self.scroll_col = self.scroll_col.min(max_col);
-        }
-    }
-
     /// Returns an iterator of `(line_index, line_string_without_newline)` for all
     /// lines visible in the current viewport.
     ///
@@ -307,26 +284,6 @@ fn display_col_for_byte_in_line(buffer: &Buffer, line_idx: usize, byte_in_line: 
     prefix.graphemes(true).map(UnicodeWidthStr::width).sum()
 }
 
-/// Display width (in terminal cells) of the widest line in the buffer.
-///
-/// Walks every line once, summing grapheme widths via `unicode-width`. O(n) in
-/// total buffer size, so cache the result if calling more than once per event.
-pub fn max_line_display_width(buffer: &Buffer) -> usize {
-    use unicode_segmentation::UnicodeSegmentation;
-    use unicode_width::UnicodeWidthStr;
-
-    let total = buffer.len_lines();
-    let mut max_w = 0usize;
-    for i in 0..total {
-        let s = buffer.line_str(i);
-        let w: usize = s.graphemes(true).map(UnicodeWidthStr::width).sum();
-        if w > max_w {
-            max_w = w;
-        }
-    }
-    max_w
-}
-
 /// Returns the substring of `s` starting from display column `skip_cols`.
 /// Handles multi-byte / wide characters correctly.
 fn clip_display_cols(s: &str, skip_cols: usize) -> String {
@@ -503,89 +460,6 @@ mod tests {
         let offset = screen_pos_to_byte_offset(2, 0, 0, 2, 80, &b, &vp);
         let expected_line_start = b.rope().char_to_byte(b.rope().line_to_char(10));
         assert_eq!(offset, expected_line_start);
-    }
-
-    // ── clamp_user_scroll ──────────────────────────────────────────────────
-
-    #[test]
-    fn clamp_keeps_last_line_at_vertical_centre() {
-        // 20 lines, height=10 → max_row = 19 - 5 = 14, so the last line ends
-        // up at row 5 (the centre) when scrolled to the bound.
-        let mut vp = Viewport {
-            scroll_row: 100,
-            scroll_col: 0,
-            word_wrap: false,
-        };
-        vp.clamp_user_scroll(20, 0, 10, 80);
-        assert_eq!(vp.scroll_row, 14);
-    }
-
-    #[test]
-    fn clamp_horizontal_stops_at_longest_line_centre() {
-        // Longest line is 40 wide, text_width = 20 → max_col = 40 - 10 = 30.
-        let mut vp = Viewport {
-            scroll_row: 0,
-            scroll_col: 100,
-            word_wrap: false,
-        };
-        vp.clamp_user_scroll(1, 40, 10, 20);
-        assert_eq!(vp.scroll_col, 30);
-    }
-
-    #[test]
-    fn clamp_horizontal_no_op_when_word_wrap() {
-        let mut vp = Viewport {
-            scroll_row: 0,
-            scroll_col: 100,
-            word_wrap: true,
-        };
-        vp.clamp_user_scroll(1, 40, 10, 20);
-        assert_eq!(vp.scroll_col, 100);
-    }
-
-    #[test]
-    fn clamp_horizontal_zero_when_line_fits() {
-        // Longest line (5) is narrower than half the viewport (text_width/2 = 10).
-        let mut vp = Viewport {
-            scroll_row: 0,
-            scroll_col: 50,
-            word_wrap: false,
-        };
-        vp.clamp_user_scroll(1, 5, 10, 20);
-        assert_eq!(vp.scroll_col, 0);
-    }
-
-    #[test]
-    fn clamp_vertical_zero_for_tiny_buffer() {
-        // 2 lines, height=10 → max_row = 1 - 5 saturating = 0.
-        let mut vp = Viewport {
-            scroll_row: 50,
-            scroll_col: 0,
-            word_wrap: false,
-        };
-        vp.clamp_user_scroll(2, 0, 10, 80);
-        assert_eq!(vp.scroll_row, 0);
-    }
-
-    // ── max_line_display_width ─────────────────────────────────────────────
-
-    #[test]
-    fn max_line_width_picks_longest() {
-        let b = buf("ab\nabcdef\nabc");
-        assert_eq!(max_line_display_width(&b), 6);
-    }
-
-    #[test]
-    fn max_line_width_empty_buffer() {
-        let b = buf("");
-        assert_eq!(max_line_display_width(&b), 0);
-    }
-
-    #[test]
-    fn max_line_width_wide_chars() {
-        // 😀 is width 2; "a😀b" → 1+2+1 = 4.
-        let b = buf("a\na😀b");
-        assert_eq!(max_line_display_width(&b), 4);
     }
 
     // ── Word-wrap mouse mapping ────────────────────────────────────────

--- a/src/input/action.rs
+++ b/src/input/action.rs
@@ -674,7 +674,9 @@ pub enum Direction {
 pub enum ScrollDir {
     Up,
     Down,
+    #[allow(dead_code)]
     Left,
+    #[allow(dead_code)]
     Right,
     #[allow(dead_code)]
     HalfPageUp,

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -126,16 +126,6 @@ impl InputHandler {
                 col,
                 row,
             },
-            MouseEventKind::ScrollLeft => EditorAction::MouseScroll {
-                dir: ScrollDir::Left,
-                col,
-                row,
-            },
-            MouseEventKind::ScrollRight => EditorAction::MouseScroll {
-                dir: ScrollDir::Right,
-                col,
-                row,
-            },
             _ => EditorAction::Unhandled,
         }
     }


### PR DESCRIPTION
## Summary

- **Why:** Holding Ctrl+Up/Down or spinning the mouse wheel on a long file would visibly freeze the editor and starve any keystroke queued behind the burst. The culprit is PR #52's `clamp_user_scroll` machinery: every scroll event called `max_line_display_width`, which walks the whole buffer summing grapheme widths line by line. PR #58 filtered vertical no-op scrolls to dampen the freeze but keyboard scrolls and horizontal mouse scrolls still paid the O(n) cost.
- **What:** Roll the editor back to the pre-PR-52 scroll model. Bound vertical scroll by `total_lines - 1`, ignore horizontal mouse-wheel events, drop the centre-of-viewport cap, delete `Viewport::clamp_user_scroll` / `max_line_display_width` and `AppState::clamp_viewport_scroll`.
- **Kept on purpose:** PR #58's drain loop + `scroll_action_is_no_op` filter (still helpful for held Ctrl+Up/Down) and the May-8 "scroll past cursor" behavior (`8be75de`). Only knock-on tweak: `scroll_action_is_no_op`'s `max_row` had been tightened to match the viewport-centre cap; with the cap gone it relaxes back to `total_lines - 1` and the now-unused `terminal_height` parameter is removed.

5 files changed, +13 / −177.

## Test plan

- [x] `scripts/check.sh` (fmt, build, clippy, unit tests) — green.
- [x] `cargo test --features ui-tests --test ui_scrolling -- --test-threads=2` — all 3 tests pass (`scroll_ctrl_down_moves_viewport`, `scroll_burst_past_end_does_not_block_other_keys`, `scroll_up_at_top_is_a_no_op`).
- [x] `cargo test --features ui-tests --tests` full suite — passes (one parallel-execution flake in `ui_clipboard_ring` that's green when re-run; unrelated to scrolling).
- [ ] Manual: open a large file with `cargo run -- <path>`. Verify holding Ctrl+Down past EOF no longer freezes the editor and a follow-up Ctrl+Home registers without delay.
- [ ] Manual: horizontal mouse-wheel tilt / two-finger trackpad swipe is a no-op in the editor pane (was: scrolled `scroll_col`).
- [ ] Manual: mouse-wheel scrolling down past the bottom stops at the last line on screen (was: stopped with the last line at vertical centre).

🤖 Generated with [Claude Code](https://claude.com/claude-code)