### PR TITLE
Allow opening non-existent files; create on first save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.7.1
+
+- Open a new empty buffer instead of exiting with an error when the file named on the command line doesn't exist; the file is created on first save, matching the behavior of common editors
+
 ## v0.7.0
 
 - Fix laggy scrolling on large files — holding a scroll key or spinning the wheel could visibly freeze the editor and stall queued keystrokes because every scroll event walked the whole buffer to sum grapheme widths. Reverts the viewport-centre scroll cap and horizontal mouse-wheel handling added in v0.5.0; the longest line and last line are once again allowed to scroll past the viewport edge, and horizontal mouse-wheel events are ignored. The v0.6.0 input-drain loop and no-op-scroll filter are kept.

--- a/src/editor/tab.rs
+++ b/src/editor/tab.rs
@@ -86,8 +86,15 @@ impl BufferHandle {
 
     /// Open a file from disk. Detects the language, loads content, and
     /// runs an initial tree-sitter parse.
+    ///
+    /// If `path` does not exist yet, an empty buffer bound to that path is
+    /// returned instead of an error; the file is created on first save.
     pub fn from_path(id: BufferId, path: PathBuf) -> anyhow::Result<Self> {
-        let content = std::fs::read_to_string(&path)?;
+        let content = match std::fs::read_to_string(&path) {
+            Ok(content) => content,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => String::new(),
+            Err(err) => return Err(err.into()),
+        };
         let mut buffer = Buffer::from_str(&content);
         buffer.modified = false;
 
@@ -282,5 +289,20 @@ mod tests {
         assert!(o.indent_size.is_none());
         // Sanity: IndentStyle is reachable through this module's imports.
         let _ = IndentStyle::Spaces;
+    }
+
+    #[test]
+    fn from_path_creates_empty_buffer_for_missing_file() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("txt_from_path_missing_{}.txt", std::process::id()));
+        // Ensure the file does not exist.
+        let _ = std::fs::remove_file(&path);
+
+        let handle = BufferHandle::from_path(0, path.clone()).expect("missing file should open");
+        assert_eq!(handle.buffer.to_string(), "");
+        assert!(!handle.buffer.modified);
+        assert_eq!(handle.path.as_deref(), Some(path.as_path()));
+        // Opening a non-existent path must not touch the filesystem.
+        assert!(!path.exists());
     }
 }


### PR DESCRIPTION
## Summary
Modified `BufferHandle::from_path()` to gracefully handle non-existent files by creating an empty buffer instead of returning an error. The file is created on disk only when the buffer is first saved, enabling a smoother workflow for creating new files.

## Changes
- **Modified `BufferHandle::from_path()`**: Changed file-reading logic to catch `NotFound` errors and return an empty buffer instead. Other I/O errors are still propagated as before.
- **Updated documentation**: Added clarification to the method's doc comment explaining the new behavior.
- **Added test**: New `from_path_creates_empty_buffer_for_missing_file()` test verifies that:
  - Opening a non-existent path succeeds and returns an empty buffer
  - The buffer is not marked as modified
  - The path is correctly bound to the buffer
  - The file is not created on the filesystem until explicitly saved

## Implementation Details
The change uses a match expression to distinguish between `NotFound` errors (which return `String::new()`) and other I/O errors (which are propagated). This maintains backward compatibility for all error cases except the specific case of missing files, which is now a valid operation rather than a failure.

https://claude.ai/code/session_01G6vK6VPw4R7cc4tb5R9TDk