### PR TITLE
Add GitHub Actions workflow for automated release tagging

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,71 @@
+name: Tag Release
+
+# Cuts a release by running scripts/release.sh with the latest version from
+# CHANGELOG.md: it bumps Cargo.toml, regenerates Cargo.lock, commits, tags
+# vX.Y.Z, and pushes both main and the tag. Pushing the tag triggers the
+# "Release" workflow (release.yml), which builds the binaries and publishes
+# the GitHub Release.
+#
+# Manual for now (workflow_dispatch). To fully automate once CHANGELOG.md
+# lands on main, add the trigger below — release.sh already no-ops (exits with
+# "already the current version") when Cargo.toml matches the latest entry, so
+# pushes that don't bump the changelog are harmless:
+#
+#   push:
+#     branches: [main]
+#     paths: [CHANGELOG.md]
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (X.Y.Z). Leave blank to use the latest CHANGELOG.md entry."
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Tag and push release
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # release.sh requires running on main and pushes commits + the tag.
+          ref: main
+          fetch-depth: 0
+          # A PAT in secrets.RELEASE_TOKEN lets the pushed tag trigger the
+          # Release workflow; pushes made with the default GITHUB_TOKEN do not
+          # trigger other workflows. Falls back to GITHUB_TOKEN when unset
+          # (the tag is still created, but release.yml must be started by hand).
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Resolve version from CHANGELOG.md
+        id: version
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          if [ -z "$VERSION" ]; then
+            VERSION="$(grep -m1 -oE '^## v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?' CHANGELOG.md | sed 's/^## v//')"
+          fi
+          VERSION="${VERSION#v}"  # strip a leading 'v' if the input included one
+          if [ -z "$VERSION" ]; then
+            echo "error: could not determine a version from CHANGELOG.md" >&2
+            exit 1
+          fi
+          echo "Releasing version: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Run release script
+        run: scripts/release.sh "${{ steps.version.outputs.version }}"


### PR DESCRIPTION
## Summary
Adds a new GitHub Actions workflow (`tag-release.yml`) that automates the release process by reading the version from `CHANGELOG.md`, bumping `Cargo.toml`, regenerating `Cargo.lock`, creating a git commit and tag, and pushing both to trigger the downstream release workflow.

## Key Changes
- **New workflow file**: `.github/workflows/tag-release.yml`
  - Triggered manually via `workflow_dispatch` with optional version input
  - Reads the latest version from `CHANGELOG.md` if no version is provided
  - Configures git user as `github-actions[bot]`
  - Runs `scripts/release.sh` with the resolved version
  - Uses `RELEASE_TOKEN` secret (with fallback to `GITHUB_TOKEN`) to ensure pushed tags trigger downstream workflows
  - Includes full git history (`fetch-depth: 0`) for proper release operations

## Implementation Details
- Version resolution supports both explicit input and automatic extraction from `CHANGELOG.md` (strips leading `v` if present)
- Includes error handling for cases where version cannot be determined
- Workflow is currently manual but includes comments for future automation via `CHANGELOG.md` push trigger
- Leverages existing `scripts/release.sh` which handles the actual version bumping and release mechanics
- Properly configured with `contents: write` permission for git operations

https://claude.ai/code/session_01MkNjBFCTZ4q4FMUP6P4Fki